### PR TITLE
Implement Kalman time filter for clock synchronization

### DIFF
--- a/pkg/sync/clock.go
+++ b/pkg/sync/clock.go
@@ -1,5 +1,5 @@
-// ABOUTME: Clock synchronization with drift compensation
-// ABOUTME: Tracks both offset AND drift to handle clock frequency differences
+// ABOUTME: Clock synchronization using Kalman time filter
+// ABOUTME: Tracks offset and drift between client and server clocks
 package sync
 
 import (
@@ -8,15 +8,14 @@ import (
 	"time"
 )
 
-// ClockSync manages clock synchronization with drift compensation
+// ClockSync manages clock synchronization using a Kalman time filter.
 type ClockSync struct {
-	mu                  sync.RWMutex
-	serverLoopStartUnix int64 // Unix microseconds when server loop started
-	rtt                 int64 // Latest round-trip time
-	quality             Quality
-	lastSync            time.Time
-	sampleCount         int
-	synced              bool // True after first successful sync
+	mu          sync.RWMutex
+	filter      *TimeFilter
+	rtt         int64
+	quality     Quality
+	lastSync    time.Time
+	sampleCount int
 }
 
 // Quality represents sync quality
@@ -31,16 +30,14 @@ const (
 // NewClockSync creates a new clock synchronizer
 func NewClockSync() *ClockSync {
 	return &ClockSync{
+		filter:  NewTimeFilter(DefaultTimeFilterConfig()),
 		quality: QualityLost,
-		synced:  false,
 	}
 }
 
-// ProcessSyncResponse processes a server/time response
-// t1: client send (Unix µs)
-// t2: server receive (server loop µs)
-// t3: server send (server loop µs)
-// t4: client receive (Unix µs)
+// ProcessSyncResponse processes a server/time response.
+// t1: client send (Unix µs), t2: server receive (server µs),
+// t3: server send (server µs), t4: client receive (Unix µs)
 func (cs *ClockSync) ProcessSyncResponse(t1, t2, t3, t4 int64) {
 	rtt := (t4 - t1) - (t3 - t2)
 
@@ -56,19 +53,14 @@ func (cs *ClockSync) ProcessSyncResponse(t1, t2, t3, t4 int64) {
 		return
 	}
 
-	// On first successful sync, compute when the server loop started in Unix µs
-	// t2 is server_received (server loop µs), t4 is our Unix µs
-	if !cs.synced {
-		cs.serverLoopStartUnix = time.Now().UnixMicro() - t2
-		cs.synced = true
-		cs.quality = QualityGood
-		cs.sampleCount++
-		log.Printf("Clock sync established: serverLoopStart=%d, rtt=%dμs", cs.serverLoopStartUnix, rtt)
-		return
-	}
+	// NTP-style offset and uncertainty
+	measurement := ((t2 - t1) + (t3 - t4)) / 2
+	maxError := rtt / 2
+
+	cs.filter.Update(measurement, maxError, t4)
 
 	// Update quality based on RTT
-	if rtt < 50000 { // <50ms
+	if rtt < 50000 {
 		cs.quality = QualityGood
 	} else {
 		cs.quality = QualityDegraded
@@ -76,8 +68,10 @@ func (cs *ClockSync) ProcessSyncResponse(t1, t2, t3, t4 int64) {
 
 	cs.sampleCount++
 
-	if cs.sampleCount < 10 {
-		log.Printf("Sync #%d: rtt=%dμs, quality=%v", cs.sampleCount, rtt, cs.quality)
+	if cs.sampleCount <= 5 {
+		filterErr := cs.filter.GetError()
+		log.Printf("Sync #%d: rtt=%dμs, offset=%dμs, error=%dμs",
+			cs.sampleCount, rtt, measurement, filterErr)
 	}
 }
 
@@ -100,40 +94,35 @@ func (cs *ClockSync) CheckQuality() Quality {
 	return cs.quality
 }
 
-// ServerToLocalTime converts server timestamp (loop µs) to local wall clock time
+// ServerToLocalTime converts server timestamp (µs) to local wall clock time.
 func (cs *ClockSync) ServerToLocalTime(serverTime int64) time.Time {
 	cs.mu.RLock()
 	defer cs.mu.RUnlock()
 
-	// If we haven't synced yet, assume server time = client time
-	if !cs.synced {
+	if !cs.filter.Synced() {
 		return time.Unix(0, serverTime*1000)
 	}
 
-	// Convert server loop µs to Unix µs
-	unixMicros := cs.serverLoopStartUnix + serverTime
-
-	return time.UnixMicro(unixMicros)
+	// server→client conversion gives us client Unix µs
+	clientMicros := cs.filter.ComputeClientTime(serverTime)
+	return time.UnixMicro(clientMicros)
 }
 
-// ServerMicrosNow returns current time in server's reference frame (server loop µs)
+// ServerMicrosNow returns current time in server's reference frame (µs).
 func ServerMicrosNow() int64 {
 	cs := globalClockSync
 	if cs == nil {
-		// Before sync initialized, use raw client time
 		return time.Now().UnixMicro()
 	}
 
 	cs.mu.RLock()
 	defer cs.mu.RUnlock()
 
-	// If we haven't synced yet, return Unix time
-	if !cs.synced {
+	if !cs.filter.Synced() {
 		return time.Now().UnixMicro()
 	}
 
-	// Calculate server loop µs from current Unix time
-	return time.Now().UnixMicro() - cs.serverLoopStartUnix
+	return cs.filter.ComputeServerTime(time.Now().UnixMicro())
 }
 
 // SetGlobalClockSync sets the global clock sync instance

--- a/pkg/sync/clock_test.go
+++ b/pkg/sync/clock_test.go
@@ -1,5 +1,5 @@
-// ABOUTME: Tests for loop-origin clock synchronization
-// ABOUTME: Tests RTT calculation, loop origin establishment, and time conversion
+// ABOUTME: Tests for Kalman-filter-based clock synchronization
+// ABOUTME: Tests RTT calculation, time conversion, quality tracking
 package sync
 
 import (
@@ -8,89 +8,62 @@ import (
 )
 
 func TestRTTCalculation(t *testing.T) {
-	// Simulate a sync exchange with 4.5ms RTT
-	t1 := int64(1000000) // Client send (Unix µs)
-	t2 := int64(2000)    // Server receive (server loop µs) - +2ms from client send
-	t3 := int64(2500)    // Server send (server loop µs) - +0.5ms processing
-	t4 := int64(1005000) // Client receive (Unix µs) - +5ms total
+	t1 := int64(1000000)
+	t2 := int64(2000)
+	t3 := int64(2500)
+	t4 := int64(1005000)
 
 	cs := NewClockSync()
 	cs.ProcessSyncResponse(t1, t2, t3, t4)
 
 	// RTT = (t4-t1) - (t3-t2) = 5000 - 500 = 4500µs
 	rtt, _ := cs.GetStats()
-	expectedRTT := int64(4500)
-	if rtt != expectedRTT {
-		t.Errorf("expected RTT %dµs, got %dµs", expectedRTT, rtt)
+	if rtt != 4500 {
+		t.Errorf("expected RTT 4500µs, got %dµs", rtt)
 	}
 }
 
-func TestLoopOriginEstablishment(t *testing.T) {
+func TestSyncEstablishment(t *testing.T) {
 	cs := NewClockSync()
 
-	// Before sync, should not be synced
-	if cs.synced {
+	if cs.filter.Synced() {
 		t.Error("expected not synced initially")
 	}
 
-	// Process first sync response
 	now := time.Now().UnixMicro()
-	t1 := now - 10000    // Sent 10ms ago
-	t2 := int64(1000000) // Server loop time at receive
-	t3 := t2 + 100       // Server processed in 0.1ms
-	t4 := now            // Received now
+	cs.ProcessSyncResponse(now-10000, 1000000, 1000100, now)
 
-	cs.ProcessSyncResponse(t1, t2, t3, t4)
-
-	// Should now be synced
-	if !cs.synced {
+	if !cs.filter.Synced() {
 		t.Error("expected synced after first response")
 	}
 
-	// Quality should be good (low RTT)
 	_, quality := cs.GetStats()
 	if quality != QualityGood {
 		t.Errorf("expected QualityGood, got %v", quality)
-	}
-
-	// Should have established loop origin
-	// serverLoopStartUnix = now - t2
-	expectedOrigin := now - t2
-	actualOrigin := cs.serverLoopStartUnix
-
-	// Allow some tolerance (should be within 1ms)
-	diff := expectedOrigin - actualOrigin
-	if diff < -1000 || diff > 1000 {
-		t.Errorf("loop origin off by %dµs (expected ~%d, got %d)",
-			diff, expectedOrigin, actualOrigin)
 	}
 }
 
 func TestServerToLocalTimeConversion(t *testing.T) {
 	cs := NewClockSync()
 
-	// Simulate sync at a known time
 	clientNow := time.Now().UnixMicro()
-	serverLoopTime := int64(5000000) // 5 seconds into server loop
+	serverTime := int64(5000000) // 5s into server loop
 
-	// Sync: client sent at (now-1000), server received at serverLoopTime
-	cs.ProcessSyncResponse(
-		clientNow-1000,
-		serverLoopTime,
-		serverLoopTime+50,
-		clientNow,
-	)
+	// Feed several samples to let the filter converge
+	for i := 0; i < 10; i++ {
+		ct := clientNow + int64(i*100000) // 100ms apart
+		st := serverTime + int64(i*100000)
+		cs.ProcessSyncResponse(ct-1000, st, st+50, ct)
+	}
 
-	// Convert server time to local time
-	serverTime := serverLoopTime + 100000 // 100ms later in server loop
-	localTime := cs.ServerToLocalTime(serverTime)
+	// Convert a server time 100ms in the future
+	futureServer := serverTime + 10*100000 + 100000
+	localTime := cs.ServerToLocalTime(futureServer)
 
-	// Local time should be approximately clientNow + 100000µs
-	expectedLocal := time.UnixMicro(clientNow + 100000)
+	expectedLocal := time.UnixMicro(clientNow + 10*100000 + 100000)
 	diff := localTime.Sub(expectedLocal).Microseconds()
 
-	// Should be within 10ms tolerance (accounting for processing delays)
-	if diff < -10000 || diff > 10000 {
+	if diff < -50000 || diff > 50000 {
 		t.Errorf("time conversion off by %dµs", diff)
 	}
 }
@@ -110,20 +83,14 @@ func TestServerMicrosNow(t *testing.T) {
 
 	// Perform sync
 	clientNow := time.Now().UnixMicro()
-	serverLoopTime := int64(3000000) // 3 seconds into server loop
+	serverLoopTime := int64(3000000)
 
-	cs.ProcessSyncResponse(
-		clientNow-1000,
-		serverLoopTime,
-		serverLoopTime+50,
-		clientNow,
-	)
+	cs.ProcessSyncResponse(clientNow-1000, serverLoopTime, serverLoopTime+50, clientNow)
 
-	// After sync, should return server loop time
+	// After sync, should return server-domain time
 	serverNow2 := ServerMicrosNow()
 
-	// Server loop time should be roughly serverLoopTime (allowing for passage of time)
-	// The exact value depends on when we call it, but it should be in the ballpark
+	// Should be in the ballpark of serverLoopTime (within 100ms)
 	if serverNow2 < serverLoopTime-100000 || serverNow2 > serverLoopTime+100000 {
 		t.Errorf("ServerMicrosNow returned %d, expected around %d", serverNow2, serverLoopTime)
 	}
@@ -150,21 +117,18 @@ func TestQualityTracking(t *testing.T) {
 func TestQualityDegradation(t *testing.T) {
 	cs := NewClockSync()
 
-	// Establish sync
 	cs.ProcessSyncResponse(1000000, 1000, 1100, 1025000)
 
-	// Check quality immediately - should be good
 	quality := cs.CheckQuality()
 	if quality != QualityGood {
 		t.Errorf("expected QualityGood initially, got %v", quality)
 	}
 
-	// Simulate time passing by directly manipulating lastSync
+	// Simulate time passing
 	cs.mu.Lock()
 	cs.lastSync = time.Now().Add(-6 * time.Second)
 	cs.mu.Unlock()
 
-	// Check quality after 6 seconds - should be lost
 	quality = cs.CheckQuality()
 	if quality != QualityLost {
 		t.Errorf("expected QualityLost after 6s, got %v", quality)
@@ -174,24 +138,16 @@ func TestQualityDegradation(t *testing.T) {
 func TestHighRTTRejection(t *testing.T) {
 	cs := NewClockSync()
 
-	// First sync with good RTT establishes loop origin
+	// First sync with good RTT
 	cs.ProcessSyncResponse(1000000, 1000, 1100, 1025000)
-	origin1 := cs.serverLoopStartUnix
-	sampleCount1 := cs.sampleCount
+	count1 := cs.sampleCount
 
-	// Second sync with very high RTT (>100ms) should not update sample count or origin
+	// Second sync with very high RTT (>100ms) should be discarded
 	cs.ProcessSyncResponse(2000000, 2000, 2100, 2250000)
-	origin2 := cs.serverLoopStartUnix
-	sampleCount2 := cs.sampleCount
+	count2 := cs.sampleCount
 
-	// Loop origin should not change (high RTT sample rejected)
-	if origin2 != origin1 {
-		t.Errorf("expected loop origin to stay the same after high RTT sample")
-	}
-
-	// Sample count should not increase (sample was discarded)
-	if sampleCount2 != sampleCount1 {
-		t.Errorf("expected sample count to stay at %d, got %d", sampleCount1, sampleCount2)
+	if count2 != count1 {
+		t.Errorf("expected sample count to stay at %d, got %d", count1, count2)
 	}
 }
 
@@ -199,38 +155,29 @@ func TestConcurrentAccess(t *testing.T) {
 	cs := NewClockSync()
 	SetGlobalClockSync(cs)
 
-	// Perform initial sync
 	cs.ProcessSyncResponse(1000000, 1000, 1100, 1025000)
 
-	// Spawn multiple goroutines accessing the clock sync
 	done := make(chan bool, 10)
 	for i := 0; i < 10; i++ {
 		go func() {
 			for j := 0; j < 100; j++ {
-				// Read operations
 				cs.GetStats()
 				cs.CheckQuality()
 				ServerMicrosNow()
 				cs.ServerToLocalTime(int64(j * 1000))
-
-				// Write operation
 				cs.ProcessSyncResponse(
-					int64(1000000+j),
-					int64(1000+j),
-					int64(1100+j),
-					int64(1025000+j),
+					int64(1000000+j), int64(1000+j),
+					int64(1100+j), int64(1025000+j),
 				)
 			}
 			done <- true
 		}()
 	}
 
-	// Wait for all goroutines
 	for i := 0; i < 10; i++ {
 		<-done
 	}
 
-	// Should still have valid state
 	rtt, quality := cs.GetStats()
 	if rtt <= 0 {
 		t.Error("invalid RTT after concurrent access")

--- a/pkg/sync/doc.go
+++ b/pkg/sync/doc.go
@@ -1,12 +1,9 @@
-// ABOUTME: Clock synchronization package
-// ABOUTME: Provides NTP-style clock sync with Resonate servers
+// ABOUTME: Clock synchronization using Kalman time filter
+// ABOUTME: Provides NTP-style clock sync with offset and drift tracking
+//
 // Package sync provides clock synchronization for precise audio timing.
 //
-// Uses NTP-style round-trip time measurement to sync with server clocks.
-//
-// Example:
-//
-//	clock := sync.NewClock()
-//	err := clock.Sync("localhost:8927")
-//	serverTime := clock.ServerTime()
+// Uses a two-dimensional Kalman filter to track both clock offset and drift
+// between client and server, following the Sendspin time filter specification.
+// NTP-style round-trip time measurements feed the filter for optimal estimation.
 package sync

--- a/pkg/sync/timefilter.go
+++ b/pkg/sync/timefilter.go
@@ -1,0 +1,217 @@
+// ABOUTME: Kalman filter for NTP-style time synchronization
+// ABOUTME: Tracks clock offset and drift between client and server
+package sync
+
+import (
+	"math"
+	"sync"
+)
+
+// TimeFilter is a two-dimensional Kalman filter that tracks clock offset and
+// drift rate between client and server using NTP-style time messages.
+// Implements the Sendspin time filter specification.
+type TimeFilter struct {
+	mu sync.Mutex
+
+	lastUpdate int64
+
+	offset float64
+	drift  float64
+
+	offsetCovariance      float64
+	offsetDriftCovariance float64
+	driftCovariance       float64
+
+	processVariance              float64
+	driftProcessVariance         float64
+	forgetVarianceFactor         float64
+	adaptiveForgettingCutoff     float64
+	driftSignificanceThresholdSq float64
+
+	useDrift   bool
+	count      uint8
+	minSamples uint8
+}
+
+// TimeFilterConfig holds configuration for the Kalman filter.
+type TimeFilterConfig struct {
+	// ProcessStdDev is the standard deviation of offset process noise in µs.
+	ProcessStdDev float64
+	// DriftProcessStdDev is the standard deviation of drift process noise in µs/s.
+	DriftProcessStdDev float64
+	// ForgetFactor (>1) applied to covariances when large residuals are detected.
+	ForgetFactor float64
+	// AdaptiveCutoff is the fraction of max_error (0-1) that triggers forgetting.
+	AdaptiveCutoff float64
+	// MinSamples before adaptive forgetting is enabled.
+	MinSamples uint8
+	// DriftSignificanceThreshold is the SNR threshold for applying drift compensation.
+	DriftSignificanceThreshold float64
+}
+
+// DefaultTimeFilterConfig returns recommended values from the spec.
+func DefaultTimeFilterConfig() TimeFilterConfig {
+	return TimeFilterConfig{
+		ProcessStdDev:              0.01,
+		DriftProcessStdDev:         0.0,
+		ForgetFactor:               1.001,
+		AdaptiveCutoff:             0.75,
+		MinSamples:                 100,
+		DriftSignificanceThreshold: 2.0,
+	}
+}
+
+// NewTimeFilter creates a Kalman filter for time synchronization.
+func NewTimeFilter(cfg TimeFilterConfig) *TimeFilter {
+	tf := &TimeFilter{
+		processVariance:              cfg.ProcessStdDev * cfg.ProcessStdDev,
+		driftProcessVariance:         cfg.DriftProcessStdDev * cfg.DriftProcessStdDev,
+		forgetVarianceFactor:         cfg.ForgetFactor * cfg.ForgetFactor,
+		adaptiveForgettingCutoff:     cfg.AdaptiveCutoff,
+		driftSignificanceThresholdSq: cfg.DriftSignificanceThreshold * cfg.DriftSignificanceThreshold,
+		minSamples:                   cfg.MinSamples,
+	}
+	tf.reset()
+	return tf
+}
+
+// Update processes a new time synchronization measurement.
+//
+//	measurement: ((T2-T1)+(T3-T4))/2 in microseconds
+//	maxError:    ((T4-T1)-(T3-T2))/2 in microseconds
+//	timeAdded:   client timestamp when measurement was taken, in microseconds
+func (tf *TimeFilter) Update(measurement, maxError, timeAdded int64) {
+	tf.mu.Lock()
+	defer tf.mu.Unlock()
+
+	if timeAdded <= tf.lastUpdate {
+		return // skip non-monotonic timestamps
+	}
+
+	dt := float64(timeAdded - tf.lastUpdate)
+	dtSq := dt * dt
+	tf.lastUpdate = timeAdded
+
+	measVar := float64(maxError) * float64(maxError)
+
+	// First measurement: establish offset baseline
+	if tf.count == 0 {
+		tf.count++
+		tf.offset = float64(measurement)
+		tf.offsetCovariance = measVar
+		tf.drift = 0
+		return
+	}
+
+	// Second measurement: initial drift estimate via finite differences
+	if tf.count == 1 {
+		tf.count++
+		tf.drift = (float64(measurement) - tf.offset) / dt
+		tf.offset = float64(measurement)
+		tf.driftCovariance = (tf.offsetCovariance + measVar) / dtSq
+		tf.offsetCovariance = measVar
+		return
+	}
+
+	// --- Kalman prediction ---
+	predOffset := tf.offset + tf.drift*dt
+
+	driftProcVar := dt * tf.driftProcessVariance
+	newDriftCov := tf.driftCovariance + driftProcVar
+	newOffsetDriftCov := tf.offsetDriftCovariance + tf.driftCovariance*dt
+	offsetProcVar := dt * tf.processVariance
+	newOffsetCov := tf.offsetCovariance + 2*tf.offsetDriftCovariance*dt +
+		tf.driftCovariance*dtSq + offsetProcVar
+
+	// --- Innovation and adaptive forgetting ---
+	residual := float64(measurement) - predOffset
+	cutoff := float64(maxError) * tf.adaptiveForgettingCutoff
+
+	if tf.count < tf.minSamples {
+		tf.count++
+	} else if math.Abs(residual) > cutoff {
+		newDriftCov *= tf.forgetVarianceFactor
+		newOffsetDriftCov *= tf.forgetVarianceFactor
+		newOffsetCov *= tf.forgetVarianceFactor
+	}
+
+	// --- Kalman update ---
+	invS := 1.0 / (newOffsetCov + measVar)
+	offsetGain := newOffsetCov * invS
+	driftGain := newOffsetDriftCov * invS
+
+	tf.offset = predOffset + offsetGain*residual
+	tf.drift += driftGain * residual
+
+	tf.driftCovariance = newDriftCov - driftGain*newOffsetDriftCov
+	tf.offsetDriftCovariance = newOffsetDriftCov - driftGain*newOffsetCov
+	tf.offsetCovariance = newOffsetCov - offsetGain*newOffsetCov
+
+	// Update drift significance flag
+	driftSq := tf.drift * tf.drift
+	tf.useDrift = driftSq > tf.driftSignificanceThresholdSq*tf.driftCovariance
+}
+
+// ComputeServerTime converts a client timestamp to server time.
+func (tf *TimeFilter) ComputeServerTime(clientTime int64) int64 {
+	tf.mu.Lock()
+	defer tf.mu.Unlock()
+
+	dt := float64(clientTime - tf.lastUpdate)
+	effectiveDrift := 0.0
+	if tf.useDrift {
+		effectiveDrift = tf.drift
+	}
+	offset := math.Round(tf.offset + effectiveDrift*dt)
+	return clientTime + int64(offset)
+}
+
+// ComputeClientTime converts a server timestamp to client time.
+func (tf *TimeFilter) ComputeClientTime(serverTime int64) int64 {
+	tf.mu.Lock()
+	defer tf.mu.Unlock()
+
+	effectiveDrift := 0.0
+	if tf.useDrift {
+		effectiveDrift = tf.drift
+	}
+	return int64(math.Round(
+		(float64(serverTime) - tf.offset + effectiveDrift*float64(tf.lastUpdate)) /
+			(1.0 + effectiveDrift)))
+}
+
+// GetError returns the estimated standard deviation of the offset in µs.
+func (tf *TimeFilter) GetError() int64 {
+	tf.mu.Lock()
+	defer tf.mu.Unlock()
+	v := math.Sqrt(tf.offsetCovariance)
+	if math.IsInf(v, 0) || math.IsNaN(v) {
+		return math.MaxInt64
+	}
+	return int64(math.Round(v))
+}
+
+// Synced returns true after at least one measurement has been processed.
+func (tf *TimeFilter) Synced() bool {
+	tf.mu.Lock()
+	defer tf.mu.Unlock()
+	return tf.count > 0
+}
+
+// Reset clears all state.
+func (tf *TimeFilter) Reset() {
+	tf.mu.Lock()
+	defer tf.mu.Unlock()
+	tf.reset()
+}
+
+func (tf *TimeFilter) reset() {
+	tf.count = 0
+	tf.offset = 0
+	tf.drift = 0
+	tf.offsetCovariance = math.Inf(1)
+	tf.offsetDriftCovariance = 0
+	tf.driftCovariance = 0
+	tf.lastUpdate = 0
+	tf.useDrift = false
+}

--- a/pkg/sync/timefilter_test.go
+++ b/pkg/sync/timefilter_test.go
@@ -1,0 +1,208 @@
+// ABOUTME: Tests for Kalman filter time synchronization
+// ABOUTME: Validates offset tracking, drift compensation, and adaptive forgetting
+package sync
+
+import (
+	"math"
+	"testing"
+)
+
+func TestTimeFilterFirstMeasurement(t *testing.T) {
+	tf := NewTimeFilter(DefaultTimeFilterConfig())
+
+	tf.Update(5000, 100, 1000000)
+
+	if !tf.Synced() {
+		t.Fatal("expected synced after first measurement")
+	}
+
+	// After one sample, server_time = client_time + offset (≈5000)
+	st := tf.ComputeServerTime(1000000)
+	diff := st - (1000000 + 5000)
+	if abs64(diff) > 10 {
+		t.Errorf("expected server time near %d, got %d", 1000000+5000, st)
+	}
+}
+
+func TestTimeFilterConvergesOnStableOffset(t *testing.T) {
+	tf := NewTimeFilter(DefaultTimeFilterConfig())
+
+	// Feed 50 measurements with constant offset=10000µs, low noise
+	for i := 0; i < 50; i++ {
+		clientTime := int64(1000000 + i*100000) // 100ms apart
+		tf.Update(10000, 50, clientTime)
+	}
+
+	// Should converge close to 10000µs offset
+	clientNow := int64(1000000 + 50*100000)
+	st := tf.ComputeServerTime(clientNow)
+	offset := st - clientNow
+	if abs64(offset-10000) > 100 {
+		t.Errorf("expected offset near 10000, got %d", offset)
+	}
+}
+
+func TestTimeFilterDriftTracking(t *testing.T) {
+	cfg := DefaultTimeFilterConfig()
+	cfg.DriftProcessStdDev = 0.1 // allow drift model
+	tf := NewTimeFilter(cfg)
+
+	// Simulate a clock drifting at 10µs per second (10ppm)
+	// Measurements taken 1s apart, offset increases by 10 each time
+	for i := 0; i < 200; i++ {
+		clientTime := int64(i) * 1000000 // 1s apart
+		trueOffset := int64(5000 + i*10) // drifting 10µs/s
+		tf.Update(trueOffset, 50, clientTime)
+	}
+
+	// Check that drift-compensated conversion is more accurate than offset-only
+	futureClient := int64(250 * 1000000)                // 50s in the future
+	trueServerTime := futureClient + int64(5000+250*10) // true offset at t=250s
+	predicted := tf.ComputeServerTime(futureClient)
+
+	err := abs64(predicted - trueServerTime)
+	if err > 1000 { // within 1ms is reasonable for 50s extrapolation
+		t.Errorf("drift prediction error %dµs, expected <1000µs", err)
+	}
+}
+
+func TestTimeFilterAdaptiveForgetting(t *testing.T) {
+	tf := NewTimeFilter(DefaultTimeFilterConfig())
+
+	// Build up stable estimate at offset=5000
+	for i := 0; i < 150; i++ {
+		clientTime := int64(1000000 + i*100000)
+		tf.Update(5000, 50, clientTime)
+	}
+
+	// Sudden jump to offset=15000 (server clock adjusted)
+	jumpTime := int64(1000000 + 150*100000)
+	tf.Update(15000, 50, jumpTime)
+
+	// After a few more samples at the new offset, should converge
+	for i := 151; i < 200; i++ {
+		clientTime := int64(1000000 + i*100000)
+		tf.Update(15000, 50, clientTime)
+	}
+
+	clientNow := int64(1000000 + 200*100000)
+	st := tf.ComputeServerTime(clientNow)
+	offset := st - clientNow
+	if abs64(offset-15000) > 1000 {
+		t.Errorf("expected offset near 15000 after jump, got %d", offset)
+	}
+}
+
+func TestTimeFilterComputeClientTime(t *testing.T) {
+	tf := NewTimeFilter(DefaultTimeFilterConfig())
+
+	for i := 0; i < 20; i++ {
+		clientTime := int64(1000000 + i*100000)
+		tf.Update(8000, 50, clientTime)
+	}
+
+	// Round-trip: client→server→client should be identity (within rounding)
+	clientTime := int64(5000000)
+	serverTime := tf.ComputeServerTime(clientTime)
+	backToClient := tf.ComputeClientTime(serverTime)
+
+	if abs64(backToClient-clientTime) > 2 {
+		t.Errorf("round-trip error: %d → %d → %d", clientTime, serverTime, backToClient)
+	}
+}
+
+func TestTimeFilterRejectsNonMonotonic(t *testing.T) {
+	tf := NewTimeFilter(DefaultTimeFilterConfig())
+
+	tf.Update(5000, 100, 2000000)
+	tf.Update(5000, 100, 1000000) // earlier timestamp, should be ignored
+
+	// Only one sample counted
+	tf.mu.Lock()
+	count := tf.count
+	tf.mu.Unlock()
+	if count != 1 {
+		t.Errorf("expected count=1 after non-monotonic update, got %d", count)
+	}
+}
+
+func TestTimeFilterReset(t *testing.T) {
+	tf := NewTimeFilter(DefaultTimeFilterConfig())
+
+	tf.Update(5000, 100, 1000000)
+	if !tf.Synced() {
+		t.Fatal("expected synced")
+	}
+
+	tf.Reset()
+	if tf.Synced() {
+		t.Fatal("expected not synced after reset")
+	}
+}
+
+func TestTimeFilterGetError(t *testing.T) {
+	tf := NewTimeFilter(DefaultTimeFilterConfig())
+
+	// Before any measurements, covariance is Inf → error should be large
+	err0 := tf.GetError()
+	if err0 < 1000000 {
+		t.Errorf("expected very large error before sync, got %d", err0)
+	}
+
+	// After many low-noise measurements, error should be small
+	for i := 0; i < 100; i++ {
+		tf.Update(5000, 20, int64(1000000+i*100000))
+	}
+	err1 := tf.GetError()
+	if err1 > 50 {
+		t.Errorf("expected small error after 100 samples, got %d", err1)
+	}
+}
+
+func TestTimeFilterConcurrentAccess(t *testing.T) {
+	tf := NewTimeFilter(DefaultTimeFilterConfig())
+
+	done := make(chan bool, 10)
+	for i := 0; i < 10; i++ {
+		go func(id int) {
+			for j := 0; j < 100; j++ {
+				clientTime := int64(id*10000000 + j*100000)
+				tf.Update(5000, 50, clientTime)
+				tf.ComputeServerTime(clientTime)
+				tf.ComputeClientTime(clientTime + 5000)
+				tf.GetError()
+				tf.Synced()
+			}
+			done <- true
+		}(i)
+	}
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+}
+
+func abs64(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+// Verify Inf covariance doesn't cause NaN propagation
+func TestTimeFilterInitialInfCovariance(t *testing.T) {
+	tf := NewTimeFilter(DefaultTimeFilterConfig())
+
+	tf.mu.Lock()
+	if !math.IsInf(tf.offsetCovariance, 1) {
+		t.Error("expected +Inf initial offset covariance")
+	}
+	tf.mu.Unlock()
+
+	// First update should produce finite values
+	tf.Update(5000, 100, 1000000)
+	tf.mu.Lock()
+	if math.IsInf(tf.offsetCovariance, 0) || math.IsNaN(tf.offsetCovariance) {
+		t.Errorf("expected finite covariance after first update, got %f", tf.offsetCovariance)
+	}
+	tf.mu.Unlock()
+}


### PR DESCRIPTION
## Summary

Replaces the single-sample offset estimator in `pkg/sync` with a two-dimensional Kalman filter that tracks both clock offset and drift rate, per the [Sendspin time filter specification](https://github.com/Sendspin/time-filter).

This addresses the README warning about poor synchronization accuracy due to missing drift tracking.

### What changed

- **`pkg/sync/timefilter.go`** — New `TimeFilter` type implementing the Kalman filter with:
  - NTP-style 4-timestamp measurement processing
  - Adaptive forgetting factor for recovery from clock adjustments
  - Drift significance check (SNR threshold) to avoid noisy early corrections
  - Thread-safe client↔server time conversions

- **`pkg/sync/clock.go`** — `ClockSync` now uses `TimeFilter` internally instead of storing a single offset. `ProcessSyncResponse` computes the NTP measurement/maxError and feeds them to the filter. `ServerToLocalTime` and `ServerMicrosNow` use the filter's time conversion methods.

- **`internal/sync/`** — Unchanged. The legacy ma-player path continues using the original single-sample approach.

### Default parameters (from spec)
| Parameter | Value | Description |
|---|---|---|
| ProcessStdDev | 0.01 µs | Offset process noise |
| DriftProcessStdDev | 0.0 µs/s | Drift process noise |
| ForgetFactor | 1.001 | Adaptive forgetting |
| AdaptiveCutoff | 0.75 | Residual threshold |
| MinSamples | 100 | Samples before forgetting |
| DriftSignificanceThreshold | 2.0 | SNR for drift compensation |

## Test plan
- [x] All existing tests pass
- [x] New `TimeFilter` unit tests: convergence, drift tracking, adaptive forgetting, reset, concurrency
- [x] Updated `ClockSync` tests for Kalman-based behavior
- [x] CI passes
- [x] Test with Music Assistant server for real-world sync accuracy