### PR TITLE
feat(audio/output): float32 oto output for 24-bit precision (#3)

### DIFF
--- a/pkg/audio/output/oto.go
+++ b/pkg/audio/output/oto.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 
 	"github.com/Sendspin/sendspin-go/pkg/audio"
 	"github.com/ebitengine/oto/v3"
@@ -42,10 +43,9 @@ func NewOto() Output {
 
 // Open initializes the output device
 func (o *Oto) Open(sampleRate, channels, bitDepth int) error {
-	// oto only supports 16-bit output
-	if bitDepth != 16 {
-		log.Printf("Warning: oto only supports 16-bit output, ignoring requested bitDepth=%d", bitDepth)
-	}
+	// Output runs at float32, which carries 24-bit precision through oto to
+	// the OS mixer. The requested bitDepth is informational only.
+	_ = bitDepth
 
 	// If already initialized with same format, reuse the existing context
 	if o.otoCtx != nil && o.sampleRate == sampleRate && o.channels == channels {
@@ -64,7 +64,7 @@ func (o *Oto) Open(sampleRate, channels, bitDepth int) error {
 	op := &oto.NewContextOptions{
 		SampleRate:   sampleRate,
 		ChannelCount: channels,
-		Format:       oto.FormatSignedInt16LE,
+		Format:       oto.FormatFloat32LE,
 	}
 
 	ctx, readyChan, err := oto.NewContext(op)
@@ -101,16 +101,12 @@ func (o *Oto) Write(samples []int32) error {
 	// Apply volume to samples (int32 format)
 	volumedSamples := applyVolume(samples, o.volume, o.muted)
 
-	// Convert int32 samples to int16 for oto (oto uses 16-bit output)
-	samples16 := make([]int16, len(volumedSamples))
+	// Normalize int32 24-bit samples to float32 in [-1.0, 1.0) and pack as
+	// little-endian IEEE 754. float32 preserves full 24-bit precision.
+	output := make([]byte, len(volumedSamples)*4)
 	for i, s := range volumedSamples {
-		samples16[i] = audio.SampleToInt16(s)
-	}
-
-	// Convert int16 samples to bytes for audio output
-	output := make([]byte, len(samples16)*2)
-	for i, sample := range samples16 {
-		binary.LittleEndian.PutUint16(output[i*2:], uint16(sample))
+		bits := math.Float32bits(audio.SampleToFloat32(s))
+		binary.LittleEndian.PutUint32(output[i*4:], bits)
 	}
 
 	// Write to pipe (which feeds the persistent player)

--- a/pkg/audio/types.go
+++ b/pkg/audio/types.go
@@ -39,6 +39,15 @@ func SampleFromInt16(sample int16) int32 {
 	return int32(sample) << 8
 }
 
+// SampleToFloat32 converts a 24-bit int32 sample to a normalized float32
+// in the range [-1.0, 1.0). Used for float32 audio output paths that
+// preserve 24-bit precision (float32 has a 24-bit mantissa).
+func SampleToFloat32(sample int32) float32 {
+	// Divide by 2^23 so Max24Bit maps just under 1.0 and Min24Bit maps to -1.0.
+	const scale = 1.0 / float32(1<<23)
+	return float32(sample) * scale
+}
+
 // SampleTo24Bit converts int32 to 24-bit packed bytes (little-endian)
 func SampleTo24Bit(sample int32) [3]byte {
 	// Take lower 24 bits, pack little-endian

--- a/pkg/audio/types_test.go
+++ b/pkg/audio/types_test.go
@@ -50,6 +50,36 @@ func TestSampleToInt16(t *testing.T) {
 	}
 }
 
+func TestSampleToFloat32(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    int32
+		expected float32
+	}{
+		{"zero", 0, 0.0},
+		{"max 24-bit", Max24Bit, float32(Max24Bit) / float32(1<<23)},
+		{"min 24-bit", Min24Bit, -1.0},
+		{"half scale positive", 1 << 22, 0.5},
+		{"half scale negative", -(1 << 22), -0.5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SampleToFloat32(tt.input)
+			if result != tt.expected {
+				t.Errorf("expected %f, got %f", tt.expected, result)
+			}
+		})
+	}
+
+	for _, s := range []int32{Max24Bit, Min24Bit, 0, 1, -1, 1234567, -1234567} {
+		f := SampleToFloat32(s)
+		if f < -1.0 || f >= 1.0 {
+			t.Errorf("sample %d normalized to %f, outside [-1.0, 1.0)", s, f)
+		}
+	}
+}
+
 func TestSampleTo24Bit(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- Switches `pkg/audio/output/oto.go` from `FormatSignedInt16LE` to `FormatFloat32LE`.
- Adds `audio.SampleToFloat32` (int32 24-bit → normalized float32 in `[-1.0, 1.0)`) with unit tests.
- Removes the `bitDepth != 16` warning in `Open()` — argument is now informational.

## Why this over the options in #3
Issue #3 proposed (1) swap to cpal, (2) swap to PortAudio, or (3) document the 16-bit limitation. oto v3 actually supports `FormatFloat32LE` already (see `context.go:46` in `oto/v3@v3.4.0`), and float32 has a 24-bit mantissa — so samples in the normalized range carry the full 24-bit precision the rest of the pipeline preserves, without a library swap, new CGo dependency, or new audio backend code.


## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` — all packages pass (audio, audio/output, internal/server, everything)
- [x] New `TestSampleToFloat32` covers zero / max / min / half-scale / range-invariant
- [ ] **Manual playback verification required**: needs a hi-res source played through the player binary on at least one platform to confirm audible output is intact.