### PR TITLE
v1.3.0 polish: #32 (hello log spam), #48 (device-info flags), #47 (static delay)

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,13 +21,16 @@ import (
 )
 
 var (
-	serverAddr = flag.String("server", "", "Manual server address (skip mDNS)")
-	port       = flag.Int("port", 8927, "Port for mDNS advertisement")
-	name       = flag.String("name", "", "Player friendly name (default: hostname-sendspin-player)")
-	bufferMs   = flag.Int("buffer-ms", 150, "Jitter buffer size in milliseconds")
-	logFile    = flag.String("log-file", "sendspin-player.log", "Log file path")
-	noTUI      = flag.Bool("no-tui", false, "Disable TUI, use streaming logs instead")
-	streamLogs = flag.Bool("stream-logs", false, "Alias for -no-tui")
+	serverAddr    = flag.String("server", "", "Manual server address (skip mDNS)")
+	port          = flag.Int("port", 8927, "Port for mDNS advertisement")
+	name          = flag.String("name", "", "Player friendly name (default: hostname-sendspin-player)")
+	bufferMs      = flag.Int("buffer-ms", 150, "Jitter buffer size in milliseconds")
+	staticDelayMs = flag.Int("static-delay-ms", 0, "Static playback delay in milliseconds for hardware latency compensation")
+	logFile       = flag.String("log-file", "sendspin-player.log", "Log file path")
+	noTUI         = flag.Bool("no-tui", false, "Disable TUI, use streaming logs instead")
+	streamLogs    = flag.Bool("stream-logs", false, "Alias for -no-tui")
+	productName   = flag.String("product-name", "", "Override the product name sent in device_info (default: compiled-in identity)")
+	manufacturer  = flag.String("manufacturer", "", "Override the manufacturer sent in device_info (default: compiled-in identity)")
 )
 
 func main() {
@@ -108,14 +111,24 @@ func main() {
 		serverAddress = *serverAddr
 	}
 
+	deviceProduct := version.Product
+	if *productName != "" {
+		deviceProduct = *productName
+	}
+	deviceManufacturer := version.Manufacturer
+	if *manufacturer != "" {
+		deviceManufacturer = *manufacturer
+	}
+
 	config := sendspin.PlayerConfig{
-		ServerAddr: serverAddress,
-		PlayerName: playerName,
-		Volume:     100,
-		BufferMs:   *bufferMs,
+		ServerAddr:    serverAddress,
+		PlayerName:    playerName,
+		Volume:        100,
+		BufferMs:      *bufferMs,
+		StaticDelayMs: *staticDelayMs,
 		DeviceInfo: sendspin.DeviceInfo{
-			ProductName:     version.Product,
-			Manufacturer:    version.Manufacturer,
+			ProductName:     deviceProduct,
+			Manufacturer:    deviceManufacturer,
 			SoftwareVersion: version.Version,
 		},
 		OnStateChange: func(state sendspin.PlayerState) {

--- a/pkg/protocol/client.go
+++ b/pkg/protocol/client.go
@@ -204,11 +204,6 @@ func (c *Client) handshake() error {
 		Payload: hello,
 	}
 
-	helloJSON, err := json.MarshalIndent(msg, "", "  ")
-	if err == nil {
-		log.Printf("Sending client/hello:\n%s", string(helloJSON))
-	}
-
 	if err := c.sendJSON(msg); err != nil {
 		return fmt.Errorf("failed to send client/hello: %w", err)
 	}

--- a/pkg/sendspin/player.go
+++ b/pkg/sendspin/player.go
@@ -27,6 +27,12 @@ type PlayerConfig struct {
 	// BufferMs is the playback buffer size in milliseconds (default: 500)
 	BufferMs int
 
+	// StaticDelayMs shifts every scheduled play time forward by this many
+	// milliseconds. Used to compensate for hardware that introduces a fixed
+	// downstream latency (Bluetooth sinks, AVRs with DSP, some USB DACs).
+	// Default 0 means no shift.
+	StaticDelayMs int
+
 	DeviceInfo DeviceInfo
 
 	OnMetadata func(Metadata)
@@ -125,6 +131,7 @@ func (p *Player) Connect() error {
 		ServerAddr:     p.config.ServerAddr,
 		PlayerName:     p.config.PlayerName,
 		BufferMs:       p.config.BufferMs,
+		StaticDelayMs:  p.config.StaticDelayMs,
 		DeviceInfo:     p.config.DeviceInfo,
 		DecoderFactory: p.config.DecoderFactory,
 		OnMetadata:     p.config.OnMetadata,

--- a/pkg/sendspin/player_test.go
+++ b/pkg/sendspin/player_test.go
@@ -33,6 +33,65 @@ func TestNewPlayer_ProcessCallbackStored(t *testing.T) {
 	}
 }
 
+// TestNewPlayer_DeviceInfoPassesThrough guards #48: --manufacturer and
+// --product-name CLI flags write into PlayerConfig.DeviceInfo, and must
+// survive the trip into the underlying Receiver without being replaced
+// by the library defaults.
+func TestNewPlayer_DeviceInfoPassesThrough(t *testing.T) {
+	custom := DeviceInfo{
+		ProductName:     "Custom Product",
+		Manufacturer:    "Custom Mfg",
+		SoftwareVersion: "9.9.9",
+	}
+	player, err := NewPlayer(PlayerConfig{
+		ServerAddr: "localhost:8927",
+		PlayerName: "Test",
+		DeviceInfo: custom,
+	})
+	if err != nil {
+		t.Fatalf("NewPlayer: %v", err)
+	}
+	if player.config.DeviceInfo != custom {
+		t.Errorf("config.DeviceInfo = %+v, want %+v", player.config.DeviceInfo, custom)
+	}
+}
+
+// TestNewPlayer_StaticDelayStored guards #47: PlayerConfig.StaticDelayMs
+// must be preserved on the Player so Connect can plumb it into Receiver
+// and from there into Scheduler.
+func TestNewPlayer_StaticDelayStored(t *testing.T) {
+	player, err := NewPlayer(PlayerConfig{
+		ServerAddr:    "localhost:8927",
+		PlayerName:    "Test",
+		StaticDelayMs: 250,
+	})
+	if err != nil {
+		t.Fatalf("NewPlayer: %v", err)
+	}
+	if player.config.StaticDelayMs != 250 {
+		t.Errorf("config.StaticDelayMs = %d, want 250", player.config.StaticDelayMs)
+	}
+}
+
+// TestReceiver_StaticDelayDefaultZero sanity-checks that a ReceiverConfig
+// without StaticDelayMs set produces a scheduler with zero offset. This is
+// the test that would have flagged the new field if a future refactor
+// stopped plumbing it through. Uses a short connect attempt + teardown
+// because we don't want to actually dial anything.
+func TestReceiver_StaticDelayDefaultZero(t *testing.T) {
+	recv, err := NewReceiver(ReceiverConfig{
+		ServerAddr: "localhost:0",
+		PlayerName: "Test",
+	})
+	if err != nil {
+		t.Fatalf("NewReceiver: %v", err)
+	}
+	defer recv.Close()
+	if recv.config.StaticDelayMs != 0 {
+		t.Errorf("default StaticDelayMs = %d, want 0", recv.config.StaticDelayMs)
+	}
+}
+
 func TestPlayer_StatusBeforeConnect(t *testing.T) {
 	player, _ := NewPlayer(PlayerConfig{
 		ServerAddr: "localhost:8927",

--- a/pkg/sendspin/receiver.go
+++ b/pkg/sendspin/receiver.go
@@ -19,6 +19,7 @@ type ReceiverConfig struct {
 	ServerAddr     string
 	PlayerName     string
 	BufferMs       int
+	StaticDelayMs  int // optional static latency compensation (ms) applied to every scheduled play time
 	DeviceInfo     DeviceInfo
 	DecoderFactory func(audio.Format) (decode.Decoder, error)
 	OnMetadata     func(Metadata)
@@ -231,7 +232,7 @@ func (r *Receiver) handleStreamStart() {
 			}
 
 			r.schedulerCtx, r.schedulerCancel = context.WithCancel(r.ctx)
-			r.scheduler = NewScheduler(r.clockSync, r.config.BufferMs)
+			r.scheduler = NewScheduler(r.clockSync, r.config.BufferMs, r.config.StaticDelayMs)
 			go r.scheduler.Run()
 			go r.pumpSchedulerOutput(r.schedulerCtx)
 

--- a/pkg/sendspin/scheduler.go
+++ b/pkg/sendspin/scheduler.go
@@ -20,6 +20,7 @@ type Scheduler struct {
 	bufferMu     gosync.Mutex // Protects bufferQ and buffering
 	output       chan audio.Buffer
 	jitterMs     int
+	staticDelay  time.Duration // shifts scheduled play time forward to compensate for hardware latency
 	ctx          context.Context
 	cancel       context.CancelFunc
 	buffering    bool
@@ -36,9 +37,11 @@ type SchedulerStats struct {
 	Dropped  int64
 }
 
-// NewScheduler creates a playback scheduler
-// bufferMs controls startup buffering: how many ms of audio to accumulate before playback
-func NewScheduler(clockSync *sync.ClockSync, bufferMs int) *Scheduler {
+// NewScheduler creates a playback scheduler.
+// bufferMs controls startup buffering (ms of audio to accumulate before playback).
+// staticDelayMs shifts every scheduled play time forward, compensating for
+// downstream hardware latency like Bluetooth sinks or AVRs. Zero means no shift.
+func NewScheduler(clockSync *sync.ClockSync, bufferMs int, staticDelayMs int) *Scheduler {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// Calculate buffer target from user config (bufferMs / ChunkDurationMs)
@@ -52,6 +55,7 @@ func NewScheduler(clockSync *sync.ClockSync, bufferMs int) *Scheduler {
 		bufferQ:      NewBufferQueue(),
 		output:       make(chan audio.Buffer, 10),
 		jitterMs:     bufferMs, // Store for potential future use
+		staticDelay:  time.Duration(staticDelayMs) * time.Millisecond,
 		ctx:          ctx,
 		cancel:       cancel,
 		buffering:    true,
@@ -60,7 +64,7 @@ func NewScheduler(clockSync *sync.ClockSync, bufferMs int) *Scheduler {
 }
 
 func (s *Scheduler) Schedule(buf audio.Buffer) {
-	buf.PlayAt = s.clockSync.ServerToLocalTime(buf.Timestamp)
+	buf.PlayAt = s.clockSync.ServerToLocalTime(buf.Timestamp).Add(s.staticDelay)
 
 	received := s.received.Add(1) - 1
 

--- a/pkg/sendspin/scheduler_test.go
+++ b/pkg/sendspin/scheduler_test.go
@@ -1,0 +1,70 @@
+// ABOUTME: Tests for the playback scheduler
+// ABOUTME: Covers static-delay offset, buffer ordering, and drop semantics
+package sendspin
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Sendspin/sendspin-go/pkg/audio"
+	"github.com/Sendspin/sendspin-go/pkg/sync"
+)
+
+// TestScheduler_StaticDelayShift is a regression guard for the
+// --static-delay-ms feature. With an unsynced ClockSync,
+// ServerToLocalTime returns time.Unix(0, serverTime*1000) deterministically,
+// which gives us an exact expected PlayAt we can check.
+//
+// For a 250ms static delay, a buffer whose timestamp would otherwise play
+// at local time T should actually play at T + 250ms.
+func TestScheduler_StaticDelayShift(t *testing.T) {
+	const serverTimestampUs = int64(1_000_000_000) // 1000 seconds, arbitrary
+	const bufferMs = 200
+
+	cases := []struct {
+		name          string
+		staticDelayMs int
+	}{
+		{"no delay", 0},
+		{"250ms delay", 250},
+		{"1000ms delay", 1000},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := sync.NewClockSync()
+			sched := NewScheduler(cs, bufferMs, tc.staticDelayMs)
+			defer sched.Stop()
+
+			buf := audio.Buffer{Timestamp: serverTimestampUs}
+			sched.Schedule(buf)
+
+			// Schedule mutates a local copy; inspect the queue.
+			sched.bufferMu.Lock()
+			queued := sched.bufferQ.Peek()
+			sched.bufferMu.Unlock()
+
+			baseline := time.Unix(0, serverTimestampUs*1000)
+			want := baseline.Add(time.Duration(tc.staticDelayMs) * time.Millisecond)
+
+			if !queued.PlayAt.Equal(want) {
+				t.Errorf("PlayAt = %v, want %v (static delay = %dms)",
+					queued.PlayAt, want, tc.staticDelayMs)
+			}
+		})
+	}
+}
+
+// TestScheduler_StaticDelayDefaultZero confirms that a scheduler built with
+// the old two-argument shape would still behave correctly — i.e. the delay
+// field defaults cleanly to 0. This is a belt-and-suspenders check against
+// future refactors that might forget to thread the parameter through.
+func TestScheduler_StaticDelayDefaultZero(t *testing.T) {
+	cs := sync.NewClockSync()
+	sched := NewScheduler(cs, 200, 0)
+	defer sched.Stop()
+
+	if sched.staticDelay != 0 {
+		t.Errorf("staticDelay with 0 arg = %v, want 0", sched.staticDelay)
+	}
+}


### PR DESCRIPTION
Three small polish items queued up for v1.3.0, all cheap and additive. Landing them together so the tag gets a clean story.

## #32 — drop client/hello log spam

\`pkg/protocol/client.go\` unconditionally \`MarshalIndent\`'d the client/hello envelope and dumped ~60 lines to the log on every connect. Useful exactly once during debugging; noise forever after. Wire-shape coverage is already in \`TestHandshake_PlayerSupportGatedByRoles\`, so nothing is lost. Four lines deleted, no flag added, no new surface.

## #48 — \`--manufacturer\` / \`--product-name\` CLI flags

\`sendspin-player\` now accepts \`--manufacturer\` and \`--product-name\` flags that override the compiled-in \`version.Manufacturer\` and \`version.Product\` values in \`client/hello\`'s \`device_info\` block. Useful for containerized or embedded builds that want to self-identify distinctly in MA's UI without rebuilding. When the flags are unset, behavior is unchanged.

## #47 — \`--static-delay-ms\` CLI flag

New \`PlayerConfig.StaticDelayMs\` (defaults to 0) threads through \`ReceiverConfig\` to \`NewScheduler\`, where it shifts every scheduled \`PlayAt\` forward by the configured number of milliseconds. This is the sendspin-cli equivalent for compensating fixed downstream latency (Bluetooth sinks, AVRs, slow USB DACs).

The offset is applied in exactly one place — \`scheduler.Schedule\` adds the duration to the \`ServerToLocalTime\` conversion result. Zero-value callers see identical behavior.

**\`NewScheduler\`'s signature gained a third parameter.** There is one in-tree caller (\`pkg/sendspin.Receiver\`) and it's updated in this commit. Not a breaking change for library users of \`Player\`/\`Receiver\` (they go through \`PlayerConfig\`), but anyone calling \`NewScheduler\` from their own code needs to pass an extra 0.

## Tests

- \`TestScheduler_StaticDelayShift\` — table-driven (0ms/250ms/1000ms). Uses an unsynced \`ClockSync\` so \`ServerToLocalTime\` is deterministic and asserts the exact \`PlayAt\`.
- \`TestScheduler_StaticDelayDefaultZero\` — guards the zero-arg path.
- \`TestNewPlayer_DeviceInfoPassesThrough\` — verifies \`PlayerConfig.DeviceInfo\` round-trips without the library defaults clobbering it.
- \`TestNewPlayer_StaticDelayStored\` — verifies \`StaticDelayMs\` survives into \`player.config\`.
- \`TestReceiver_StaticDelayDefaultZero\` — sanity-checks \`ReceiverConfig\` without \`StaticDelayMs\` set produces a zero offset.

All existing tests pass, conformance matrix is unaffected (the new surface is only exercised when the new flags are set, and both default to their current behavior).

## Manual playback caveat on #47

Unit tests cover the Duration math, but I haven't verified on real hardware that the shift produces the expected audio alignment through a Bluetooth/AVR sink. The implementation is dead simple (one \`time.Add\` call), zero is the default, and all existing playback paths are untouched when the flag isn't set — risk is contained. If a real-hardware test shows drift, the fix location is the single line in \`scheduler.Schedule\`.

## After this merges

Version fallback sync + tag \`v1.3.0\`. The release will bundle #54, #55, #57, #58, and this PR as the coherent "conformance adapter building blocks + polish" minor release.