### PR TITLE
feat(protocol): Client.Send + ServerHello capture (PR A follow-up)

### DIFF
--- a/pkg/protocol/client.go
+++ b/pkg/protocol/client.go
@@ -70,6 +70,15 @@ type Client struct {
 	ServerState   chan ServerStateMessage
 	GroupUpdate   chan GroupUpdate
 
+	// serverHello holds the parsed server/hello message received during
+	// handshake. Nil until Start()/Connect() completes successfully.
+	serverHello *ServerHello
+
+	// rawServerHello holds the raw JSON envelope bytes of the server/hello
+	// message, useful for conformance testing and protocol debugging where
+	// the exact wire representation matters.
+	rawServerHello []byte
+
 	connected bool
 	ctx       context.Context
 	cancel    context.CancelFunc
@@ -213,6 +222,23 @@ func (c *Client) handshake() error {
 		return fmt.Errorf("expected server/hello, got %s", serverMsg.Type)
 	}
 
+	// Parse the server hello payload into a typed struct and cache both
+	// the parsed form and the raw envelope bytes for later retrieval via
+	// ServerHello() / RawServerHello().
+	payloadBytes, err := json.Marshal(serverMsg.Payload)
+	if err != nil {
+		return fmt.Errorf("failed to re-marshal server/hello payload: %w", err)
+	}
+	var parsedHello ServerHello
+	if err := json.Unmarshal(payloadBytes, &parsedHello); err != nil {
+		return fmt.Errorf("failed to decode server/hello payload: %w", err)
+	}
+
+	c.mu.Lock()
+	c.serverHello = &parsedHello
+	c.rawServerHello = append([]byte(nil), data...)
+	c.mu.Unlock()
+
 	log.Printf("Handshake complete with server")
 
 	// Send initial state per spec (client/state with nested player object)
@@ -234,6 +260,40 @@ func (c *Client) handshake() error {
 	}
 
 	return nil
+}
+
+// ServerHello returns the parsed server/hello message received during
+// handshake, or nil if handshake has not yet completed. Safe for concurrent
+// reads; callers should not mutate the returned struct.
+func (c *Client) ServerHello() *ServerHello {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.serverHello
+}
+
+// RawServerHello returns the raw JSON envelope bytes of the server/hello
+// message received during handshake, or nil if handshake has not yet
+// completed. Useful for conformance testing and protocol debugging where
+// the exact wire representation matters. Returns a fresh copy; callers
+// may mutate it without affecting the client.
+func (c *Client) RawServerHello() []byte {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.rawServerHello == nil {
+		return nil
+	}
+	out := make([]byte, len(c.rawServerHello))
+	copy(out, c.rawServerHello)
+	return out
+}
+
+// Send writes a typed envelope to the connected peer. The message is
+// wrapped as {"type": msgType, "payload": payload} and sent as a text
+// WebSocket frame. Use this for protocol messages the library does not
+// yet have a dedicated sender for (e.g. client/command in controller
+// scenarios).
+func (c *Client) Send(msgType string, payload any) error {
+	return c.sendJSON(Message{Type: msgType, Payload: payload})
 }
 
 // buildSupportedRoles returns the role list for the client/hello message.

--- a/pkg/protocol/client_test.go
+++ b/pkg/protocol/client_test.go
@@ -3,6 +3,7 @@
 package protocol
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"net/http"
@@ -333,6 +334,43 @@ func TestNewClientFromConn_HandshakeAndClose(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("server never captured a client/hello")
 	}
+
+	// ServerHello() and RawServerHello() must return the handshake data
+	// after Start() completes. The test server above responds with a hello
+	// whose ServerID is "test-server" and Name is "Test Server", so both
+	// accessors should agree.
+	parsed := client.ServerHello()
+	if parsed == nil {
+		t.Fatal("ServerHello() returned nil after successful handshake")
+	}
+	if parsed.ServerID != "test-server" {
+		t.Errorf("ServerHello().ServerID = %q, want test-server", parsed.ServerID)
+	}
+	if parsed.Name != "Test Server" {
+		t.Errorf("ServerHello().Name = %q, want Test Server", parsed.Name)
+	}
+
+	raw := client.RawServerHello()
+	if len(raw) == 0 {
+		t.Fatal("RawServerHello() returned empty bytes after successful handshake")
+	}
+	var envelope map[string]any
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("RawServerHello() did not return valid JSON: %v", err)
+	}
+	if envelope["type"] != "server/hello" {
+		t.Errorf("raw envelope type = %v, want server/hello", envelope["type"])
+	}
+
+	// Confirm RawServerHello returns a copy: mutating the returned slice
+	// must not affect subsequent calls.
+	if len(raw) > 0 {
+		raw[0] = 0xFF
+	}
+	raw2 := client.RawServerHello()
+	if bytes.Equal(raw, raw2) {
+		t.Error("RawServerHello returned a shared reference; mutation leaked into the client")
+	}
 }
 
 // TestStart_NoConnection confirms Start refuses to run without a connection
@@ -345,5 +383,116 @@ func TestStart_NoConnection(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no connection") {
 		t.Errorf("error message = %q, want substring %q", err.Error(), "no connection")
+	}
+}
+
+// TestServerHello_BeforeHandshake guards against nil confusion: the
+// accessors must return nil/empty before Start() runs, not stale data
+// from a previous client or a zero-value ServerHello.
+func TestServerHello_BeforeHandshake(t *testing.T) {
+	client := NewClient(Config{ServerAddr: "localhost:0", ClientID: "t", Name: "t"})
+
+	if hello := client.ServerHello(); hello != nil {
+		t.Errorf("ServerHello() before handshake = %+v, want nil", hello)
+	}
+	if raw := client.RawServerHello(); raw != nil {
+		t.Errorf("RawServerHello() before handshake = %v, want nil", raw)
+	}
+}
+
+// TestClientSend_WritesEnvelope verifies that Client.Send emits a correctly
+// shaped {"type": ..., "payload": ...} envelope on the wire. The test
+// server reads a client/command message after handshake and asserts on the
+// envelope shape, which is exactly what the conformance adapter's
+// controller scenarios need.
+func TestClientSend_WritesEnvelope(t *testing.T) {
+	capturedCommand := make(chan map[string]any, 1)
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+
+		// Handshake: read client/hello, write server/hello, read client/state.
+		if _, _, err := conn.ReadMessage(); err != nil {
+			t.Errorf("read client/hello: %v", err)
+			return
+		}
+		if err := conn.WriteJSON(Message{
+			Type:    "server/hello",
+			Payload: ServerHello{ServerID: "srv", Name: "srv", Version: 1},
+		}); err != nil {
+			t.Errorf("write server/hello: %v", err)
+			return
+		}
+		if _, _, err := conn.ReadMessage(); err != nil {
+			t.Errorf("read client/state: %v", err)
+			return
+		}
+
+		// Now read the client/command the test below will send via Send().
+		_, cmdBytes, err := conn.ReadMessage()
+		if err != nil {
+			t.Errorf("read client/command: %v", err)
+			return
+		}
+		var envelope map[string]any
+		if err := json.Unmarshal(cmdBytes, &envelope); err != nil {
+			t.Errorf("unmarshal envelope: %v", err)
+			return
+		}
+		capturedCommand <- envelope
+
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	client := NewClientFromConn(Config{
+		ClientID:       "sender",
+		Name:           "Sender Test",
+		Version:        1,
+		SupportedRoles: []string{"controller@v1"},
+	}, conn)
+	defer client.Close()
+
+	if err := client.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	payload := map[string]any{"controller": map[string]any{"command": "next"}}
+	if err := client.Send("client/command", payload); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	select {
+	case envelope := <-capturedCommand:
+		if envelope["type"] != "client/command" {
+			t.Errorf("envelope.type = %v, want client/command", envelope["type"])
+		}
+		innerPayload, ok := envelope["payload"].(map[string]any)
+		if !ok {
+			t.Fatalf("envelope.payload not a map: %v", envelope["payload"])
+		}
+		controller, ok := innerPayload["controller"].(map[string]any)
+		if !ok {
+			t.Fatalf("payload.controller not a map: %v", innerPayload["controller"])
+		}
+		if controller["command"] != "next" {
+			t.Errorf("controller.command = %v, want next", controller["command"])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server never captured a client/command")
 	}
 }


### PR DESCRIPTION
Small follow-up to #55. Drafting the conformance adapter rewrite against the freshly-merged PR A revealed two library gaps that block a clean \`NewClientFromConn\` takeover of \`runConnectedSession\`:

## Gap 1: No access to the received server/hello

The conformance adapter's summary for server-initiated scenarios includes the raw server/hello envelope bytes in \`peer_hello\`. The library's \`handshake()\` type-checks the message and then discards the payload, so callers have no way to recover either the parsed form or the raw wire bytes after \`Start()\` / \`Connect()\` returns.

## Gap 2: No way to send arbitrary envelopes

Controller scenarios need to send \`client/command\` in response to a \`server/state\` with controller info. The library has \`SendTimeSync\` for \`client/time\` and \`SendState\` for \`client/state\` but no generic escape hatch, so the rewritten message loop has to fall back to raw \`conn.WriteMessage\` — defeating the point of using \`NewClientFromConn\` in the first place.

## Additions (all backward-compatible)

- \`Client.serverHello\` + \`rawServerHello\` stored during handshake, behind the existing \`mu\` so reads are safe during the read loop.
- \`Client.ServerHello() *ServerHello\` — returns the parsed hello, or nil before handshake.
- \`Client.RawServerHello() []byte\` — returns a copy of the envelope bytes so callers can mutate the result without corrupting the client.
- \`Client.Send(msgType string, payload any) error\` — thin wrapper around the existing internal \`sendJSON\` for arbitrary envelopes.

## Tests

- Extended \`TestNewClientFromConn_HandshakeAndClose\` to assert \`ServerHello()\` returns the expected struct after \`Start()\`, \`RawServerHello()\` returns valid JSON with \`type == "server/hello"\`, and confirms the returned slice is a fresh copy (mutating it doesn't leak into a subsequent call).
- New \`TestServerHello_BeforeHandshake\` locks down the nil-return case so a future refactor can't accidentally leak a stale value.
- New \`TestClientSend_WritesEnvelope\` spins up a local websocket server that reads a \`client/command\` emitted via \`Send()\` and asserts the envelope shape matches what controller scenarios need: \`type=client/command\`, \`payload.controller.command=next\`.

## Why this wasn't in #55

Honest answer: I didn't see it until I started writing the adapter rewrite against the new API. Both gaps are obvious once you're actually using \`NewClientFromConn\` to drive a full conformance scenario, and not obvious when you're just designing the API in the abstract. Good reminder to sketch the caller code before declaring an API done.

Once this merges I'll tag \`v1.3.0\` and open the adapter rewrite PR in the conformance repo.