### PR TITLE
feat(player): auto-reconnect with exponential backoff and rediscovery

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -31,6 +32,7 @@ var (
 	streamLogs    = flag.Bool("stream-logs", false, "Alias for -no-tui")
 	productName   = flag.String("product-name", "", "Override the product name sent in device_info (default: compiled-in identity)")
 	manufacturer  = flag.String("manufacturer", "", "Override the manufacturer sent in device_info (default: compiled-in identity)")
+	noReconnect   = flag.Bool("no-reconnect", false, "Disable automatic reconnect on connection loss")
 )
 
 func main() {
@@ -89,9 +91,10 @@ func main() {
 	}
 
 	var serverAddress string
+	var disc *discovery.Manager
 	if *serverAddr == "" {
 		log.Printf("Searching for servers via mDNS (press Ctrl+C to quit)...")
-		disc := discovery.NewManager(discovery.Config{
+		disc = discovery.NewManager(discovery.Config{
 			ServiceName: playerName,
 			Port:        *port,
 		})
@@ -138,13 +141,15 @@ func main() {
 				Channels:   state.Channels,
 				BitDepth:   state.BitDepth,
 			})
-			if state.Connected {
-				connected := true
-				updateTUI(ui.StatusMsg{
-					Connected:  &connected,
-					ServerName: serverAddress,
-				})
+			connected := state.Connected
+			serverLabel := serverAddress
+			if state.State == "reconnecting" {
+				serverLabel = "reconnecting..."
 			}
+			updateTUI(ui.StatusMsg{
+				Connected:  &connected,
+				ServerName: serverLabel,
+			})
 		},
 		OnMetadata: func(meta sendspin.Metadata) {
 			updateTUI(ui.StatusMsg{
@@ -156,6 +161,25 @@ func main() {
 		OnError: func(err error) {
 			log.Printf("Player error: %v", err)
 		},
+		Reconnect: sendspin.ReconnectConfig{
+			Enabled: !*noReconnect,
+		},
+	}
+
+	if !*noReconnect && disc != nil {
+		config.Reconnect.Rediscover = func(ctx context.Context) (string, error) {
+			disc.Browse()
+			select {
+			case server := <-disc.Servers():
+				addr := fmt.Sprintf("%s:%d", server.Host, server.Port)
+				log.Printf("Rediscovered server at %s", addr)
+				return addr, nil
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-time.After(5 * time.Second):
+				return "", fmt.Errorf("rediscover timed out")
+			}
+		}
 	}
 
 	player, err := sendspin.NewPlayer(config)

--- a/pkg/sendspin/player.go
+++ b/pkg/sendspin/player.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math/rand"
+	"time"
 
 	"github.com/Sendspin/sendspin-go/pkg/audio"
 	"github.com/Sendspin/sendspin-go/pkg/audio/decode"
@@ -13,6 +15,24 @@ import (
 	"github.com/Sendspin/sendspin-go/pkg/protocol"
 	"github.com/Sendspin/sendspin-go/pkg/sync"
 )
+
+// ReconnectConfig controls automatic reconnect behavior after the protocol
+// connection drops. When Enabled is false (the zero value), Player behaves
+// as a one-shot: a lost connection stays lost.
+type ReconnectConfig struct {
+	Enabled      bool
+	InitialDelay time.Duration // default 500ms
+	MaxDelay     time.Duration // default 30s
+	Multiplier   float64       // default 2.0
+	MaxAttempts  int           // 0 = infinite (default)
+
+	// Rediscover is an optional callback invoked before each reconnect
+	// attempt. Returning a non-empty address overrides the configured
+	// ServerAddr for that attempt. Use this to re-run mDNS discovery when
+	// the server may have moved. Errors are logged and the attempt falls
+	// back to the last known address.
+	Rediscover func(ctx context.Context) (string, error)
+}
 
 // PlayerConfig holds player configuration
 type PlayerConfig struct {
@@ -52,6 +72,10 @@ type PlayerConfig struct {
 	// ProcessCallback is called with decoded samples before they are written to output.
 	// Must not block. Runs on the audio consumption goroutine.
 	ProcessCallback func([]int32)
+
+	// Reconnect controls automatic reconnection behavior when the protocol
+	// connection drops. Disabled by default.
+	Reconnect ReconnectConfig
 }
 
 type DeviceInfo struct {
@@ -109,6 +133,17 @@ func NewPlayer(config PlayerConfig) (*Player, error) {
 	if config.BufferMs == 0 {
 		config.BufferMs = 500
 	}
+	if config.Reconnect.Enabled {
+		if config.Reconnect.InitialDelay <= 0 {
+			config.Reconnect.InitialDelay = 500 * time.Millisecond
+		}
+		if config.Reconnect.MaxDelay <= 0 {
+			config.Reconnect.MaxDelay = 30 * time.Second
+		}
+		if config.Reconnect.Multiplier <= 1.0 {
+			config.Reconnect.Multiplier = 2.0
+		}
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -127,8 +162,30 @@ func NewPlayer(config PlayerConfig) (*Player, error) {
 }
 
 func (p *Player) Connect() error {
-	recv, err := NewReceiver(ReceiverConfig{
-		ServerAddr:     p.config.ServerAddr,
+	recv, err := p.buildReceiver(p.config.ServerAddr)
+	if err != nil {
+		return err
+	}
+	if err := recv.Connect(); err != nil {
+		return err
+	}
+
+	p.receiver = recv
+	p.state.Connected = true
+	p.notifyStateChange()
+
+	go p.consumeAudio(recv)
+
+	if p.config.Reconnect.Enabled {
+		go p.runReconnectLoop(recv)
+	}
+
+	return nil
+}
+
+func (p *Player) buildReceiver(addr string) (*Receiver, error) {
+	return NewReceiver(ReceiverConfig{
+		ServerAddr:     addr,
 		PlayerName:     p.config.PlayerName,
 		BufferMs:       p.config.BufferMs,
 		StaticDelayMs:  p.config.StaticDelayMs,
@@ -139,22 +196,98 @@ func (p *Player) Connect() error {
 		OnStreamEnd:    p.onStreamEnd,
 		OnError:        p.config.OnError,
 	})
-	if err != nil {
-		return err
+}
+
+// runReconnectLoop supervises the active receiver and rebuilds it with
+// exponential backoff whenever its Done channel closes. Exits when the
+// Player context is cancelled.
+func (p *Player) runReconnectLoop(initial *Receiver) {
+	current := initial
+	for {
+		select {
+		case <-p.ctx.Done():
+			return
+		case <-current.Done():
+		}
+
+		// Connection lost. Enter reconnecting state and back off.
+		select {
+		case <-p.ctx.Done():
+			return
+		default:
+		}
+
+		p.state.Connected = false
+		p.state.State = "reconnecting"
+		p.notifyStateChange()
+
+		next, ok := p.reconnectWithBackoff()
+		if !ok {
+			return
+		}
+		current = next
+
+		p.receiver = current
+		p.state.Connected = true
+		p.notifyStateChange()
+
+		go p.consumeAudio(current)
 	}
+}
 
-	p.receiver = recv
+func (p *Player) reconnectWithBackoff() (*Receiver, bool) {
+	cfg := p.config.Reconnect
+	delay := cfg.InitialDelay
+	attempt := 0
 
-	if err := recv.Connect(); err != nil {
-		return err
+	for {
+		attempt++
+		if cfg.MaxAttempts > 0 && attempt > cfg.MaxAttempts {
+			p.notifyError(fmt.Errorf("reconnect: gave up after %d attempts", cfg.MaxAttempts))
+			return nil, false
+		}
+
+		// Jittered sleep (±20%).
+		jittered := jitter(delay, 0.2)
+		log.Printf("Reconnect attempt %d in %v", attempt, jittered)
+		select {
+		case <-p.ctx.Done():
+			return nil, false
+		case <-time.After(jittered):
+		}
+
+		addr := p.config.ServerAddr
+		if cfg.Rediscover != nil {
+			discovered, err := cfg.Rediscover(p.ctx)
+			if err != nil {
+				log.Printf("Reconnect: rediscover failed: %v (using last known addr %s)", err, addr)
+			} else if discovered != "" {
+				addr = discovered
+			}
+		}
+
+		recv, err := p.buildReceiver(addr)
+		if err == nil {
+			if err = recv.Connect(); err == nil {
+				log.Printf("Reconnect: connected to %s on attempt %d", addr, attempt)
+				return recv, true
+			}
+		}
+		log.Printf("Reconnect attempt %d to %s failed: %v", attempt, addr, err)
+
+		delay = time.Duration(float64(delay) * cfg.Multiplier)
+		if delay > cfg.MaxDelay {
+			delay = cfg.MaxDelay
+		}
 	}
+}
 
-	p.state.Connected = true
-	p.notifyStateChange()
-
-	go p.consumeAudio()
-
-	return nil
+func jitter(d time.Duration, frac float64) time.Duration {
+	if d <= 0 {
+		return d
+	}
+	delta := (rand.Float64()*2 - 1) * frac
+	return time.Duration(float64(d) * (1 + delta))
 }
 
 func (p *Player) onStreamStart(format audio.Format) {
@@ -183,10 +316,10 @@ func (p *Player) onStreamEnd() {
 	p.notifyStateChange()
 }
 
-func (p *Player) consumeAudio() {
+func (p *Player) consumeAudio(recv *Receiver) {
 	for {
 		select {
-		case buf, ok := <-p.receiver.Output():
+		case buf, ok := <-recv.Output():
 			if !ok {
 				return
 			}

--- a/pkg/sendspin/player_test.go
+++ b/pkg/sendspin/player_test.go
@@ -3,7 +3,9 @@
 package sendspin
 
 import (
+	"context"
 	"testing"
+	"time"
 )
 
 func TestNewPlayer_Defaults(t *testing.T) {
@@ -89,6 +91,89 @@ func TestReceiver_StaticDelayDefaultZero(t *testing.T) {
 	defer recv.Close()
 	if recv.config.StaticDelayMs != 0 {
 		t.Errorf("default StaticDelayMs = %d, want 0", recv.config.StaticDelayMs)
+	}
+}
+
+// TestNewPlayer_ReconnectDefaultsApplied guards the reconnect backoff
+// defaults (#38). When the caller enables reconnect but leaves timing
+// fields zero, NewPlayer must fill them with the documented defaults so
+// an accidentally-zero delay never spin-loops.
+func TestNewPlayer_ReconnectDefaultsApplied(t *testing.T) {
+	player, err := NewPlayer(PlayerConfig{
+		ServerAddr: "localhost:8927",
+		PlayerName: "Test",
+		Reconnect:  ReconnectConfig{Enabled: true},
+	})
+	if err != nil {
+		t.Fatalf("NewPlayer: %v", err)
+	}
+	rc := player.config.Reconnect
+	if rc.InitialDelay != 500*time.Millisecond {
+		t.Errorf("InitialDelay = %v, want 500ms", rc.InitialDelay)
+	}
+	if rc.MaxDelay != 30*time.Second {
+		t.Errorf("MaxDelay = %v, want 30s", rc.MaxDelay)
+	}
+	if rc.Multiplier != 2.0 {
+		t.Errorf("Multiplier = %v, want 2.0", rc.Multiplier)
+	}
+	if rc.MaxAttempts != 0 {
+		t.Errorf("MaxAttempts = %d, want 0 (infinite)", rc.MaxAttempts)
+	}
+}
+
+// TestNewPlayer_ReconnectDefaultsSkippedWhenDisabled makes sure we don't
+// silently turn reconnect on. If Enabled is false we leave the zero values
+// alone — there is no supervisor goroutine to read them anyway.
+func TestNewPlayer_ReconnectDefaultsSkippedWhenDisabled(t *testing.T) {
+	player, _ := NewPlayer(PlayerConfig{
+		ServerAddr: "localhost:8927",
+		PlayerName: "Test",
+	})
+	if player.config.Reconnect.Enabled {
+		t.Error("Reconnect.Enabled should default to false")
+	}
+	if player.config.Reconnect.InitialDelay != 0 {
+		t.Error("InitialDelay should not be populated when Reconnect.Enabled is false")
+	}
+}
+
+// TestNewPlayer_ReconnectRediscoverCallbackStored confirms the closure
+// survives into player.config so the reconnect supervisor can call it.
+func TestNewPlayer_ReconnectRediscoverCallbackStored(t *testing.T) {
+	called := false
+	player, _ := NewPlayer(PlayerConfig{
+		ServerAddr: "localhost:8927",
+		PlayerName: "Test",
+		Reconnect: ReconnectConfig{
+			Enabled: true,
+			Rediscover: func(ctx context.Context) (string, error) {
+				called = true
+				return "other:1234", nil
+			},
+		},
+	})
+	if player.config.Reconnect.Rediscover == nil {
+		t.Fatal("Rediscover callback not stored")
+	}
+	addr, err := player.config.Reconnect.Rediscover(context.Background())
+	if err != nil || addr != "other:1234" || !called {
+		t.Errorf("callback not invoked correctly: addr=%q err=%v called=%v", addr, err, called)
+	}
+}
+
+// TestJitter stays inside the ±frac band. With frac=0.2 and a 1s delay,
+// the result must always fall within [800ms, 1200ms].
+func TestJitter(t *testing.T) {
+	base := 1 * time.Second
+	for i := 0; i < 100; i++ {
+		got := jitter(base, 0.2)
+		if got < 800*time.Millisecond || got > 1200*time.Millisecond {
+			t.Errorf("jitter(%v, 0.2) = %v, outside ±20%% band", base, got)
+		}
+	}
+	if jitter(0, 0.2) != 0 {
+		t.Error("jitter(0, _) should return 0")
 	}
 }
 

--- a/pkg/sendspin/receiver.go
+++ b/pkg/sendspin/receiver.go
@@ -101,6 +101,13 @@ func (r *Receiver) ClockSync() *sync.ClockSync {
 	return r.clockSync
 }
 
+// Done returns a channel that is closed when the receiver's context is
+// cancelled — either by Close() or by watchConnection detecting a dropped
+// protocol client. Callers can use this to implement reconnect loops.
+func (r *Receiver) Done() <-chan struct{} {
+	return r.ctx.Done()
+}
+
 // Stats returns current pipeline statistics from the scheduler and clock sync.
 func (r *Receiver) Stats() ReceiverStats {
 	stats := ReceiverStats{}


### PR DESCRIPTION
## Summary
- Player now supervises its Receiver and rebuilds on connection loss with jittered exponential backoff (500ms → 30s, 2×, infinite attempts by default).
- Optional `Rediscover` callback lets the CLI re-run mDNS between attempts so servers that move are picked up.
- New `"reconnecting"` state emitted via `OnStateChange` so the TUI reflects the transition; CLI shows `reconnecting...` as the server label.
- `--no-reconnect` flag disables the loop for one-shot use. Reconnect is ON by default.

Closes #38. Prerequisite for daemon deployment (#39).

## Design notes
- Receiver stays a one-shot primitive; the supervisor owns lifecycle and builds a fresh Receiver per attempt.
- Supervisor watches `receiver.Done()` — a single signal covers TCP read errors, server hangup, and explicit teardown.
- Volume/mute state is preserved across reconnects via existing `p.state` + `onStreamStart` re-application.
- Output device (malgo) is reused across reconnects; no teardown between.

## Test plan
- [x] `go test ./... -count=1` green
- [x] gofmt clean on all touched files
- [x] New unit tests: reconnect defaults applied/skipped, Rediscover callback storage, jitter bounds
- [x] Manual smoke test confirmed working by @chrisuthe