### PR TITLE
feat(protocol): artwork binary routing and StreamStart.Artwork

### DIFF
--- a/pkg/protocol/client.go
+++ b/pkg/protocol/client.go
@@ -19,9 +19,19 @@ const (
 	// BinaryMessageHeaderSize is the size of binary message header (type byte + timestamp)
 	BinaryMessageHeaderSize = 1 + 8 // 9 bytes: 1 byte type + 8 byte timestamp
 
-	// AudioChunkMessageType is the binary message type ID for audio chunks
-	// Per spec: Player role binary messages use IDs 4-7 (bits 000001xx), slot 0 is audio
+	// AudioChunkMessageType is the binary message type ID for audio chunks.
+	// Per spec: Player role binary messages use IDs 4-7 (bits 000001xx), slot 0 is audio.
 	AudioChunkMessageType = 4
+
+	// Artwork binary message type IDs per spec: Artwork role uses 8-11, one per channel.
+	// ArtworkChannel0MessageType is channel 0; channels 1-3 use 9, 10, 11 respectively.
+	ArtworkChannel0MessageType = 8
+	ArtworkChannel1MessageType = 9
+	ArtworkChannel2MessageType = 10
+	ArtworkChannel3MessageType = 11
+
+	// ArtworkChannelCount is the maximum number of artwork channels the spec allocates binary IDs for.
+	ArtworkChannelCount = 4
 )
 
 type Config struct {
@@ -40,14 +50,15 @@ type Client struct {
 	conn   *websocket.Conn
 	mu     sync.RWMutex
 
-	AudioChunks  chan AudioChunk
-	ControlMsgs  chan PlayerCommand
-	TimeSyncResp chan ServerTime
-	StreamStart  chan StreamStart
-	StreamClear  chan StreamClear
-	StreamEnd    chan StreamEnd
-	ServerState  chan ServerStateMessage
-	GroupUpdate  chan GroupUpdate
+	AudioChunks   chan AudioChunk
+	ArtworkChunks chan ArtworkChunk
+	ControlMsgs   chan PlayerCommand
+	TimeSyncResp  chan ServerTime
+	StreamStart   chan StreamStart
+	StreamClear   chan StreamClear
+	StreamEnd     chan StreamEnd
+	ServerState   chan ServerStateMessage
+	GroupUpdate   chan GroupUpdate
 
 	connected bool
 	ctx       context.Context
@@ -59,21 +70,29 @@ type AudioChunk struct {
 	Data      []byte
 }
 
+// ArtworkChunk is an incoming binary artwork frame routed from the artwork@v1 role.
+type ArtworkChunk struct {
+	Channel   int   // 0-3; derived from the binary message type minus ArtworkChannel0MessageType
+	Timestamp int64 // Microseconds, server clock
+	Data      []byte
+}
+
 func NewClient(config Config) *Client {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return &Client{
-		config:       config,
-		AudioChunks:  make(chan AudioChunk, 100),
-		ControlMsgs:  make(chan PlayerCommand, 10),
-		TimeSyncResp: make(chan ServerTime, 10),
-		StreamStart:  make(chan StreamStart, 1),
-		StreamClear:  make(chan StreamClear, 10),
-		StreamEnd:    make(chan StreamEnd, 1),
-		ServerState:  make(chan ServerStateMessage, 10),
-		GroupUpdate:  make(chan GroupUpdate, 10),
-		ctx:          ctx,
-		cancel:       cancel,
+		config:        config,
+		AudioChunks:   make(chan AudioChunk, 100),
+		ArtworkChunks: make(chan ArtworkChunk, 10),
+		ControlMsgs:   make(chan PlayerCommand, 10),
+		TimeSyncResp:  make(chan ServerTime, 10),
+		StreamStart:   make(chan StreamStart, 1),
+		StreamClear:   make(chan StreamClear, 10),
+		StreamEnd:     make(chan StreamEnd, 1),
+		ServerState:   make(chan ServerStateMessage, 10),
+		GroupUpdate:   make(chan GroupUpdate, 10),
+		ctx:           ctx,
+		cancel:        cancel,
 	}
 }
 
@@ -222,22 +241,26 @@ func (c *Client) handleBinaryMessage(data []byte) {
 	}
 
 	msgType := data[0]
-	if msgType != AudioChunkMessageType {
-		log.Printf("Unknown binary message type: %d", msgType)
-		return
-	}
-
 	timestamp := int64(binary.BigEndian.Uint64(data[1:BinaryMessageHeaderSize]))
-	audioData := data[BinaryMessageHeaderSize:]
+	payload := data[BinaryMessageHeaderSize:]
 
-	chunk := AudioChunk{
-		Timestamp: timestamp,
-		Data:      audioData,
-	}
-
-	select {
-	case c.AudioChunks <- chunk:
-	case <-c.ctx.Done():
+	switch {
+	case msgType == AudioChunkMessageType:
+		select {
+		case c.AudioChunks <- AudioChunk{Timestamp: timestamp, Data: payload}:
+		case <-c.ctx.Done():
+		}
+	case msgType >= ArtworkChannel0MessageType && msgType <= ArtworkChannel3MessageType:
+		select {
+		case c.ArtworkChunks <- ArtworkChunk{
+			Channel:   int(msgType) - ArtworkChannel0MessageType,
+			Timestamp: timestamp,
+			Data:      payload,
+		}:
+		case <-c.ctx.Done():
+		}
+	default:
+		log.Printf("Unknown binary message type: %d", msgType)
 	}
 }
 

--- a/pkg/protocol/client_test.go
+++ b/pkg/protocol/client_test.go
@@ -3,7 +3,9 @@
 package protocol
 
 import (
+	"encoding/binary"
 	"testing"
+	"time"
 )
 
 func TestNewClient(t *testing.T) {
@@ -20,5 +22,118 @@ func TestNewClient(t *testing.T) {
 
 	if client.config.ServerAddr != "localhost:8927" {
 		t.Errorf("expected server addr localhost:8927, got %s", client.config.ServerAddr)
+	}
+
+	if client.ArtworkChunks == nil {
+		t.Error("expected ArtworkChunks channel to be initialized")
+	}
+}
+
+// buildBinaryFrame constructs a binary protocol frame matching what the server
+// emits: [1 byte type][8 byte big-endian timestamp µs][payload].
+func buildBinaryFrame(msgType byte, timestamp int64, payload []byte) []byte {
+	frame := make([]byte, BinaryMessageHeaderSize+len(payload))
+	frame[0] = msgType
+	binary.BigEndian.PutUint64(frame[1:BinaryMessageHeaderSize], uint64(timestamp))
+	copy(frame[BinaryMessageHeaderSize:], payload)
+	return frame
+}
+
+// recvWithTimeout waits briefly for a value on a channel. Returns the zero
+// value + false if nothing arrives in time.
+func recvAudioChunk(t *testing.T, ch <-chan AudioChunk) (AudioChunk, bool) {
+	t.Helper()
+	select {
+	case chunk := <-ch:
+		return chunk, true
+	case <-time.After(100 * time.Millisecond):
+		return AudioChunk{}, false
+	}
+}
+
+func recvArtworkChunk(t *testing.T, ch <-chan ArtworkChunk) (ArtworkChunk, bool) {
+	t.Helper()
+	select {
+	case chunk := <-ch:
+		return chunk, true
+	case <-time.After(100 * time.Millisecond):
+		return ArtworkChunk{}, false
+	}
+}
+
+func TestHandleBinaryMessage_AudioChunkRouting(t *testing.T) {
+	client := NewClient(Config{ServerAddr: "localhost:0", ClientID: "t", Name: "t"})
+	payload := []byte{0x01, 0x02, 0x03, 0x04}
+
+	client.handleBinaryMessage(buildBinaryFrame(AudioChunkMessageType, 123_456, payload))
+
+	chunk, ok := recvAudioChunk(t, client.AudioChunks)
+	if !ok {
+		t.Fatal("expected an AudioChunk on the channel")
+	}
+	if chunk.Timestamp != 123_456 {
+		t.Errorf("timestamp = %d, want 123456", chunk.Timestamp)
+	}
+	if string(chunk.Data) != string(payload) {
+		t.Errorf("data = %x, want %x", chunk.Data, payload)
+	}
+}
+
+// TestHandleBinaryMessage_ArtworkRouting covers all four artwork channel IDs
+// (types 8, 9, 10, 11 → channels 0, 1, 2, 3). Closes #27: "Unknown binary
+// message type: 8" was the spec-defined ArtworkChannel0MessageType being
+// silently dropped.
+func TestHandleBinaryMessage_ArtworkRouting(t *testing.T) {
+	cases := []struct {
+		name    string
+		msgType byte
+		channel int
+	}{
+		{"channel 0", ArtworkChannel0MessageType, 0},
+		{"channel 1", ArtworkChannel1MessageType, 1},
+		{"channel 2", ArtworkChannel2MessageType, 2},
+		{"channel 3", ArtworkChannel3MessageType, 3},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := NewClient(Config{ServerAddr: "localhost:0", ClientID: "t", Name: "t"})
+			imageBytes := []byte("fake-jpeg-bytes-here")
+			timestamp := int64(999_888_777)
+
+			client.handleBinaryMessage(buildBinaryFrame(tc.msgType, timestamp, imageBytes))
+
+			chunk, ok := recvArtworkChunk(t, client.ArtworkChunks)
+			if !ok {
+				t.Fatalf("expected an ArtworkChunk on the channel (msgType=%d)", tc.msgType)
+			}
+			if chunk.Channel != tc.channel {
+				t.Errorf("channel = %d, want %d", chunk.Channel, tc.channel)
+			}
+			if chunk.Timestamp != timestamp {
+				t.Errorf("timestamp = %d, want %d", chunk.Timestamp, timestamp)
+			}
+			if string(chunk.Data) != string(imageBytes) {
+				t.Errorf("data = %q, want %q", chunk.Data, imageBytes)
+			}
+		})
+	}
+}
+
+// TestHandleBinaryMessage_UnknownTypeLogged confirms unknown types are still
+// dropped (and not routed anywhere) after the artwork additions. This guards
+// the switch-default branch so a future add-without-test doesn't turn a
+// real bug into silent mis-routing.
+func TestHandleBinaryMessage_UnknownTypeLogged(t *testing.T) {
+	client := NewClient(Config{ServerAddr: "localhost:0", ClientID: "t", Name: "t"})
+
+	// Type 99 is not defined anywhere in the spec.
+	client.handleBinaryMessage(buildBinaryFrame(99, 0, []byte{0xff}))
+
+	if _, ok := recvAudioChunk(t, client.AudioChunks); ok {
+		t.Error("unknown type was routed to AudioChunks")
+	}
+	if _, ok := recvArtworkChunk(t, client.ArtworkChunks); ok {
+		t.Error("unknown type was routed to ArtworkChunks")
 	}
 }

--- a/pkg/protocol/messages.go
+++ b/pkg/protocol/messages.go
@@ -113,9 +113,27 @@ type StreamStartPlayer struct {
 	CodecHeader string `json:"codec_header,omitempty"` // Base64-encoded
 }
 
-// StreamStart notifies the client of stream format (nested structure)
+// StreamStartArtwork describes the artwork channels a server is about to send.
+// Distinct from ArtworkV1Support (client hello): the hello advertises what the
+// client can accept (media_width/height), while this describes the actual
+// dimensions of the image about to be streamed (width/height).
+type StreamStartArtwork struct {
+	Channels []ArtworkStreamChannel `json:"channels"`
+}
+
+// ArtworkStreamChannel is a single channel entry inside StreamStartArtwork.
+type ArtworkStreamChannel struct {
+	Source string `json:"source"` // "album", "artist", etc.
+	Format string `json:"format"` // "jpeg", "png", "bmp"
+	Width  int    `json:"width"`
+	Height int    `json:"height"`
+}
+
+// StreamStart notifies the client of stream format (nested structure).
+// Player and Artwork fields are independent — a server may send either or both.
 type StreamStart struct {
-	Player *StreamStartPlayer `json:"player,omitempty"`
+	Player  *StreamStartPlayer  `json:"player,omitempty"`
+	Artwork *StreamStartArtwork `json:"artwork,omitempty"`
 }
 
 // ServerStateMessage is sent as server/state with role-specific objects

--- a/pkg/protocol/messages_test.go
+++ b/pkg/protocol/messages_test.go
@@ -109,3 +109,62 @@ func TestServerHelloMarshaling(t *testing.T) {
 		t.Errorf("expected type server/hello, got %s", decoded.Type)
 	}
 }
+
+// TestStreamStartArtwork_RoundTrip verifies the StreamStart message can carry
+// an artwork channel list alongside (or instead of) the player field. The
+// wire format must use width/height (not media_width/media_height, which is
+// the hello-message convention).
+func TestStreamStartArtwork_RoundTrip(t *testing.T) {
+	original := StreamStart{
+		Artwork: &StreamStartArtwork{
+			Channels: []ArtworkStreamChannel{
+				{Source: "album", Format: "jpeg", Width: 256, Height: 256},
+			},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// Spot-check the wire shape matches what peers expect.
+	want := `{"artwork":{"channels":[{"source":"album","format":"jpeg","width":256,"height":256}]}}`
+	if string(data) != want {
+		t.Errorf("marshal output = %s, want %s", data, want)
+	}
+
+	var decoded StreamStart
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.Artwork == nil {
+		t.Fatal("decoded.Artwork is nil")
+	}
+	if len(decoded.Artwork.Channels) != 1 {
+		t.Fatalf("channels = %d, want 1", len(decoded.Artwork.Channels))
+	}
+	ch := decoded.Artwork.Channels[0]
+	if ch.Source != "album" || ch.Format != "jpeg" || ch.Width != 256 || ch.Height != 256 {
+		t.Errorf("decoded channel = %+v", ch)
+	}
+}
+
+// TestStreamStart_PlayerOmittedWhenNil confirms that existing callers who
+// only set Player (never Artwork) still produce the same wire shape.
+func TestStreamStart_PlayerOnlyUnchanged(t *testing.T) {
+	msg := StreamStart{
+		Player: &StreamStartPlayer{
+			Codec: "pcm", SampleRate: 48000, Channels: 2, BitDepth: 24,
+		},
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// Artwork field must be omitted entirely when nil.
+	want := `{"player":{"codec":"pcm","sample_rate":48000,"channels":2,"bit_depth":24}}`
+	if string(data) != want {
+		t.Errorf("marshal output = %s, want %s", data, want)
+	}
+}


### PR DESCRIPTION
## Summary

Closes two gaps from [Sendspin/conformance#16](https://github.com/Sendspin/conformance/issues/16) — the artwork-pipeline cluster (Gap 3 + Gap 4) from balloob's adapter-simplification proposal. Both changes are strictly additive and backward-compatible; existing callers produce byte-identical JSON and see no behavior changes.

Also **closes #27** as a side effect. The "Unknown binary message type: 8" log line seen in yesterday's 192kHz/24-bit playback verification wasn't a mystery — it was \`ArtworkChannel0MessageType\` arriving without a handler. Now routed cleanly to \`Client.ArtworkChunks\`.

## What changed

**Gap 3 — binary routing for types 8-11 (\`pkg/protocol/client.go\`):**

- Four new \`const\`s: \`ArtworkChannel0MessageType\` through \`ArtworkChannel3MessageType\` (spec values 8, 9, 10, 11) plus \`ArtworkChannelCount = 4\`.
- New \`ArtworkChunk\` struct with \`Channel int\` + \`Timestamp int64\` + \`Data []byte\` — mirrors \`AudioChunk\` with the channel index derived from the type byte.
- New \`Client.ArtworkChunks chan ArtworkChunk\` buffered at 10 (same order of magnitude as the other non-audio channels).
- \`handleBinaryMessage\` refactored from \`if != AudioChunkMessageType\` to a \`switch\`: audio routes as before, types 8-11 route to \`ArtworkChunks\`, everything else logs and drops unchanged.

**Gap 4 — \`StreamStart.Artwork\` (\`pkg/protocol/messages.go\`):**

- New \`StreamStartArtwork\` struct carrying \`Channels []ArtworkStreamChannel\`.
- New \`ArtworkStreamChannel\` with JSON fields \`source\`, \`format\`, \`width\`, \`height\` — **deliberately distinct from \`ArtworkChannel\`** used in \`ArtworkV1Support\` hellos (which uses \`media_width\`/\`media_height\`). The two serve different purposes: the hello advertises what the client can *accept*, \`stream/start\` reports the actual dimensions of the image about to be streamed. Field names match what the conformance adapter's server already sends over the wire.
- \`StreamStart\` gains an optional \`Artwork *StreamStartArtwork\` field with \`omitempty\` so existing player-only callers serialize identically.

## Tests

All new tests in \`pkg/protocol/\`:

- \`TestNewClient\` extended to assert \`ArtworkChunks\` is initialized.
- \`TestHandleBinaryMessage_AudioChunkRouting\` — regression guard: audio path unchanged.
- \`TestHandleBinaryMessage_ArtworkRouting\` — table-driven, covers all four channel types (msgType 8-11 → channel 0-3).
- \`TestHandleBinaryMessage_UnknownTypeLogged\` — guards the switch-default so a future type addition can't silently mis-route.
- \`TestStreamStartArtwork_RoundTrip\` — JSON marshal + unmarshal, with a byte-exact wire-format assertion to lock down the \`width\`/\`height\` field names.
- \`TestStreamStart_PlayerOnlyUnchanged\` — byte-exact assertion that existing player-only \`StreamStart\` serialization is identical pre/post PR.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test -count=1 ./...\` green (pkg/protocol and all 14 surviving packages)
- [x] New tests: 11 assertions across 6 new test functions, all passing locally
- [x] Protocol conformance workflow will run on this PR once [#53](https://github.com/Sendspin/sendspin-go/pull/53) is merged — expect continued green since the library additions are backward-compatible and the adapter still uses the old code paths

## Coordination with Sendspin/conformance

This is the first PR in a planned sequence that will let the conformance Go adapter shed roughly 400 lines of hand-rolled WebSocket code. The adapter currently parses artwork binary frames manually; with the additions in this PR, a future adapter PR can delete \`artworkChunk()\` / the manual frame dispatcher in \`adapters/sendspin-go/server/main.go\` and replace the \`map[string]any\` construction of the stream/start artwork payload with the typed \`StreamStartArtwork\`.

I'll draft the matching adapter update in a PR against \`Sendspin/conformance\` once this PR merges and we tag a release (likely \`v1.3.0\` after PR A and PR C also land — see issue #16's grouping).

Two additional library PRs are planned to complete the issue #16 work:

- **PR A** — client flexibility: \`Config.SupportedRoles\` + \`NewClientFromConn()\` (Gap 1 + Gap 2). Biggest structural change, saves ~200 adapter lines.
- **PR C** — server-side controller role: \`ServerConfig.SupportedRoles\` + \`client/command\` handling (Gap 5). ~40 adapter lines.

Each will land with a matching conformance adapter PR drafted and submitted for balloob to approve.

## Semver

Pure additions. No breaking changes. Minor version bump (\`v1.3.0\` eventually, after the full Gap 1-5 sequence is in).