### PR TITLE
Re-add server CLI and fix .gitignore binary patterns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
     - name: Build binaries
       run: |
         go build -v -o sendspin-player .
+        go build -v -o sendspin-server ./cmd/sendspin-server
         go build -v -o ma-player ./cmd/ma-player
         go build -v -o test-sync ./cmd/test-sync
 
@@ -102,5 +103,6 @@ jobs:
     - name: Build native binaries
       run: |
         go build -v -o sendspin-player .
+        go build -v -o sendspin-server ./cmd/sendspin-server
         go build -v -o ma-player ./cmd/ma-player
         go build -v -o test-sync ./cmd/test-sync

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 # Binaries
-sendspin-player
-sendspin-server
-resonate-player
-resonate-server
-test-sync
+/sendspin-player
+/sendspin-server
+/resonate-player
+/resonate-server
+/test-sync
+/ma-player
 *.exe
 *.dll
 *.so
@@ -35,4 +36,3 @@ output.txt
 sendspin-go
 resonate-go
 prompts/
-ma-player

--- a/cmd/sendspin-server/main.go
+++ b/cmd/sendspin-server/main.go
@@ -1,0 +1,185 @@
+// ABOUTME: Entry point for Sendspin Protocol server
+// ABOUTME: Thin CLI wrapper around pkg/sendspin.Server with TUI support
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/Sendspin/sendspin-go/internal/server"
+	"github.com/Sendspin/sendspin-go/pkg/sendspin"
+)
+
+var (
+	port      = flag.Int("port", 8927, "WebSocket server port")
+	name      = flag.String("name", "", "Server friendly name (default: hostname-sendspin-server)")
+	logFile   = flag.String("log-file", "sendspin-server.log", "Log file path")
+	debug     = flag.Bool("debug", false, "Enable debug logging")
+	noMDNS    = flag.Bool("no-mdns", false, "Disable mDNS advertisement")
+	noTUI     = flag.Bool("no-tui", false, "Disable TUI, use streaming logs instead")
+	audioFile = flag.String("audio", "", "Audio source to stream (MP3, FLAC, HTTP URL, HLS). Default: test tone")
+)
+
+func main() {
+	flag.Parse()
+
+	useTUI := !*noTUI
+
+	// Set up logging
+	f, err := os.OpenFile(*logFile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	if err != nil {
+		log.Fatalf("error opening log file: %v", err)
+	}
+	defer f.Close()
+
+	if useTUI {
+		log.SetOutput(f)
+	} else {
+		log.SetOutput(io.MultiWriter(os.Stdout, f))
+	}
+
+	// Determine server name
+	serverName := *name
+	if serverName == "" {
+		hostname, err := os.Hostname()
+		if err != nil {
+			hostname = "unknown"
+		}
+		serverName = fmt.Sprintf("%s-sendspin-server", hostname)
+	}
+
+	if !useTUI {
+		log.Printf("Starting Sendspin Server: %s on port %d", serverName, *port)
+	}
+
+	// Create audio source
+	var source sendspin.AudioSource
+	if *audioFile == "" {
+		source = sendspin.NewTestTone(sendspin.DefaultSampleRate, sendspin.DefaultChannels)
+	} else {
+		internalSource, err := server.NewAudioSource(*audioFile)
+		if err != nil {
+			log.Fatalf("Failed to create audio source: %v", err)
+		}
+		source = internalSource
+	}
+
+	srv, err := sendspin.NewServer(sendspin.ServerConfig{
+		Port:       *port,
+		Name:       serverName,
+		Source:     source,
+		EnableMDNS: !*noMDNS,
+		Debug:      *debug,
+	})
+	if err != nil {
+		log.Fatalf("Failed to create server: %v", err)
+	}
+
+	// Set up TUI if enabled
+	var tui *server.ServerTUI
+	var tuiDone chan struct{}
+	if useTUI {
+		tui = server.NewServerTUI(serverName, *port)
+		tuiDone = make(chan struct{})
+
+		go func() {
+			defer close(tuiDone)
+			if err := tui.Start(serverName, *port); err != nil {
+				log.Printf("TUI error: %v", err)
+			}
+		}()
+
+		time.Sleep(100 * time.Millisecond)
+
+		go func() {
+			ticker := time.NewTicker(500 * time.Millisecond)
+			defer ticker.Stop()
+
+			for {
+				select {
+				case <-ticker.C:
+					updateTUI(tui, srv, source, serverName, *port)
+				case <-tuiDone:
+					return
+				}
+			}
+		}()
+	}
+
+	// Handle shutdown
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	var tuiQuitChan <-chan struct{}
+	if tui != nil {
+		tuiQuitChan = tui.QuitChan()
+	}
+
+	serverDone := make(chan error, 1)
+	go func() {
+		serverDone <- srv.Start()
+	}()
+
+	// Wait for shutdown signal, TUI quit, or server error
+	serverStopped := false
+	select {
+	case sig := <-sigChan:
+		log.Printf("Received %v, shutting down...", sig)
+	case <-tuiQuitChan:
+		log.Printf("TUI quit requested, shutting down...")
+	case err := <-serverDone:
+		serverStopped = true
+		if err != nil {
+			log.Printf("Server error: %v", err)
+		}
+	}
+
+	srv.Stop()
+
+	if tui != nil {
+		tui.Stop()
+		<-tuiDone
+	}
+
+	if !serverStopped {
+		if err := <-serverDone; err != nil {
+			log.Printf("Server shutdown error: %v", err)
+		}
+	}
+
+	log.Printf("Server stopped")
+}
+
+// updateTUI sends current server state to the TUI
+func updateTUI(tui *server.ServerTUI, srv *sendspin.Server, source sendspin.AudioSource, serverName string, port int) {
+	clients := srv.Clients()
+
+	tuiClients := make([]server.ClientInfo, len(clients))
+	for i, c := range clients {
+		tuiClients[i] = server.ClientInfo{
+			Name:  c.Name,
+			ID:    c.ID,
+			Codec: c.Codec,
+			State: c.State,
+		}
+	}
+
+	title, artist, _ := source.Metadata()
+	audioTitle := title
+	if artist != "" && artist != "Unknown Artist" {
+		audioTitle = artist + " - " + title
+	}
+
+	tui.Update(server.ServerStatus{
+		Name:       serverName,
+		Port:       port,
+		Clients:    tuiClients,
+		AudioTitle: audioTitle,
+	})
+}


### PR DESCRIPTION
## Summary
- Add `cmd/sendspin-server` wrapping `pkg/sendspin.Server` with TUI support
- Prefix `.gitignore` binary entries with `/` to avoid matching source directories
- Add `sendspin-server` to CI build targets

Based on work from #6 by @abmantis, with fixes for:
- Log file permissions (`0600` instead of `0666`)
- `serverDone` channel deadlock when server exits before signal

Closes #6

## Test plan
- [ ] CI passes (build, test, lint)
- [ ] `make server` builds successfully
- [ ] Server starts with `--no-tui` and accepts player connections