### PR TITLE
Align pkg/sendspin with official Sendspin Protocol spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ Thumbs.db
 output.txt
 sendspin-go
 resonate-go
+prompts/

--- a/internal/app/player.go
+++ b/internal/app/player.go
@@ -14,10 +14,10 @@ import (
 	"github.com/Sendspin/sendspin-go/internal/client"
 	"github.com/Sendspin/sendspin-go/internal/discovery"
 	"github.com/Sendspin/sendspin-go/internal/player"
-	"github.com/Sendspin/sendspin-go/internal/protocol"
 	"github.com/Sendspin/sendspin-go/internal/sync"
 	"github.com/Sendspin/sendspin-go/internal/ui"
 	"github.com/Sendspin/sendspin-go/internal/version"
+	"github.com/Sendspin/sendspin-go/pkg/protocol"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/google/uuid"
 )

--- a/internal/client/websocket.go
+++ b/internal/client/websocket.go
@@ -79,7 +79,7 @@ func NewClient(config Config) *Client {
 
 // Connect establishes WebSocket connection and performs handshake
 func (c *Client) Connect() error {
-	u := url.URL{Scheme: "ws", Host: c.config.ServerAddr, Path: "/resonate"}
+	u := url.URL{Scheme: "ws", Host: c.config.ServerAddr, Path: "/sendspin"}
 	log.Printf("Connecting to %s", u.String())
 
 	conn, _, err := websocket.DefaultDialer.Dial(u.String(), nil)

--- a/internal/client/websocket.go
+++ b/internal/client/websocket.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sendspin/sendspin-go/internal/protocol"
+	"github.com/Sendspin/sendspin-go/pkg/protocol"
 	"github.com/gorilla/websocket"
 )
 

--- a/internal/client/websocket.go
+++ b/internal/client/websocket.go
@@ -152,17 +152,12 @@ func (c *Client) handshake() error {
 
 	// Send initial state
 	state := protocol.ClientState{
-		State:  "idle",
+		State:  "synchronized",
 		Volume: 100,
 		Muted:  false,
 	}
 
-	stateMsg := protocol.Message{
-		Type:    "player/update",
-		Payload: state,
-	}
-
-	if err := c.sendJSON(stateMsg); err != nil {
+	if err := c.SendState(state); err != nil {
 		return fmt.Errorf("failed to send initial state: %w", err)
 	}
 

--- a/internal/player/scheduler.go
+++ b/internal/player/scheduler.go
@@ -43,17 +43,22 @@ type SchedulerStats struct {
 }
 
 // NewScheduler creates a playback scheduler
-func NewScheduler(clockSync *sync.ClockSync, jitterMs int) *Scheduler {
+// bufferMs controls startup buffering: how many ms of audio to accumulate before playback
+func NewScheduler(clockSync *sync.ClockSync, bufferMs int) *Scheduler {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// Buffer chunks to match server's lead time (BufferAheadMs / ChunkDurationMs)
-	bufferTarget := BufferAheadMs / ChunkDurationMs
+	// Calculate buffer target from user config (bufferMs / ChunkDurationMs)
+	// This determines how many chunks to buffer before starting playback
+	bufferTarget := bufferMs / ChunkDurationMs
+	if bufferTarget < 1 {
+		bufferTarget = 1 // Minimum 1 chunk
+	}
 
 	return &Scheduler{
 		clockSync:    clockSync,
 		bufferQ:      NewBufferQueue(),
 		output:       make(chan audio.Buffer, 10),
-		jitterMs:     jitterMs,
+		jitterMs:     bufferMs, // Store for potential future use
 		ctx:          ctx,
 		cancel:       cancel,
 		buffering:    true,

--- a/internal/protocol/messages.go
+++ b/internal/protocol/messages.go
@@ -1,4 +1,4 @@
-// ABOUTME: Resonate Protocol message type definitions
+// ABOUTME: Sendspin Protocol message type definitions
 // ABOUTME: Defines structs for all message types in the protocol
 package protocol
 
@@ -69,9 +69,9 @@ type ServerHello struct {
 	Version  int    `json:"version"`
 }
 
-// ClientState reports the player's current state (sent as player/update message)
+// ClientState reports the player's current state (sent as client/state message)
 type ClientState struct {
-	State  string `json:"state"`  // "playing" or "idle"
+	State  string `json:"state"`  // "synchronized" or "error" (per spec)
 	Volume int    `json:"volume"` // 0-100
 	Muted  bool   `json:"muted"`  // All fields are required
 }

--- a/internal/protocol/messages.go
+++ b/internal/protocol/messages.go
@@ -1,5 +1,8 @@
-// ABOUTME: Sendspin Protocol message type definitions
-// ABOUTME: Defines structs for all message types in the protocol
+// ABOUTME: DEPRECATED - Use pkg/protocol instead
+// ABOUTME: Legacy message types kept for backward compatibility tests
+//
+// Deprecated: This package is deprecated. Use github.com/Sendspin/sendspin-go/pkg/protocol instead.
+// All new code should import pkg/protocol which contains spec-aligned message types.
 package protocol
 
 // Message is the top-level wrapper for all protocol messages

--- a/internal/server/audio_engine.go
+++ b/internal/server/audio_engine.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sendspin/sendspin-go/internal/protocol"
+	"github.com/Sendspin/sendspin-go/pkg/protocol"
 )
 
 const (

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -22,8 +22,9 @@ const (
 	// Protocol constants
 	ProtocolVersion = 1
 
-	// Message type for binary audio chunks (player role uses type 1)
-	AudioChunkMessageType = 1
+	// Message type for binary audio chunks
+	// Per spec: Player role binary messages use IDs 4-7 (bits 000001xx), slot 0 is audio
+	AudioChunkMessageType = 4
 )
 
 // Config holds server configuration

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/Sendspin/sendspin-go/internal/discovery"
-	"github.com/Sendspin/sendspin-go/internal/protocol"
+	"github.com/Sendspin/sendspin-go/pkg/protocol"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 )

--- a/pkg/protocol/client.go
+++ b/pkg/protocol/client.go
@@ -260,7 +260,6 @@ func (c *Client) handleJSONMessage(data []byte) {
 		return
 	}
 
-	log.Printf("Received message type: %s", msg.Type)
 	payloadBytes, _ := json.Marshal(msg.Payload)
 
 	switch msg.Type {

--- a/pkg/protocol/messages.go
+++ b/pkg/protocol/messages.go
@@ -1,5 +1,5 @@
-// ABOUTME: Resonate Protocol message type definitions
-// ABOUTME: Defines structs for all message types in the protocol
+// ABOUTME: Sendspin Protocol message type definitions
+// ABOUTME: Defines structs for all message types per the Sendspin spec
 package protocol
 
 // Message is the top-level wrapper for all protocol messages
@@ -9,15 +9,17 @@ type Message struct {
 }
 
 // ClientHello is sent by clients to initiate the handshake
+// Per spec: roles use versioned format like "player@v1"
 type ClientHello struct {
-	ClientID          string             `json:"client_id"`
-	Name              string             `json:"name"`
-	Version           int                `json:"version"`
-	SupportedRoles    []string           `json:"supported_roles"`
-	DeviceInfo        *DeviceInfo        `json:"device_info,omitempty"`
-	PlayerSupport     *PlayerSupport     `json:"player_support,omitempty"`
-	MetadataSupport   *MetadataSupport   `json:"metadata_support,omitempty"`
-	VisualizerSupport *VisualizerSupport `json:"visualizer_support,omitempty"`
+	ClientID       string      `json:"client_id"`
+	Name           string      `json:"name"`
+	Version        int         `json:"version"`
+	SupportedRoles []string    `json:"supported_roles"`
+	DeviceInfo     *DeviceInfo `json:"device_info,omitempty"`
+	// Per spec: support objects use versioned keys like "player@v1_support"
+	PlayerV1Support     *PlayerV1Support     `json:"player@v1_support,omitempty"`
+	ArtworkV1Support    *ArtworkV1Support    `json:"artwork@v1_support,omitempty"`
+	VisualizerV1Support *VisualizerV1Support `json:"visualizer@v1_support,omitempty"`
 }
 
 // DeviceInfo contains device identification
@@ -27,18 +29,29 @@ type DeviceInfo struct {
 	SoftwareVersion string `json:"software_version"`
 }
 
-// PlayerSupport describes player capabilities
-type PlayerSupport struct {
-	// Spec fields (newer)
-	SupportFormats    []AudioFormat `json:"support_formats,omitempty"`
-	BufferCapacity    int           `json:"buffer_capacity,omitempty"`
-	SupportedCommands []string      `json:"supported_commands,omitempty"`
+// PlayerV1Support describes player@v1 capabilities per spec
+type PlayerV1Support struct {
+	SupportedFormats  []AudioFormat `json:"supported_formats"`
+	BufferCapacity    int           `json:"buffer_capacity"`
+	SupportedCommands []string      `json:"supported_commands"`
+}
 
-	// Legacy fields (Music Assistant compatibility - uses separate arrays)
-	SupportCodecs      []string `json:"support_codecs,omitempty"`
-	SupportChannels    []int    `json:"support_channels,omitempty"`
-	SupportSampleRates []int    `json:"support_sample_rates,omitempty"`
-	SupportBitDepth    []int    `json:"support_bit_depth,omitempty"`
+// ArtworkV1Support describes artwork@v1 capabilities per spec
+type ArtworkV1Support struct {
+	Channels []ArtworkChannel `json:"channels"`
+}
+
+// ArtworkChannel describes a single artwork channel
+type ArtworkChannel struct {
+	Source      string `json:"source"` // "album", "artist", or "none"
+	Format      string `json:"format"` // "jpeg", "png", or "bmp"
+	MediaWidth  int    `json:"media_width"`
+	MediaHeight int    `json:"media_height"`
+}
+
+// VisualizerV1Support describes visualizer@v1 capabilities per spec
+type VisualizerV1Support struct {
+	BufferCapacity int `json:"buffer_capacity"`
 }
 
 // AudioFormat describes a supported audio format
@@ -49,36 +62,35 @@ type AudioFormat struct {
 	BitDepth   int    `json:"bit_depth"`
 }
 
-// MetadataSupport describes metadata/artwork capabilities
-type MetadataSupport struct {
-	SupportPictureFormats []string `json:"support_picture_formats"`
-	MediaWidth            int      `json:"media_width,omitempty"`
-	MediaHeight           int      `json:"media_height,omitempty"`
-}
-
-// VisualizerSupport describes visualization capabilities
-type VisualizerSupport struct {
-	BufferCapacity int `json:"buffer_capacity,omitempty"`
-	// FFT details - to be determined by spec
-}
-
 // ServerHello is the server's response to client/hello
 type ServerHello struct {
-	ServerID string `json:"server_id"`
-	Name     string `json:"name"`
-	Version  int    `json:"version"`
+	ServerID         string   `json:"server_id"`
+	Name             string   `json:"name"`
+	Version          int      `json:"version"`
+	ActiveRoles      []string `json:"active_roles"`
+	ConnectionReason string   `json:"connection_reason"` // "discovery" or "playback"
 }
 
-// ClientState reports the player's current state (sent as player/update message)
-type ClientState struct {
-	State  string `json:"state"`  // "playing" or "idle"
-	Volume int    `json:"volume"` // 0-100
-	Muted  bool   `json:"muted"`  // All fields are required
+// ClientStateMessage is sent as client/state with role-specific objects
+type ClientStateMessage struct {
+	Player *PlayerState `json:"player,omitempty"`
 }
 
-// ServerCommand is a control message from the server
-type ServerCommand struct {
-	Command string `json:"command"`
+// PlayerState reports the player's current state per spec
+type PlayerState struct {
+	State  string `json:"state"`            // "synchronized" or "error"
+	Volume int    `json:"volume,omitempty"` // 0-100, if volume command supported
+	Muted  bool   `json:"muted,omitempty"`  // if mute command supported
+}
+
+// ServerCommandMessage is sent as server/command with role-specific objects
+type ServerCommandMessage struct {
+	Player *PlayerCommand `json:"player,omitempty"`
+}
+
+// PlayerCommand is a control command for the player
+type PlayerCommand struct {
+	Command string `json:"command"` // "volume" or "mute"
 	Volume  int    `json:"volume,omitempty"`
 	Mute    bool   `json:"mute,omitempty"`
 }
@@ -97,35 +109,61 @@ type StreamStart struct {
 	Player *StreamStartPlayer `json:"player,omitempty"`
 }
 
-// StreamMetadata contains track information
-type StreamMetadata struct {
-	Title      string `json:"title,omitempty"`
-	Artist     string `json:"artist,omitempty"`
-	Album      string `json:"album,omitempty"`
-	ArtworkURL string `json:"artwork_url,omitempty"`
+// ServerStateMessage is sent as server/state with role-specific objects
+type ServerStateMessage struct {
+	Metadata   *MetadataState   `json:"metadata,omitempty"`
+	Controller *ControllerState `json:"controller,omitempty"`
 }
 
-// SessionMetadata contains track metadata within session updates
-type SessionMetadata struct {
-	Title         string  `json:"title,omitempty"`
-	Artist        string  `json:"artist,omitempty"`
-	Album         string  `json:"album,omitempty"`
-	AlbumArtist   string  `json:"album_artist,omitempty"`
-	ArtworkURL    string  `json:"artwork_url,omitempty"`
-	Track         int     `json:"track,omitempty"`
-	TrackDuration int     `json:"track_duration,omitempty"`
-	Year          int     `json:"year,omitempty"`
-	PlaybackSpeed float64 `json:"playback_speed,omitempty"`
-	Repeat        string  `json:"repeat,omitempty"`
-	Shuffle       bool    `json:"shuffle,omitempty"`
-	Timestamp     int64   `json:"timestamp,omitempty"`
+// MetadataState contains track metadata per spec (for metadata role)
+type MetadataState struct {
+	Timestamp   int64          `json:"timestamp"`              // Server clock µs when valid
+	Title       *string        `json:"title,omitempty"`        // Track title
+	Artist      *string        `json:"artist,omitempty"`       // Primary artist(s)
+	AlbumArtist *string        `json:"album_artist,omitempty"` // Album artist(s)
+	Album       *string        `json:"album,omitempty"`        // Album name
+	ArtworkURL  *string        `json:"artwork_url,omitempty"`  // URL to artwork
+	Year        *int           `json:"year,omitempty"`         // Release year YYYY
+	Track       *int           `json:"track,omitempty"`        // Track number (1-indexed)
+	Progress    *ProgressState `json:"progress,omitempty"`     // Playback progress
+	Repeat      *string        `json:"repeat,omitempty"`       // "off", "one", "all"
+	Shuffle     *bool          `json:"shuffle,omitempty"`      // Shuffle enabled
 }
 
-// SessionUpdate notifies client of session state changes
-type SessionUpdate struct {
-	GroupID       string           `json:"group_id"`
-	PlaybackState string           `json:"playback_state,omitempty"` // "playing" or "idle"
-	Metadata      *SessionMetadata `json:"metadata,omitempty"`
+// ProgressState contains playback progress info per spec
+type ProgressState struct {
+	TrackProgress int `json:"track_progress"` // Current position in ms
+	TrackDuration int `json:"track_duration"` // Total duration in ms (0 = unknown)
+	PlaybackSpeed int `json:"playback_speed"` // Speed * 1000 (1000 = normal, 0 = paused)
+}
+
+// ControllerState contains controller state per spec
+type ControllerState struct {
+	SupportedCommands []string `json:"supported_commands"`
+	Volume            int      `json:"volume"` // Group volume 0-100
+	Muted             bool     `json:"muted"`  // Group mute state
+}
+
+// GroupUpdate is sent as group/update per spec
+type GroupUpdate struct {
+	PlaybackState *string `json:"playback_state,omitempty"` // "playing", "paused", "stopped"
+	GroupID       *string `json:"group_id,omitempty"`
+	GroupName     *string `json:"group_name,omitempty"`
+}
+
+// StreamClear instructs clients to clear buffers (for seek)
+type StreamClear struct {
+	Roles []string `json:"roles,omitempty"` // Roles to clear: "player", "visualizer"
+}
+
+// StreamEnd ends streams for specified roles
+type StreamEnd struct {
+	Roles []string `json:"roles,omitempty"` // Roles to end (omit = all)
+}
+
+// ClientGoodbye is sent before graceful disconnect
+type ClientGoodbye struct {
+	Reason string `json:"reason"` // "another_server", "shutdown", "restart", "user_request"
 }
 
 // ClientTime is sent for clock synchronization

--- a/pkg/protocol/messages.go
+++ b/pkg/protocol/messages.go
@@ -20,6 +20,12 @@ type ClientHello struct {
 	PlayerV1Support     *PlayerV1Support     `json:"player@v1_support,omitempty"`
 	ArtworkV1Support    *ArtworkV1Support    `json:"artwork@v1_support,omitempty"`
 	VisualizerV1Support *VisualizerV1Support `json:"visualizer@v1_support,omitempty"`
+
+	// Legacy support fields for Music Assistant backward compatibility
+	// Uses unversioned keys like "player_support" instead of "player@v1_support"
+	PlayerSupport     *PlayerSupport     `json:"player_support,omitempty"`
+	MetadataSupport   *MetadataSupport   `json:"metadata_support,omitempty"`
+	VisualizerSupport *VisualizerSupport `json:"visualizer_support,omitempty"`
 }
 
 // DeviceInfo contains device identification
@@ -34,6 +40,13 @@ type PlayerV1Support struct {
 	SupportedFormats  []AudioFormat `json:"supported_formats"`
 	BufferCapacity    int           `json:"buffer_capacity"`
 	SupportedCommands []string      `json:"supported_commands"`
+
+	// Legacy fields for Music Assistant backward compatibility
+	// MA uses separate arrays instead of AudioFormat objects
+	SupportCodecs      []string `json:"support_codecs,omitempty"`
+	SupportChannels    []int    `json:"support_channels,omitempty"`
+	SupportSampleRates []int    `json:"support_sample_rates,omitempty"`
+	SupportBitDepth    []int    `json:"support_bit_depth,omitempty"`
 }
 
 // ArtworkV1Support describes artwork@v1 capabilities per spec
@@ -176,4 +189,76 @@ type ServerTime struct {
 	ClientTransmitted int64 `json:"client_transmitted"` // Echoed client timestamp
 	ServerReceived    int64 `json:"server_received"`    // Server receive timestamp
 	ServerTransmitted int64 `json:"server_transmitted"` // Server send timestamp
+}
+
+// Legacy types for Music Assistant backward compatibility
+
+// MetadataSupport describes metadata/artwork capabilities (legacy format)
+type MetadataSupport struct {
+	SupportPictureFormats []string `json:"support_picture_formats"`
+	MediaWidth            int      `json:"media_width,omitempty"`
+	MediaHeight           int      `json:"media_height,omitempty"`
+}
+
+// StreamMetadata contains track information (legacy message type)
+type StreamMetadata struct {
+	Title      string `json:"title,omitempty"`
+	Artist     string `json:"artist,omitempty"`
+	Album      string `json:"album,omitempty"`
+	ArtworkURL string `json:"artwork_url,omitempty"`
+}
+
+// SessionMetadata contains track metadata within session updates (legacy format)
+type SessionMetadata struct {
+	Title         string  `json:"title,omitempty"`
+	Artist        string  `json:"artist,omitempty"`
+	Album         string  `json:"album,omitempty"`
+	AlbumArtist   string  `json:"album_artist,omitempty"`
+	ArtworkURL    string  `json:"artwork_url,omitempty"`
+	Track         int     `json:"track,omitempty"`
+	TrackDuration int     `json:"track_duration,omitempty"`
+	Year          int     `json:"year,omitempty"`
+	PlaybackSpeed float64 `json:"playback_speed,omitempty"`
+	Repeat        string  `json:"repeat,omitempty"`
+	Shuffle       bool    `json:"shuffle,omitempty"`
+	Timestamp     int64   `json:"timestamp,omitempty"`
+}
+
+// SessionUpdate notifies client of session state changes (legacy message type)
+type SessionUpdate struct {
+	GroupID       string           `json:"group_id"`
+	PlaybackState string           `json:"playback_state,omitempty"` // "playing" or "idle"
+	Metadata      *SessionMetadata `json:"metadata,omitempty"`
+}
+
+// VisualizerSupport is a legacy alias for VisualizerV1Support
+type VisualizerSupport = VisualizerV1Support
+
+// ClientState is a legacy alias for PlayerState (flat format used with client/state)
+type ClientState struct {
+	State  string `json:"state"`  // "synchronized" or "error"
+	Volume int    `json:"volume"` // 0-100
+	Muted  bool   `json:"muted"`
+}
+
+// ServerCommand is a legacy flat format for player commands
+type ServerCommand struct {
+	Command string `json:"command"`
+	Volume  int    `json:"volume,omitempty"`
+	Mute    bool   `json:"mute,omitempty"`
+}
+
+// PlayerSupport is a legacy format for player capabilities (Music Assistant compatibility)
+// Uses different JSON tags than PlayerV1Support: support_formats vs supported_formats
+type PlayerSupport struct {
+	// Uses support_formats (MA format) not supported_formats (spec format)
+	SupportFormats    []AudioFormat `json:"support_formats,omitempty"`
+	BufferCapacity    int           `json:"buffer_capacity,omitempty"`
+	SupportedCommands []string      `json:"supported_commands,omitempty"`
+
+	// Legacy arrays (MA compatibility)
+	SupportCodecs      []string `json:"support_codecs,omitempty"`
+	SupportChannels    []int    `json:"support_channels,omitempty"`
+	SupportSampleRates []int    `json:"support_sample_rates,omitempty"`
+	SupportBitDepth    []int    `json:"support_bit_depth,omitempty"`
 }

--- a/pkg/protocol/messages_test.go
+++ b/pkg/protocol/messages_test.go
@@ -1,4 +1,4 @@
-// ABOUTME: Tests for Resonate Protocol message types
+// ABOUTME: Tests for Sendspin Protocol message types
 // ABOUTME: Verifies JSON marshaling/unmarshaling of protocol messages
 package protocol
 
@@ -12,14 +12,14 @@ func TestClientHelloMarshaling(t *testing.T) {
 		ClientID:       "test-id",
 		Name:           "Test Player",
 		Version:        1,
-		SupportedRoles: []string{"player"},
+		SupportedRoles: []string{"player@v1"},
 		DeviceInfo: &DeviceInfo{
 			ProductName:     "Test Product",
 			Manufacturer:    "Test Mfg",
 			SoftwareVersion: "0.1.0",
 		},
-		PlayerSupport: &PlayerSupport{
-			SupportFormats: []AudioFormat{
+		PlayerV1Support: &PlayerV1Support{
+			SupportedFormats: []AudioFormat{
 				{Codec: "opus", Channels: 2, SampleRate: 48000, BitDepth: 16},
 				{Codec: "flac", Channels: 2, SampleRate: 48000, BitDepth: 16},
 				{Codec: "pcm", Channels: 2, SampleRate: 48000, BitDepth: 16},
@@ -51,10 +51,12 @@ func TestClientHelloMarshaling(t *testing.T) {
 }
 
 func TestClientStateMarshaling(t *testing.T) {
-	state := ClientState{
-		State:  "synchronized",
-		Volume: 80,
-		Muted:  false,
+	state := ClientStateMessage{
+		Player: &PlayerState{
+			State:  "synchronized",
+			Volume: 80,
+			Muted:  false,
+		},
 	}
 
 	msg := Message{
@@ -75,5 +77,35 @@ func TestClientStateMarshaling(t *testing.T) {
 
 	if decoded.Type != "client/state" {
 		t.Errorf("expected type client/state, got %s", decoded.Type)
+	}
+}
+
+func TestServerHelloMarshaling(t *testing.T) {
+	hello := ServerHello{
+		ServerID:         "server-123",
+		Name:             "Test Server",
+		Version:          1,
+		ActiveRoles:      []string{"player@v1", "metadata@v1"},
+		ConnectionReason: "playback",
+	}
+
+	msg := Message{
+		Type:    "server/hello",
+		Payload: hello,
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	var decoded Message
+	err = json.Unmarshal(data, &decoded)
+	if err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if decoded.Type != "server/hello" {
+		t.Errorf("expected type server/hello, got %s", decoded.Type)
 	}
 }

--- a/pkg/sendspin/scheduler.go
+++ b/pkg/sendspin/scheduler.go
@@ -140,8 +140,8 @@ func (s *Scheduler) Stats() SchedulerStats {
 
 // BufferDepth returns the current buffer queue depth in milliseconds
 func (s *Scheduler) BufferDepth() int {
-	// Each buffer is typically 10ms (480 samples at 48kHz)
-	return s.bufferQ.Len() * 10
+	// Each buffer is 20ms (server sends ChunkDurationMs = 20)
+	return s.bufferQ.Len() * 20
 }
 
 // Stop stops the scheduler

--- a/pkg/sendspin/scheduler.go
+++ b/pkg/sendspin/scheduler.go
@@ -149,6 +149,15 @@ func (s *Scheduler) Stop() {
 	s.cancel()
 }
 
+// Clear clears all buffered audio (used for seek operations)
+func (s *Scheduler) Clear() {
+	// Reset the buffer queue
+	s.bufferQ = NewBufferQueue()
+	// Re-enter buffering mode to rebuild buffer
+	s.buffering = true
+	log.Printf("Scheduler buffers cleared, re-entering buffering mode")
+}
+
 // BufferQueue is a priority queue for audio buffers
 type BufferQueue struct {
 	items []audio.Buffer

--- a/pkg/sendspin/server.go
+++ b/pkg/sendspin/server.go
@@ -770,7 +770,8 @@ func (s *Server) hasRole(c *client, role string) bool {
 }
 
 // activateRoles returns the active roles based on client's supported roles
-// Preserves input order (first occurrence of each role family)
+// Only activates roles that this server actually implements.
+// Preserves input order (first occurrence of each role family).
 func (s *Server) activateRoles(supportedRoles []string) []string {
 	// Track which families we've seen to avoid duplicates
 	seen := make(map[string]bool)
@@ -789,9 +790,12 @@ func (s *Server) activateRoles(supportedRoles []string) []string {
 			continue
 		}
 
-		// Check if we support this role family
+		// Only activate roles this server actually implements
+		// - player: audio streaming (implemented)
+		// - metadata: track info via server/state (implemented)
+		// - visualizer, artwork, controller: NOT implemented
 		switch family {
-		case "player", "metadata", "visualizer", "artwork", "controller":
+		case "player", "metadata":
 			seen[family] = true
 			result = append(result, role)
 		}


### PR DESCRIPTION
## Summary

- Fix binary message type ID from 1 → 4 (player role bits 000001xx, slot 0)
- Implement versioned roles: `player` → `player@v1`, `metadata@v1`, `artwork@v1`, `visualizer@v1`
- Add `active_roles` and `connection_reason` fields to `server/hello`
- Rename message types: `player/update` → `client/state`, `stream/metadata` → `server/state`
- Restructure `client/state` to nest state under role key (`player: {...}`)
- Fix player state values: `playing`/`idle` → `synchronized`/`error`
- Add `client/goodbye`, `stream/clear`, `stream/end`, `group/update` messages
- Add `Scheduler.Clear()` method for seek operations

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Protocol message marshaling verified
- [x] Server client connection tests updated for new message flow
- [x] Duplicate client ID rejection still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)