### PR TITLE
ci: drop redundant Go module cache step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libopus-dev libopusfile-dev libasound2-dev
 
-    - name: Cache Go modules
-      uses: actions/cache@v4
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
     - name: Download dependencies
       run: go mod download
 


### PR DESCRIPTION
## What's broken

Every CI run has a wall of red \`##[error]\` lines like this in the Test job:

\`\`\`
##[error]/usr/bin/tar: ../../../go/pkg/mod/github.com/miekg/dns@v1.1.55/acceptfunc.go: Cannot open: File exists
##[error]/usr/bin/tar: ../../../go/pkg/mod/github.com/miekg/dns@v1.1.55/duplicate_generate.go: Cannot open: File exists
... (many more)
\`\`\`

The job still reports pass because the step's final exit code is 0, but the run logs look terrifying and any real error in adjacent steps is easy to miss in the noise.

## Cause

The Test job has two things trying to manage \`~/go/pkg/mod\`:

1. \`actions/setup-go@v5\` — caches GOMODCACHE by default, keyed on \`go.sum\`.
2. An explicit \`actions/cache@v4\` step right after — does the same thing.

Both try to extract their tarballs into the same directory. The second one hits files already unpacked by the first and tar errors on every overwrite. GitHub Actions then helpfully annotates every line as \`##[error]\`.

The Build and Lint jobs don't have the explicit cache step and have been running clean all along — that was the smoking gun.

## Fix

Delete the explicit \`Cache Go modules\` step. \`setup-go@v5\` already handles this correctly; the second step is vestigial. -8 lines, zero behavior change except the error noise goes away.