### PR TITLE
feat(protocol): Config.SupportedRoles override + NewClientFromConn

### DIFF
--- a/pkg/protocol/client.go
+++ b/pkg/protocol/client.go
@@ -43,6 +43,16 @@ type Config struct {
 	PlayerV1Support     PlayerV1Support
 	ArtworkV1Support    *ArtworkV1Support
 	VisualizerV1Support *VisualizerV1Support
+
+	// SupportedRoles overrides the auto-built role list in the client/hello
+	// message. When nil or empty, handshake() builds the list from the V1
+	// support fields above (player@v1 + metadata@v1 always, plus artwork@v1
+	// and visualizer@v1 when their support structs are set). Set this to
+	// advertise a specific subset — e.g. []string{"metadata@v1"} for a
+	// metadata-only client, or []string{"controller@v1"} for controller
+	// scenarios where advertising player@v1 would incorrectly activate
+	// the audio stream.
+	SupportedRoles []string
 }
 
 type Client struct {
@@ -78,6 +88,26 @@ type ArtworkChunk struct {
 }
 
 func NewClient(config Config) *Client {
+	return newClient(config)
+}
+
+// NewClientFromConn wraps an already-established websocket connection. Use
+// this for server-initiated scenarios: the caller has accepted an incoming
+// connection on a listening socket and now needs the library to run the
+// client-side protocol (handshake, message loop, channel routing) over it.
+//
+// Unlike NewClient+Connect, the returned client is NOT yet running — call
+// Start to perform the handshake and launch the read loop.
+//
+// The caller transfers ownership of conn to the client; Close will close it.
+func NewClientFromConn(config Config, conn *websocket.Conn) *Client {
+	c := newClient(config)
+	c.conn = conn
+	c.connected = true
+	return c
+}
+
+func newClient(config Config) *Client {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return &Client{
@@ -96,7 +126,9 @@ func NewClient(config Config) *Client {
 	}
 }
 
-// Connect establishes WebSocket connection and performs handshake
+// Connect dials the configured server, runs the handshake, and starts the
+// message read loop. Use NewClientFromConn + Start when you already have
+// an accepted connection (server-initiated scenarios).
 func (c *Client) Connect() error {
 	u := url.URL{Scheme: "ws", Host: c.config.ServerAddr, Path: "/sendspin"}
 	log.Printf("Connecting to %s", u.String())
@@ -111,6 +143,20 @@ func (c *Client) Connect() error {
 	c.connected = true
 	c.mu.Unlock()
 
+	return c.Start()
+}
+
+// Start runs the client/hello handshake and launches the background read
+// loop. The connection must already be set via NewClientFromConn or Connect.
+// Calling Start more than once on the same client is undefined.
+func (c *Client) Start() error {
+	c.mu.RLock()
+	conn := c.conn
+	c.mu.RUnlock()
+	if conn == nil {
+		return fmt.Errorf("no connection: use NewClientFromConn or Connect before Start")
+	}
+
 	conn.SetReadLimit(1 << 20) // 1MB
 
 	if err := c.handshake(); err != nil {
@@ -124,14 +170,7 @@ func (c *Client) Connect() error {
 }
 
 func (c *Client) handshake() error {
-	// Build versioned role list per spec
-	roles := []string{"player@v1", "metadata@v1"}
-	if c.config.ArtworkV1Support != nil {
-		roles = append(roles, "artwork@v1")
-	}
-	if c.config.VisualizerV1Support != nil {
-		roles = append(roles, "visualizer@v1")
-	}
+	roles := c.buildSupportedRoles()
 
 	hello := ClientHello{
 		ClientID:            c.config.ClientID,
@@ -195,6 +234,27 @@ func (c *Client) handshake() error {
 	}
 
 	return nil
+}
+
+// buildSupportedRoles returns the role list for the client/hello message.
+// An explicit Config.SupportedRoles wins when set, since the caller is
+// telling us exactly which roles to advertise (metadata-only, controller,
+// etc.). Otherwise we build the default list from the V1 support fields:
+// player@v1 and metadata@v1 are always advertised for backwards
+// compatibility, and artwork@v1 / visualizer@v1 join the list when their
+// support structs are set.
+func (c *Client) buildSupportedRoles() []string {
+	if len(c.config.SupportedRoles) > 0 {
+		return c.config.SupportedRoles
+	}
+	roles := []string{"player@v1", "metadata@v1"}
+	if c.config.ArtworkV1Support != nil {
+		roles = append(roles, "artwork@v1")
+	}
+	if c.config.VisualizerV1Support != nil {
+		roles = append(roles, "visualizer@v1")
+	}
+	return roles
 }
 
 func (c *Client) sendJSON(msg Message) error {

--- a/pkg/protocol/client_test.go
+++ b/pkg/protocol/client_test.go
@@ -4,8 +4,15 @@ package protocol
 
 import (
 	"encoding/binary"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/gorilla/websocket"
 )
 
 func TestNewClient(t *testing.T) {
@@ -135,5 +142,208 @@ func TestHandleBinaryMessage_UnknownTypeLogged(t *testing.T) {
 	}
 	if _, ok := recvArtworkChunk(t, client.ArtworkChunks); ok {
 		t.Error("unknown type was routed to ArtworkChunks")
+	}
+}
+
+// TestBuildSupportedRoles_Default covers the old auto-built path. Keep this
+// test lean; a table test for every permutation of the four V1 support
+// fields is over-investment for what's essentially a handful of if
+// statements.
+func TestBuildSupportedRoles_Default(t *testing.T) {
+	cases := []struct {
+		name   string
+		config Config
+		want   []string
+	}{
+		{
+			name:   "bare default is player+metadata",
+			config: Config{},
+			want:   []string{"player@v1", "metadata@v1"},
+		},
+		{
+			name:   "artwork support adds artwork@v1",
+			config: Config{ArtworkV1Support: &ArtworkV1Support{}},
+			want:   []string{"player@v1", "metadata@v1", "artwork@v1"},
+		},
+		{
+			name:   "visualizer support adds visualizer@v1",
+			config: Config{VisualizerV1Support: &VisualizerV1Support{}},
+			want:   []string{"player@v1", "metadata@v1", "visualizer@v1"},
+		},
+		{
+			name: "both support structs set",
+			config: Config{
+				ArtworkV1Support:    &ArtworkV1Support{},
+				VisualizerV1Support: &VisualizerV1Support{},
+			},
+			want: []string{"player@v1", "metadata@v1", "artwork@v1", "visualizer@v1"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := NewClient(tc.config)
+			got := client.buildSupportedRoles()
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("buildSupportedRoles() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildSupportedRoles_ExplicitOverride verifies that Config.SupportedRoles
+// wins over the V1 support struct auto-build. This is the load-bearing
+// behavior for conformance metadata-only and controller scenarios that
+// need to NOT advertise player@v1.
+func TestBuildSupportedRoles_ExplicitOverride(t *testing.T) {
+	cases := []struct {
+		name   string
+		config Config
+		want   []string
+	}{
+		{
+			name:   "controller only",
+			config: Config{SupportedRoles: []string{"controller@v1"}},
+			want:   []string{"controller@v1"},
+		},
+		{
+			name:   "metadata only",
+			config: Config{SupportedRoles: []string{"metadata@v1"}},
+			want:   []string{"metadata@v1"},
+		},
+		{
+			// Confirms that setting ArtworkV1Support alongside an override
+			// does NOT inject artwork@v1 — the caller's override is canon.
+			name: "override wins over artwork support struct",
+			config: Config{
+				SupportedRoles:   []string{"player@v1"},
+				ArtworkV1Support: &ArtworkV1Support{},
+			},
+			want: []string{"player@v1"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := NewClient(tc.config)
+			got := client.buildSupportedRoles()
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("buildSupportedRoles() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNewClientFromConn_HandshakeAndClose spins up a local WebSocket server
+// that plays the Sendspin handshake dance (read client/hello, send
+// server/hello, read client/state, close). The test then uses
+// NewClientFromConn + Start to drive the client side over an accepted
+// connection, proving that server-initiated scenarios can use the library
+// without hand-rolling the message loop.
+func TestNewClientFromConn_HandshakeAndClose(t *testing.T) {
+	// Capture the roles the client advertises so we can assert the override
+	// plumbed through to the wire.
+	capturedHello := make(chan ClientHello, 1)
+
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(*http.Request) bool { return true },
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+
+		// Read client/hello.
+		_, helloBytes, err := conn.ReadMessage()
+		if err != nil {
+			t.Errorf("read client/hello: %v", err)
+			return
+		}
+		var envelope Message
+		if err := json.Unmarshal(helloBytes, &envelope); err != nil {
+			t.Errorf("unmarshal client/hello: %v", err)
+			return
+		}
+		payloadBytes, _ := json.Marshal(envelope.Payload)
+		var hello ClientHello
+		_ = json.Unmarshal(payloadBytes, &hello)
+		capturedHello <- hello
+
+		// Send server/hello.
+		serverHello := Message{
+			Type: "server/hello",
+			Payload: ServerHello{
+				ServerID:    "test-server",
+				Name:        "Test Server",
+				Version:     1,
+				ActiveRoles: hello.SupportedRoles,
+			},
+		}
+		if err := conn.WriteJSON(serverHello); err != nil {
+			t.Errorf("write server/hello: %v", err)
+			return
+		}
+
+		// Read client/state (the library sends this immediately after
+		// a successful handshake — see handshake() in client.go).
+		if _, _, err := conn.ReadMessage(); err != nil {
+			t.Errorf("read client/state: %v", err)
+			return
+		}
+
+		// Hold the connection open briefly so the client's read loop has
+		// something to read, then close.
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	defer server.Close()
+
+	// Dial it ourselves to simulate a server-initiated scenario where the
+	// caller has an accepted *websocket.Conn and hands it to the library.
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	client := NewClientFromConn(Config{
+		ClientID:       "test-from-conn",
+		Name:           "FromConn Test",
+		Version:        1,
+		SupportedRoles: []string{"controller@v1"},
+	}, conn)
+	defer client.Close()
+
+	if err := client.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	select {
+	case hello := <-capturedHello:
+		if !reflect.DeepEqual(hello.SupportedRoles, []string{"controller@v1"}) {
+			t.Errorf("server saw SupportedRoles = %v, want [controller@v1]", hello.SupportedRoles)
+		}
+		if hello.ClientID != "test-from-conn" {
+			t.Errorf("server saw ClientID = %q, want test-from-conn", hello.ClientID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server never captured a client/hello")
+	}
+}
+
+// TestStart_NoConnection confirms Start refuses to run without a connection
+// in place. Prevents a future caller from assuming Start does its own dialing.
+func TestStart_NoConnection(t *testing.T) {
+	client := NewClient(Config{ServerAddr: "localhost:0", ClientID: "t", Name: "t"})
+	err := client.Start()
+	if err == nil {
+		t.Fatal("expected error when Start is called with no connection")
+	}
+	if !strings.Contains(err.Error(), "no connection") {
+		t.Errorf("error message = %q, want substring %q", err.Error(), "no connection")
 	}
 }


### PR DESCRIPTION
Second in the staggered sequence from Sendspin/conformance#16 — Gaps 1 + 2. Drop-in additive changes, no breaking surface, existing callers keep working.

## What's new

**\`Config.SupportedRoles []string\`** — optional override for the role list in \`client/hello\`. When nil/empty, \`handshake()\` builds the list the way it always has (\`player@v1\` + \`metadata@v1\`, plus \`artwork@v1\` / \`visualizer@v1\` when their support structs are set). When set, the caller's list goes on the wire verbatim. The practical win: a metadata-only or controller-only client can now advertise just \`[\"controller@v1\"]\` without falsely claiming \`player@v1\` and triggering the peer to start an audio stream.

**\`NewClientFromConn(config, conn)\`** — wraps a pre-accepted \`*websocket.Conn\`. For server-initiated scenarios where the caller has already listened + accepted, the library can now run the client-side protocol (handshake, read loop, channel routing) over the existing connection instead of forcing callers to re-implement ~200 lines of manual WebSocket handling.

To make the above work without duplicating setup logic, I split \`Connect()\`'s post-dial work into a new public \`Start()\` method. \`Connect()\` still does the full dial + setup; callers with their own conn do \`NewClientFromConn(...)\` + \`Start()\`. If someone calls \`Start()\` without a connection they get a clean error instead of a nil-deref.

## Tests

Four new test functions, 12 assertions total:

- **\`TestBuildSupportedRoles_Default\`** — four subtests covering every permutation of the optional V1 support structs, confirming the auto-build behavior is byte-identical to what \`handshake()\` used to produce.
- **\`TestBuildSupportedRoles_ExplicitOverride\`** — three subtests, including one that sets \`ArtworkV1Support\` alongside an override to prove the override wins. This is load-bearing for conformance metadata/controller scenarios.
- **\`TestNewClientFromConn_HandshakeAndClose\`** — spins up an \`httptest.Server\` with a handler that plays the server side of the handshake (read \`client/hello\`, write \`server/hello\`, read \`client/state\`). The client side uses \`NewClientFromConn\` with \`SupportedRoles=[\"controller@v1\"]\` and asserts the server captured the advertised role list. End-to-end proof the full path works over a real websocket, not just struct construction.
- **\`TestStart_NoConnection\`** — guards the error path so a future caller can't accidentally bypass \`Connect\`/\`NewClientFromConn\` and expect \`Start\` to figure it out.

## Follow-up

Matching conformance adapter PR is next — this lets the \`runConnectedSession\` path in \`adapters/sendspin-go/client/main.go\` collapse from its ~200-line manual read-write loop into a channel-based \`select\` matching the existing \`runOutboundProtocolClient\`. That's the big line-savings win from issue #16.

Gap 5 (server-side controller role) will be PR C, smaller and following the same library→adapter pattern.

Closes Gaps 1 and 2 in Sendspin/conformance#16.