### PR TITLE
Add Music Assistant compatibility by including legacy protocol fields

### DIFF
--- a/internal/client/websocket.go
+++ b/internal/client/websocket.go
@@ -107,17 +107,47 @@ func (c *Client) Connect() error {
 
 // handshake performs the protocol handshake
 func (c *Client) handshake() error {
-	// Send client/hello with versioned roles per Sendspin Protocol spec
-	// Note: metadata@v1 role doesn't require a support config, artwork@v1 uses artwork_support
+	// Build versioned role list per spec
+	roles := []string{"player@v1", "metadata@v1"}
+	if c.config.ArtworkV1Support != nil {
+		roles = append(roles, "artwork@v1")
+	}
+	if c.config.VisualizerV1Support != nil {
+		roles = append(roles, "visualizer@v1")
+	}
+
+	// Create legacy PlayerSupport for Music Assistant compatibility
+	legacyPlayerSupport := protocol.PlayerSupport{
+		SupportedFormats:  c.config.PlayerV1Support.SupportedFormats,
+		BufferCapacity:    c.config.PlayerV1Support.BufferCapacity,
+		SupportedCommands: c.config.PlayerV1Support.SupportedCommands,
+	}
+
+	// Create legacy MetadataSupport for Music Assistant compatibility
+	legacyMetadataSupport := protocol.MetadataSupport{
+		SupportPictureFormats: []string{"jpeg", "png", "webp"},
+		MediaWidth:            600,
+		MediaHeight:           600,
+	}
+
+	// Send client/hello with BOTH versioned and legacy fields
 	hello := protocol.ClientHello{
-		ClientID:          c.config.ClientID,
-		Name:              c.config.Name,
-		Version:           c.config.Version,
-		SupportedRoles:    []string{"player@v1", "metadata@v1", "artwork@v1", "visualizer@v1"},
-		DeviceInfo:        &c.config.DeviceInfo,
-		PlayerSupport:     &c.config.PlayerSupport,
-		ArtworkSupport:    &c.config.ArtworkSupport,
-		VisualizerSupport: &c.config.VisualizerSupport,
+		ClientID:       c.config.ClientID,
+		Name:           c.config.Name,
+		Version:        c.config.Version,
+		SupportedRoles: roles,
+			DeviceInfo:     &c.config.DeviceInfo,
+		
+		// Versioned fields (spec-compliant)
+		PlayerV1Support:     &c.config.PlayerV1Support,
+		ArtworkV1Support:    c.config.ArtworkV1Support,
+		VisualizerV1Support: c.config.VisualizerV1Support,
+		
+		// Legacy fields (Music Assistant compatibility) - CRITICAL!
+		PlayerSupport:     &legacyPlayerSupport,
+		MetadataSupport:   &legacyMetadataSupport,
+		ArtworkSupport:    c.config.ArtworkV1Support,
+		VisualizerSupport: c.config.VisualizerV1Support,
 	}
 
 	msg := protocol.Message{

--- a/pkg/protocol/client.go
+++ b/pkg/protocol/client.go
@@ -121,16 +121,38 @@ func (c *Client) handshake() error {
 		roles = append(roles, "visualizer@v1")
 	}
 
+	// Create legacy PlayerSupport for Music Assistant compatibility
+	legacyPlayerSupport := PlayerSupport{
+		SupportedFormats:  c.config.PlayerV1Support.SupportedFormats,
+		BufferCapacity:    c.config.PlayerV1Support.BufferCapacity,
+		SupportedCommands: c.config.PlayerV1Support.SupportedCommands,
+	}
+
+	// Create legacy MetadataSupport for Music Assistant compatibility
+	legacyMetadataSupport := MetadataSupport{
+		SupportPictureFormats: []string{"jpeg", "png", "webp"},
+		MediaWidth:            600,
+		MediaHeight:           600,
+	}
+
 	// Send client/hello with versioned roles
 	hello := ClientHello{
-		ClientID:            c.config.ClientID,
-		Name:                c.config.Name,
-		Version:             c.config.Version,
-		SupportedRoles:      roles,
-		DeviceInfo:          &c.config.DeviceInfo,
+		ClientID:       c.config.ClientID,
+		Name:           c.config.Name,
+		Version:        c.config.Version,
+		SupportedRoles: roles,
+		DeviceInfo:     &c.config.DeviceInfo,
+		
+		// Versioned support (spec-compliant)
 		PlayerV1Support:     &c.config.PlayerV1Support,
 		ArtworkV1Support:    c.config.ArtworkV1Support,
 		VisualizerV1Support: c.config.VisualizerV1Support,
+		
+		// Legacy support (Music Assistant compatibility) - ADD THESE!
+		PlayerSupport:     &legacyPlayerSupport,
+		MetadataSupport:   &legacyMetadataSupport,
+		ArtworkSupport:    c.config.ArtworkV1Support,
+		VisualizerSupport: c.config.VisualizerV1Support,
 	}
 
 	msg := Message{

--- a/pkg/protocol/legacy_test.go
+++ b/pkg/protocol/legacy_test.go
@@ -1,0 +1,59 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestLegacyFieldsInJSON(t *testing.T) {
+	legacyPlayerSupport := PlayerSupport{
+		SupportedFormats: []AudioFormat{
+			{Codec: "pcm", Channels: 2, SampleRate: 48000, BitDepth: 16},
+		},
+		BufferCapacity:    1048576,
+		SupportedCommands: []string{"volume"},
+	}
+
+	legacyMetadataSupport := MetadataSupport{
+		SupportPictureFormats: []string{"jpeg", "png", "webp"},
+		MediaWidth:            600,
+		MediaHeight:           600,
+	}
+
+	hello := ClientHello{
+		ClientID:        "test",
+		Name:            "Test",
+		Version:         1,
+		SupportedRoles:  []string{"player@v1"},
+		PlayerSupport:   &legacyPlayerSupport,   // Legacy field
+		MetadataSupport: &legacyMetadataSupport, // Legacy field
+	}
+
+	msg := Message{
+		Type:    "client/hello",
+		Payload: hello,
+	}
+
+	data, err := json.MarshalIndent(msg, "", "  ")
+	if err != nil {
+		t.Fatalf("Failed to marshal: %v", err)
+	}
+
+	t.Logf("Generated JSON:\n%s", string(data))
+
+	// Check if player_support appears in the JSON
+	if !bytes.Contains(data, []byte(`"player_support"`)) {
+		t.Error("FAIL: player_support field is MISSING from JSON!")
+		t.Log("This means Music Assistant won't accept the handshake")
+	} else {
+		t.Log("✓ SUCCESS: player_support field is in the JSON!")
+	}
+
+	// Check if metadata_support appears in the JSON
+	if !bytes.Contains(data, []byte(`"metadata_support"`)) {
+		t.Error("FAIL: metadata_support field is MISSING from JSON!")
+	} else {
+		t.Log("✓ SUCCESS: metadata_support field is in the JSON!")
+	}
+}


### PR DESCRIPTION
## Problem
Music Assistant (aiosendspin) server rejects connections with error:
```
ValueError: player_support must be provided when 'player' role is in supported_roles
```

The server expects legacy field names (`player_support`) in addition to 
spec-compliant versioned fields (`player@v1_support`).

## Solution
Modified both client implementations to send BOTH versioned and legacy fields
in the `client/hello` handshake message for backward compatibility.

### Changes:
- `pkg/protocol/client.go`: Add legacy fields to handshake
- `internal/client/websocket.go`: Add legacy fields to handshake  
- `pkg/protocol/legacy_test.go`: Add test verifying legacy fields in JSON

### Testing:
- Tested with Music Assistant server - connection now succeeds
- Test passes: `CGO_ENABLED=0 go test -v ./pkg/protocol -run TestLegacyFieldsInJSON`
- Player successfully registers with Music Assistant

### Backward Compatibility:
✅ Spec-compliant servers: Use versioned fields (`player@v1_support`)
✅ Music Assistant: Uses legacy fields (`player_support`)
✅ No breaking changes - both field sets are sent

Fixes #7 