### PR TITLE
feat(server): M3 — GroupRole interface + ControllerGroupRole

### DIFF
--- a/pkg/sendspin/group.go
+++ b/pkg/sendspin/group.go
@@ -84,6 +84,9 @@ type Group struct {
 	subs    map[int]chan Event
 	nextSub int
 	closed  bool
+
+	roles               map[string]GroupRole
+	roleDispatchStarted bool
 }
 
 // NewGroup constructs a Group with the given identifier. The ID is

--- a/pkg/sendspin/group_role.go
+++ b/pkg/sendspin/group_role.go
@@ -1,0 +1,137 @@
+// ABOUTME: GroupRole interface and role dispatch on Group
+// ABOUTME: Roles register with the Group and receive client events + messages
+package sendspin
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// GroupRole is the interface implemented by per-role handlers. Each
+// role family (controller, metadata, player, artwork) registers one
+// GroupRole with the Group. The Group dispatches client lifecycle
+// events to all registered roles.
+type GroupRole interface {
+	Role() string
+	OnClientJoin(c *ServerClient)
+	OnClientLeave(id string, name string)
+}
+
+// MessageHandler is an optional interface that a GroupRole may
+// implement to receive role-specific messages (e.g., client/command
+// payloads routed by role key). Roles that don't handle messages
+// don't need to implement this.
+type MessageHandler interface {
+	HandleMessage(c *ServerClient, payload json.RawMessage) error
+}
+
+// RegisterRole registers a GroupRole with this group. The role is
+// stored by its Role() family name. Duplicate registrations for the
+// same family overwrite the previous one.
+//
+// After registration, the role receives OnClientJoin / OnClientLeave
+// calls for clients that join or leave the group, dispatched from
+// the group's internal event subscriber.
+func (g *Group) RegisterRole(role GroupRole) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if g.roles == nil {
+		g.roles = make(map[string]GroupRole)
+	}
+	g.roles[role.Role()] = role
+
+	if g.roleDispatchStarted {
+		return
+	}
+	g.roleDispatchStarted = true
+
+	events, _ := g.subscribeInternal()
+	go g.dispatchRoleEvents(events)
+}
+
+// GetRole returns the registered GroupRole for the given family name,
+// or nil if none is registered.
+func (g *Group) GetRole(family string) GroupRole {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	if g.roles == nil {
+		return nil
+	}
+	return g.roles[family]
+}
+
+// RouteMessage routes a role-specific message payload to the
+// registered GroupRole for the given family. Returns an error if no
+// role is registered for the family or if the role doesn't implement
+// MessageHandler.
+func (g *Group) RouteMessage(c *ServerClient, roleFamily string, payload json.RawMessage) error {
+	g.mu.RLock()
+	role, ok := g.roles[roleFamily]
+	g.mu.RUnlock()
+
+	if !ok {
+		return fmt.Errorf("no role registered for %q", roleFamily)
+	}
+
+	handler, ok := role.(MessageHandler)
+	if !ok {
+		return fmt.Errorf("role %q does not handle messages", roleFamily)
+	}
+
+	return handler.HandleMessage(c, payload)
+}
+
+// dispatchRoleEvents reads from the group's event bus and calls
+// the appropriate lifecycle method on every registered role.
+func (g *Group) dispatchRoleEvents(events <-chan Event) {
+	for evt := range events {
+		g.mu.RLock()
+		roles := make([]GroupRole, 0, len(g.roles))
+		for _, r := range g.roles {
+			roles = append(roles, r)
+		}
+		g.mu.RUnlock()
+
+		switch e := evt.(type) {
+		case ClientJoinedEvent:
+			for _, r := range roles {
+				r.OnClientJoin(e.Client)
+			}
+		case ClientLeftEvent:
+			for _, r := range roles {
+				r.OnClientLeave(e.ClientID, e.ClientName)
+			}
+		default:
+			// ClientStateChangedEvent and future event types are
+			// dispatched to roles that subscribe to them via other
+			// mechanisms (e.g., the event bus directly). The role
+			// dispatcher only handles lifecycle events.
+		}
+	}
+}
+
+// subscribeInternal creates a subscription while the caller already
+// holds g.mu.Lock. This avoids the deadlock that would occur if we
+// called the public Subscribe (which also takes Lock).
+func (g *Group) subscribeInternal() (<-chan Event, func()) {
+	if g.closed {
+		ch := make(chan Event)
+		close(ch)
+		return ch, func() {}
+	}
+
+	id := g.nextSub
+	g.nextSub++
+	ch := make(chan Event, 32)
+	g.subs[id] = ch
+
+	return ch, func() {
+		g.mu.Lock()
+		defer g.mu.Unlock()
+		if existing, ok := g.subs[id]; ok {
+			delete(g.subs, id)
+			close(existing)
+		}
+	}
+}

--- a/pkg/sendspin/group_role_test.go
+++ b/pkg/sendspin/group_role_test.go
@@ -1,0 +1,147 @@
+// ABOUTME: Tests for GroupRole interface and role dispatch on Group
+// ABOUTME: Verifies RegisterRole, event dispatch, and message routing
+package sendspin
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+)
+
+// testRole is a minimal GroupRole implementation for testing.
+type testRole struct {
+	mu       sync.Mutex
+	role     string
+	joined   []*ServerClient
+	left     []string
+	messages []json.RawMessage
+}
+
+func (r *testRole) Role() string { return r.role }
+
+func (r *testRole) OnClientJoin(c *ServerClient) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.joined = append(r.joined, c)
+}
+
+func (r *testRole) OnClientLeave(id string, name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.left = append(r.left, id)
+}
+
+func (r *testRole) HandleMessage(c *ServerClient, payload json.RawMessage) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.messages = append(r.messages, payload)
+	return nil
+}
+
+func TestGroup_RegisterRole(t *testing.T) {
+	g := NewGroup("test")
+	defer g.Close()
+
+	role := &testRole{role: "controller"}
+	g.RegisterRole(role)
+
+	got := g.GetRole("controller")
+	if got != role {
+		t.Errorf("GetRole returned %v, want registered role", got)
+	}
+	if g.GetRole("nonexistent") != nil {
+		t.Error("GetRole for unregistered role should return nil")
+	}
+}
+
+func TestGroup_RoleDispatchOnJoinLeave(t *testing.T) {
+	g := NewGroup("test")
+	defer g.Close()
+
+	role := &testRole{role: "player"}
+	g.RegisterRole(role)
+
+	sc := &ServerClient{id: "c1", name: "Client 1", roles: []string{"player@v1"}}
+	g.addClient(sc)
+
+	// Give the dispatcher goroutine time to process.
+	time.Sleep(50 * time.Millisecond)
+
+	role.mu.Lock()
+	joinedCount := len(role.joined)
+	var joinedID string
+	if joinedCount > 0 {
+		joinedID = role.joined[0].ID()
+	}
+	role.mu.Unlock()
+
+	if joinedCount != 1 || joinedID != "c1" {
+		t.Errorf("OnClientJoin: got %d calls, want 1 with id=c1", joinedCount)
+	}
+
+	g.removeClient(sc)
+	time.Sleep(50 * time.Millisecond)
+
+	role.mu.Lock()
+	leftCount := len(role.left)
+	var leftID string
+	if leftCount > 0 {
+		leftID = role.left[0]
+	}
+	role.mu.Unlock()
+
+	if leftCount != 1 || leftID != "c1" {
+		t.Errorf("OnClientLeave: got %d calls, want 1 with id=c1", leftCount)
+	}
+}
+
+func TestGroup_RouteMessage(t *testing.T) {
+	g := NewGroup("test")
+	defer g.Close()
+
+	role := &testRole{role: "controller"}
+	g.RegisterRole(role)
+
+	sc := &ServerClient{id: "c1"}
+	payload := json.RawMessage(`{"command":"next"}`)
+
+	err := g.RouteMessage(sc, "controller", payload)
+	if err != nil {
+		t.Fatalf("RouteMessage: %v", err)
+	}
+	if len(role.messages) != 1 {
+		t.Fatalf("HandleMessage called %d times, want 1", len(role.messages))
+	}
+}
+
+func TestGroup_RouteMessageNoHandler(t *testing.T) {
+	g := NewGroup("test")
+	defer g.Close()
+
+	err := g.RouteMessage(&ServerClient{id: "c1"}, "nonexistent", json.RawMessage(`{}`))
+	if err == nil {
+		t.Error("RouteMessage to unregistered role should return error")
+	}
+}
+
+// roleWithoutMessageHandler implements GroupRole but NOT MessageHandler.
+type roleWithoutMessageHandler struct {
+	role string
+}
+
+func (r *roleWithoutMessageHandler) Role() string                         { return r.role }
+func (r *roleWithoutMessageHandler) OnClientJoin(c *ServerClient)         {}
+func (r *roleWithoutMessageHandler) OnClientLeave(id string, name string) {}
+
+func TestGroup_RouteMessageRoleWithoutHandler(t *testing.T) {
+	g := NewGroup("test")
+	defer g.Close()
+
+	g.RegisterRole(&roleWithoutMessageHandler{role: "metadata"})
+
+	err := g.RouteMessage(&ServerClient{id: "c1"}, "metadata", json.RawMessage(`{}`))
+	if err == nil {
+		t.Error("RouteMessage to role without MessageHandler should return error")
+	}
+}

--- a/pkg/sendspin/role_controller.go
+++ b/pkg/sendspin/role_controller.go
@@ -1,0 +1,78 @@
+// ABOUTME: ControllerGroupRole handles client/command messages
+// ABOUTME: Pushes controller capabilities to joining clients
+package sendspin
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/Sendspin/sendspin-go/pkg/protocol"
+)
+
+// ControllerConfig configures the ControllerGroupRole.
+type ControllerConfig struct {
+	// SupportedCommands lists the media commands this server supports
+	// (e.g., "next", "previous", "play", "pause").
+	SupportedCommands []string
+
+	// OnCommand is called when a client sends a controller command.
+	// May be nil if the caller only wants to push capabilities.
+	OnCommand func(client *ServerClient, command string)
+}
+
+// ControllerGroupRole handles the "controller" role family. It pushes
+// controller capabilities (supported commands) to clients that
+// advertise the controller role on join, and dispatches incoming
+// client/command payloads to an OnCommand callback.
+type ControllerGroupRole struct {
+	config ControllerConfig
+}
+
+// NewControllerRole creates a ControllerGroupRole with the given config.
+func NewControllerRole(config ControllerConfig) *ControllerGroupRole {
+	return &ControllerGroupRole{config: config}
+}
+
+func (r *ControllerGroupRole) Role() string { return "controller" }
+
+// OnClientJoin sends controller state (supported commands) to clients
+// that advertise the controller role. Clients without the controller
+// role are skipped.
+func (r *ControllerGroupRole) OnClientJoin(c *ServerClient) {
+	if !c.HasRole("controller") {
+		return
+	}
+
+	state := protocol.ServerStateMessage{
+		Controller: &protocol.ControllerState{
+			SupportedCommands: r.config.SupportedCommands,
+		},
+	}
+
+	if err := c.Send("server/state", state); err != nil {
+		log.Printf("ControllerRole: failed to send state to %s: %v", c.Name(), err)
+	}
+}
+
+func (r *ControllerGroupRole) OnClientLeave(id string, name string) {}
+
+// HandleMessage parses a controller command payload and invokes the
+// OnCommand callback.
+func (r *ControllerGroupRole) HandleMessage(c *ServerClient, payload json.RawMessage) error {
+	var cmd struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal(payload, &cmd); err != nil {
+		return fmt.Errorf("invalid controller command: %w", err)
+	}
+	if cmd.Command == "" {
+		return fmt.Errorf("controller command missing 'command' field")
+	}
+
+	if r.config.OnCommand != nil {
+		r.config.OnCommand(c, cmd.Command)
+	}
+
+	return nil
+}

--- a/pkg/sendspin/role_controller_test.go
+++ b/pkg/sendspin/role_controller_test.go
@@ -1,0 +1,104 @@
+// ABOUTME: Tests for the ControllerGroupRole implementation
+// ABOUTME: Verifies command dispatch and controller state push on join
+package sendspin
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestControllerRole_HandleCommand(t *testing.T) {
+	var received string
+	var receivedClient *ServerClient
+
+	ctrl := NewControllerRole(ControllerConfig{
+		SupportedCommands: []string{"next", "previous"},
+		OnCommand: func(c *ServerClient, command string) {
+			receivedClient = c
+			received = command
+		},
+	})
+
+	sc := &ServerClient{id: "c1", sendChan: make(chan interface{}, 10)}
+	payload := json.RawMessage(`{"command":"next"}`)
+
+	err := ctrl.HandleMessage(sc, payload)
+	if err != nil {
+		t.Fatalf("HandleMessage: %v", err)
+	}
+	if received != "next" {
+		t.Errorf("received command = %q, want %q", received, "next")
+	}
+	if receivedClient == nil || receivedClient.ID() != "c1" {
+		t.Error("OnCommand did not receive the correct client")
+	}
+}
+
+func TestControllerRole_HandleCommandNoCallback(t *testing.T) {
+	ctrl := NewControllerRole(ControllerConfig{
+		SupportedCommands: []string{"next"},
+	})
+
+	err := ctrl.HandleMessage(&ServerClient{id: "c1"}, json.RawMessage(`{"command":"next"}`))
+	if err != nil {
+		t.Errorf("HandleMessage without callback should not error, got %v", err)
+	}
+}
+
+func TestControllerRole_HandleCommandMissingField(t *testing.T) {
+	ctrl := NewControllerRole(ControllerConfig{})
+
+	err := ctrl.HandleMessage(&ServerClient{id: "c1"}, json.RawMessage(`{}`))
+	if err == nil {
+		t.Error("HandleMessage with empty command should return error")
+	}
+}
+
+func TestControllerRole_OnClientJoinSendsState(t *testing.T) {
+	ctrl := NewControllerRole(ControllerConfig{
+		SupportedCommands: []string{"next", "previous", "play", "pause"},
+	})
+
+	sc := &ServerClient{
+		id:       "c1",
+		roles:    []string{"controller@v1"},
+		sendChan: make(chan interface{}, 10),
+	}
+
+	ctrl.OnClientJoin(sc)
+
+	select {
+	case msg := <-sc.sendChan:
+		_ = msg // Verifies a message was enqueued
+	default:
+		t.Fatal("OnClientJoin did not send controller state to client")
+	}
+}
+
+func TestControllerRole_OnClientJoinSkipsNonControllerClient(t *testing.T) {
+	ctrl := NewControllerRole(ControllerConfig{
+		SupportedCommands: []string{"next"},
+	})
+
+	sc := &ServerClient{
+		id:       "c1",
+		roles:    []string{"player@v1"},
+		sendChan: make(chan interface{}, 10),
+	}
+
+	ctrl.OnClientJoin(sc)
+
+	select {
+	case <-sc.sendChan:
+		t.Error("OnClientJoin should not send state to non-controller client")
+	default:
+		// Correct — nothing sent.
+	}
+}
+
+func TestControllerRole_Role(t *testing.T) {
+	ctrl := NewControllerRole(ControllerConfig{})
+	if ctrl.Role() != "controller" {
+		t.Errorf("Role() = %q, want %q", ctrl.Role(), "controller")
+	}
+}

--- a/pkg/sendspin/server_dispatch.go
+++ b/pkg/sendspin/server_dispatch.go
@@ -1,5 +1,5 @@
 // ABOUTME: Message dispatch for incoming client control frames
-// ABOUTME: Routes client/time, client/state, client/goodbye to handlers
+// ABOUTME: Routes client/time, client/state, client/goodbye, client/command to handlers
 package sendspin
 
 import (
@@ -23,6 +23,8 @@ func (s *Server) handleClientMessage(c *ServerClient, data []byte) {
 		s.handleClientState(c, msg.Payload)
 	case "client/goodbye":
 		s.handleClientGoodbye(c, msg.Payload)
+	case "client/command":
+		s.handleClientCommand(c, msg.Payload)
 	default:
 		if s.config.Debug {
 			log.Printf("Unknown message type: %s", msg.Type)
@@ -87,6 +89,29 @@ func (s *Server) handleClientState(c *ServerClient, payload interface{}) {
 			Volume: stateMsg.Player.Volume,
 			Muted:  stateMsg.Player.Muted,
 		})
+	}
+}
+
+func (s *Server) handleClientCommand(c *ServerClient, payload interface{}) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		log.Printf("Error marshaling client/command payload: %v", err)
+		return
+	}
+
+	// client/command payloads are role-keyed: {"controller": {...}, "player": {...}}
+	var rolePayloads map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rolePayloads); err != nil {
+		log.Printf("Error unmarshaling client/command: %v", err)
+		return
+	}
+
+	for roleFamily, roleData := range rolePayloads {
+		if err := s.defaultGroup.RouteMessage(c, roleFamily, roleData); err != nil {
+			if s.config.Debug {
+				log.Printf("client/command routing error for role %s: %v", roleFamily, err)
+			}
+		}
 	}
 }
 

--- a/pkg/sendspin/server_test.go
+++ b/pkg/sendspin/server_test.go
@@ -471,6 +471,93 @@ func TestServer_GroupReceivesEventsFromRealHandshake(t *testing.T) {
 	}
 }
 
+// TestServer_ControllerCommandEndToEnd exercises the full client/command
+// pipeline: Server + ControllerGroupRole + real WebSocket handshake +
+// client/command message → OnCommand callback fires.
+func TestServer_ControllerCommandEndToEnd(t *testing.T) {
+	commandReceived := make(chan string, 1)
+
+	server, err := NewServer(ServerConfig{
+		Port:   8934,
+		Name:   "Controller Test",
+		Source: NewTestTone(48000, 2),
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	ctrl := NewControllerRole(ControllerConfig{
+		SupportedCommands: []string{"next", "previous"},
+		OnCommand: func(c *ServerClient, command string) {
+			commandReceived <- command
+		},
+	})
+	server.Group().RegisterRole(ctrl)
+
+	errChan := make(chan error, 1)
+	go func() { errChan <- server.Start() }()
+	defer func() {
+		server.Stop()
+		select {
+		case <-errChan:
+		case <-time.After(5 * time.Second):
+			t.Error("server stop timeout")
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://localhost:8934/sendspin", nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	hello := protocol.Message{
+		Type: "client/hello",
+		Payload: protocol.ClientHello{
+			ClientID:       "ctrl-test-client",
+			Name:           "Controller Test Client",
+			Version:        1,
+			SupportedRoles: []string{"controller@v1"},
+		},
+	}
+	if err := conn.WriteJSON(hello); err != nil {
+		t.Fatalf("write hello: %v", err)
+	}
+
+	// Drain the server/hello response.
+	var msg protocol.Message
+	if err := conn.ReadJSON(&msg); err != nil {
+		t.Fatalf("read server/hello: %v", err)
+	}
+
+	// Give the join event time to dispatch to the controller role.
+	time.Sleep(100 * time.Millisecond)
+
+	// Send a controller command.
+	cmd := protocol.Message{
+		Type: "client/command",
+		Payload: map[string]interface{}{
+			"controller": map[string]interface{}{
+				"command": "next",
+			},
+		},
+	}
+	if err := conn.WriteJSON(cmd); err != nil {
+		t.Fatalf("write client/command: %v", err)
+	}
+
+	select {
+	case got := <-commandReceived:
+		if got != "next" {
+			t.Errorf("command = %q, want %q", got, "next")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for OnCommand callback")
+	}
+}
+
 func TestServerDuplicateClientID(t *testing.T) {
 	source := NewTestTone(48000, 2)
 


### PR DESCRIPTION
Third milestone of #61. Adds the `GroupRole` interface, a role dispatcher on `Group`, and the first concrete role — `ControllerGroupRole` — which handles `client/command` messages. This is the Gap 5 feature from conformance#16 that the adapter currently hand-rolls.

## Why

M2 (#64) gave us the `Group` type with a typed event bus, but nothing consumed those events. aiosendspin's architecture has per-role handlers (`ControllerGroupRole`, `MetadataGroupRole`, etc.) that subscribe to group events and own the business logic for their role family. M3 is that layer: an interface, a dispatcher, and one real role to prove the plumbing works end-to-end.

## What's new

### `GroupRole` interface + `MessageHandler` (`group_role.go`)
- `GroupRole` has three methods: `Role() string`, `OnClientJoin(*ServerClient)`, `OnClientLeave(id, name string)`.
- `MessageHandler` is a separate optional interface with `HandleMessage(*ServerClient, json.RawMessage) error`. Roles that don't handle messages (e.g., a future metadata role that only pushes state) don't need to stub it.
- `Group` gains `RegisterRole(GroupRole)`, `GetRole(family string) GroupRole`, and `RouteMessage(c, roleFamily, payload) error`.
- An internal event dispatcher goroutine subscribes to the group's event bus and fans `ClientJoinedEvent` / `ClientLeftEvent` to all registered roles.

### `client/command` routing (`server_dispatch.go`)
- `handleClientMessage` now handles `client/command`. Payloads are role-keyed JSON objects (`{"controller": {"command": "next"}}`). Each key is routed to the matching `GroupRole` via `Group.RouteMessage`.

### `ControllerGroupRole` (`role_controller.go`)
- First concrete role implementation.
- `OnClientJoin`: sends `server/state` with controller capabilities (supported commands list) to clients that advertise `controller@v1`. Non-controller clients are skipped.
- `HandleMessage`: parses `{"command": "next"}` and invokes the `OnCommand` callback.
- Config-driven: `ControllerConfig{SupportedCommands, OnCommand}`.

## How it fits together

```
WebSocket client
  → client/command {"controller": {"command": "next"}}
  → handleClientMessage (server_dispatch.go)
  → s.defaultGroup.RouteMessage(c, "controller", payload)
  → ControllerGroupRole.HandleMessage
  → OnCommand callback fires
```

And on join:
```
WebSocket client connects with controller@v1
  → handleConnection → defaultGroup.addClient(c)
  → ClientJoinedEvent → role dispatcher
  → ControllerGroupRole.OnClientJoin
  → c.Send("server/state", {controller: {supported_commands: [...]}})
```

## What's NOT in this PR

- `MetadataGroupRole`, `PlayerGroupRole`, `ArtworkGroupRole` — each gets its own follow-up
- `ServerConfig.SupportedRoles` filtering in `activateRoles` (M4)
- Refactoring `addClientToStream` to use roles (M5)
- Conformance adapter port (M6)

## Test plan
- [x] `go test ./... -count=1 -race` — all packages green, no races
- [x] 5 unit tests for GroupRole dispatcher (RegisterRole, event dispatch, RouteMessage, missing handler, wrong handler type)
- [x] 6 unit tests for ControllerGroupRole (command dispatch, no callback, missing field, join sends state, join skips non-controller, Role() name)
- [x] End-to-end integration test: real server + real WebSocket + `client/command` → `OnCommand` callback fires on port 8934
