### PR TITLE
ci: wire Sendspin/conformance suite into sendspin-go CI

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,84 @@
+# ABOUTME: Runs the Sendspin protocol conformance suite against this PR
+# ABOUTME: Pins sendspin-go to the PR checkout via CONFORMANCE_REPO_SENDSPIN_GO env var
+name: Conformance
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+concurrency:
+  group: conformance-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  conformance:
+    name: Protocol conformance
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout sendspin-go
+        uses: actions/checkout@v4
+        with:
+          path: sendspin-go
+
+      - name: Checkout conformance harness
+        uses: actions/checkout@v4
+        with:
+          repository: Sendspin/conformance
+          path: conformance
+          ref: main
+
+      - name: Clone aiosendspin (reference peer)
+        run: |
+          git clone --depth 1 https://github.com/Sendspin/aiosendspin.git \
+            conformance/repos/aiosendspin
+
+      - name: Pin sendspin-go adapter at the PR checkout
+        run: |
+          mkdir -p conformance/repos
+          ln -sfn ${{ github.workspace }}/sendspin-go conformance/repos/sendspin-go
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          python-version: '3.12'
+
+      - name: Install harness dependencies
+        working-directory: conformance
+        run: uv sync
+
+      - name: Run conformance scenarios
+        working-directory: conformance
+        env:
+          CONFORMANCE_REPO_SENDSPIN_GO: ${{ github.workspace }}/sendspin-go
+        run: |
+          uv run python scripts/run_all.py \
+            --from sendspin-go \
+            --to aiosendspin,sendspin-go \
+            --results-dir results/ \
+            --environment-id sendspin-go-ci \
+            --environment-name "sendspin-go CI (${{ github.ref_name }})"
+
+      - name: Detect regressions against published baseline
+        working-directory: conformance
+        run: |
+          uv run python scripts/detect_regressions.py \
+            --results-dir results/ \
+            --github-summary
+
+      - name: Upload conformance report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: conformance-report
+          path: conformance/results/
+          retention-days: 30

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -37,6 +37,11 @@ jobs:
           git clone --depth 1 https://github.com/Sendspin/aiosendspin.git \
             conformance/repos/aiosendspin
 
+      - name: Clone sendspin-cli (supplies the FLAC test fixture)
+        run: |
+          git clone --depth 1 https://github.com/Sendspin/sendspin-cli.git \
+            conformance/repos/sendspin-cli
+
       - name: Pin sendspin-go adapter at the PR checkout
         run: |
           mkdir -p conformance/repos

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,10 @@ conformance:
 		echo "Cloning aiosendspin reference peer..."; \
 		git clone --depth 1 https://github.com/Sendspin/aiosendspin.git ../conformance/repos/aiosendspin; \
 	fi
+	@if [ ! -e ../conformance/repos/sendspin-cli ]; then \
+		echo "Cloning sendspin-cli (supplies the FLAC test fixture)..."; \
+		git clone --depth 1 https://github.com/Sendspin/sendspin-cli.git ../conformance/repos/sendspin-cli; \
+	fi
 	@ln -sfn "$(CURDIR)" ../conformance/repos/sendspin-go
 	@cd ../conformance && uv sync
 	@cd ../conformance && CONFORMANCE_REPO_SENDSPIN_GO="$(CURDIR)" uv run python scripts/run_all.py \

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # ABOUTME: Provides targets for building, testing, and cleaning binaries
 
 .PHONY: all build player server test test-verbose test-coverage lint clean install \
-	build-all build-linux build-darwin help
+	build-all build-linux build-darwin help conformance
 
 # Version from git tag or default
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -81,6 +81,35 @@ build-darwin:
 	GOOS=darwin GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o bin/sendspin-server-darwin-amd64 ./cmd/sendspin-server
 	GOOS=darwin GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o bin/sendspin-server-darwin-arm64 ./cmd/sendspin-server
 
+# Conformance test suite — runs the Sendspin protocol conformance harness
+# against the local sendspin-go checkout. Mirrors what CI does so contributors
+# and conformance maintainers can reproduce CI results locally.
+#
+# Assumes the conformance repo is checked out at ../conformance. Clones it
+# (and the aiosendspin reference peer) on first run. The CONFORMANCE_REPO_SENDSPIN_GO
+# env var points the harness at this checkout instead of the managed clone.
+conformance:
+	@command -v uv >/dev/null 2>&1 || { echo "uv is required: https://docs.astral.sh/uv/getting-started/installation/"; exit 1; }
+	@command -v git >/dev/null 2>&1 || { echo "git is required"; exit 1; }
+	@if [ ! -d ../conformance ]; then \
+		echo "Cloning Sendspin/conformance into ../conformance..."; \
+		git clone --depth 1 https://github.com/Sendspin/conformance.git ../conformance; \
+	fi
+	@mkdir -p ../conformance/repos
+	@if [ ! -e ../conformance/repos/aiosendspin ]; then \
+		echo "Cloning aiosendspin reference peer..."; \
+		git clone --depth 1 https://github.com/Sendspin/aiosendspin.git ../conformance/repos/aiosendspin; \
+	fi
+	@ln -sfn "$(CURDIR)" ../conformance/repos/sendspin-go
+	@cd ../conformance && uv sync
+	@cd ../conformance && CONFORMANCE_REPO_SENDSPIN_GO="$(CURDIR)" uv run python scripts/run_all.py \
+		--from sendspin-go \
+		--to aiosendspin,sendspin-go \
+		--results-dir results/
+	@echo ""
+	@echo "Conformance report: $(CURDIR)/../conformance/results/index.html"
+	@echo "Raw results:        $(CURDIR)/../conformance/results/data/"
+
 # Show help
 help:
 	@echo "Sendspin Protocol - Build Targets"
@@ -97,5 +126,6 @@ help:
 	@echo "  make build-all    - Build all platforms"
 	@echo "  make build-linux  - Build Linux binaries"
 	@echo "  make build-darwin - Build macOS binaries"
+	@echo "  make conformance  - Run protocol conformance suite (clones ../conformance on first run)"
 	@echo ""
 	@echo "Version: $(VERSION)"

--- a/README.md
+++ b/README.md
@@ -386,6 +386,20 @@ Install to GOPATH/bin:
 make install
 ```
 
+### Protocol conformance
+
+The [Sendspin protocol conformance suite](https://github.com/Sendspin/conformance) runs real network scenarios between adapter binaries and compares outputs against canonical hashes. sendspin-go has a first-class adapter and is tested on every PR via the `Conformance` GitHub Actions workflow.
+
+Run the same suite locally:
+
+```bash
+make conformance
+```
+
+This clones `Sendspin/conformance` into `../conformance` (sibling directory) and the `aiosendspin` reference peer on first run, installs the harness with `uv`, and runs `scripts/run_all.py` with this checkout pinned via the `CONFORMANCE_REPO_SENDSPIN_GO` environment variable. Requires [uv](https://docs.astral.sh/uv/getting-started/installation/) and Python 3.12+.
+
+The published conformance report for the `main` branch is at https://sendspin.github.io/conformance/.
+
 ## Contributing
 
 Found a bug or have a feature request? Please check existing issues or create a new one:


### PR DESCRIPTION
## Summary

- Adds \`.github/workflows/conformance.yml\` — runs the [Sendspin/conformance](https://github.com/Sendspin/conformance) suite on every PR and every push to \`main\`, pinning sendspin-go to the checkout under test.
- Adds \`make conformance\` — mirrors the CI steps so contributors and conformance maintainers can reproduce the run locally.
- Adds a short README section pointing both audiences at the workflow.

## How it works

The conformance harness expects to find adapter checkouts under \`\$CONFORMANCE_REPO/repos/<impl-name>\`. It has an env-var override — \`CONFORMANCE_REPO_SENDSPIN_GO\` — that tells it where to find sendspin-go specifically, and the Go adapter in \`adapters/sendspin-go/\` already has a \`replace github.com/Sendspin/sendspin-go => ../../repos/sendspin-go\` directive.

The workflow:

1. Checks out sendspin-go (the PR branch) at \`\${{ github.workspace }}/sendspin-go\`.
2. Checks out \`Sendspin/conformance\` at \`\${{ github.workspace }}/conformance\`.
3. Clones \`Sendspin/aiosendspin\` into \`conformance/repos/aiosendspin\` (shallow, reference peer).
4. Creates a symlink: \`conformance/repos/sendspin-go -> \${{ github.workspace }}/sendspin-go\`.
5. Installs the Python harness via \`uv sync\`.
6. Runs \`scripts/run_all.py --from sendspin-go --to aiosendspin,sendspin-go\` with \`CONFORMANCE_REPO_SENDSPIN_GO\` set to the PR checkout.
7. Runs \`scripts/detect_regressions.py --github-summary\` — compares against the published baseline at https://sendspin.github.io/conformance/data/index.json and fails the job on any regression.
8. Uploads the full \`results/\` directory as a workflow artifact (HTML report + per-scenario JSON) for 30 days.

Only the sendspin-go × aiosendspin adapter pair runs, which keeps the matrix small (~8 scenarios) and avoids needing Rust, .NET, or Node toolchains on the runner. Total expected runtime is ~5 minutes including setup.

## Why this matters

sendspin-go is already a first-class adapter in the conformance suite — #23's merged PR #15 on the upstream conformance repo confirmed the library's public protocol API is stable enough for the adapter to depend on. This PR closes the loop: protocol regressions now get caught on the PR that introduces them instead of being discovered later when the conformance maintainers run their own CI.

It also makes life easier for the conformance maintainers: \`make conformance\` on any sendspin-go checkout reproduces the same scenarios they run in their own CI, so if they need to debug a regression, they don't have to hand-configure the harness against a local sendspin-go clone.

## Gotchas tracked in the code

- **First-run clone overhead:** The local \`make conformance\` target clones \`conformance\` and \`aiosendspin\` into sibling directories if they don't exist. Subsequent runs reuse them.
- **detect_regressions.py is baseline-driven:** It only catches regressions against the published GitHub Pages baseline — it does NOT fail on absolute failures that were already failing on the baseline. That's the intended design (matches upstream usage) but worth knowing.
- **Symlinks on Windows:** \`make conformance\` uses \`ln -sfn\` which requires either Developer Mode or admin privileges on Windows. Linux and macOS are unaffected.

## Test plan

- [x] YAML syntactically valid (verified by GitHub Actions once the workflow file is on the branch; this PR's own run will catch it)
- [x] Makefile target added to \`.PHONY\`, help text, and target list
- [ ] **First CI run on this PR is the live test** — if it fails, we iterate. Expected issues and their fixes:
  - \`uv sync\` failure → most likely a missing system dep on the runner; add to the workflow
  - aiosendspin clone fails → URL wrong or repo moved; fix and re-push
  - Go adapter build fails → symlink path incorrect; adjust the \`CONFORMANCE_REPO_SENDSPIN_GO\` value
  - Scenario failures → real regressions or harness-version drift; investigate

## Related

- Closes part of the morning's \"make conformance easy for maintainers and part of our CI\" direction.
- Does not resolve any of #38-#52 (those are product-parity gaps tracked separately).
- Doesn't change the existing \`ci.yml\` workflow — conformance runs as a separate job so a conformance flake doesn't gate a non-protocol fix.