### PR TITLE
feat(server): M4 — configurable SupportedRoles

### DIFF
--- a/pkg/sendspin/server.go
+++ b/pkg/sendspin/server.go
@@ -51,6 +51,12 @@ type ServerConfig struct {
 	// clients advertising _sendspin._tcp and dial out to them.
 	// See https://www.sendspin-audio.com/spec/ — "server-initiated" mode.
 	DiscoverClients bool
+
+	// SupportedRoles lists the role families this server activates.
+	// When nil, defaults to ["player", "metadata"] for backward compat.
+	// Roles registered via Group.RegisterRole are also activated
+	// regardless of this list.
+	SupportedRoles []string
 }
 
 type Server struct {
@@ -101,6 +107,9 @@ func NewServer(config ServerConfig) (*Server, error) {
 	}
 	if config.Source == nil {
 		return nil, fmt.Errorf("audio source is required")
+	}
+	if config.SupportedRoles == nil {
+		config.SupportedRoles = []string{"player", "metadata"}
 	}
 
 	mux := http.NewServeMux()
@@ -465,18 +474,30 @@ func (s *Server) removeClient(c *ServerClient) {
 	close(c.done)
 }
 
-// activateRoles filters a client's advertised role list down to the roles this
-// server actually implements, keeping only the first version of each role family
-// so "player@v1" wins over a later "player@v2" entry in the same hello.
-//
-// Implemented: player (audio streaming), metadata (track info via server/state).
-// Not implemented: visualizer, artwork, controller.
+// activateRoles filters a client's advertised role list down to the roles
+// this server supports (via config + registered GroupRoles), keeping only
+// the first version of each role family so "player@v1" wins over a later
+// "player@v2" entry in the same hello.
 func (s *Server) activateRoles(supportedRoles []string) []string {
+	// Build the set of role families this server supports.
+	allowed := make(map[string]bool)
+	for _, family := range s.config.SupportedRoles {
+		allowed[family] = true
+	}
+
+	// Roles registered on the Group are also allowed.
+	if s.defaultGroup != nil {
+		s.defaultGroup.mu.RLock()
+		for family := range s.defaultGroup.roles {
+			allowed[family] = true
+		}
+		s.defaultGroup.mu.RUnlock()
+	}
+
 	seen := make(map[string]bool)
 	result := make([]string, 0, len(supportedRoles))
 
 	for _, role := range supportedRoles {
-		// Extract role family (e.g., "player" from "player@v1")
 		family := role
 		if idx := strings.Index(role, "@"); idx > 0 {
 			family = role[:idx]
@@ -486,8 +507,7 @@ func (s *Server) activateRoles(supportedRoles []string) []string {
 			continue
 		}
 
-		switch family {
-		case "player", "metadata":
+		if allowed[family] {
 			seen[family] = true
 			result = append(result, role)
 		}

--- a/pkg/sendspin/server_test.go
+++ b/pkg/sendspin/server_test.go
@@ -558,6 +558,96 @@ func TestServer_ControllerCommandEndToEnd(t *testing.T) {
 	}
 }
 
+// TestServer_ActivateRolesDefaultsToPlayerMetadata confirms backward
+// compat: when ServerConfig.SupportedRoles is nil, activateRoles still
+// accepts "player" and "metadata" and rejects unknown families.
+func TestServer_ActivateRolesDefault(t *testing.T) {
+	s, err := NewServer(ServerConfig{
+		Port:   0,
+		Name:   "test",
+		Source: NewTestTone(48000, 2),
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	got := s.activateRoles([]string{"player@v1", "metadata@v1", "controller@v1", "artwork@v1"})
+
+	want := map[string]bool{"player@v1": true, "metadata@v1": true}
+	gotSet := make(map[string]bool)
+	for _, r := range got {
+		gotSet[r] = true
+	}
+	if len(gotSet) != len(want) {
+		t.Errorf("activateRoles default = %v, want player+metadata only", got)
+	}
+	for r := range want {
+		if !gotSet[r] {
+			t.Errorf("missing expected role %s in %v", r, got)
+		}
+	}
+}
+
+// TestServer_ActivateRolesFromConfig confirms that explicitly listing
+// roles in ServerConfig.SupportedRoles controls what gets activated.
+func TestServer_ActivateRolesFromConfig(t *testing.T) {
+	s, err := NewServer(ServerConfig{
+		Port:           0,
+		Name:           "test",
+		Source:         NewTestTone(48000, 2),
+		SupportedRoles: []string{"player", "artwork"},
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	got := s.activateRoles([]string{"player@v1", "metadata@v1", "artwork@v1"})
+
+	gotSet := make(map[string]bool)
+	for _, r := range got {
+		gotSet[r] = true
+	}
+	if gotSet["metadata@v1"] {
+		t.Error("metadata should NOT be active when not in SupportedRoles")
+	}
+	if !gotSet["player@v1"] || !gotSet["artwork@v1"] {
+		t.Errorf("expected player+artwork, got %v", got)
+	}
+}
+
+// TestServer_ActivateRolesFromGroupRegistry confirms that registering a
+// GroupRole on the server's Group auto-activates that role family even
+// when it's not in ServerConfig.SupportedRoles.
+func TestServer_ActivateRolesFromGroupRegistry(t *testing.T) {
+	s, err := NewServer(ServerConfig{
+		Port:   0,
+		Name:   "test",
+		Source: NewTestTone(48000, 2),
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	// Register a controller role — should auto-activate "controller".
+	ctrl := NewControllerRole(ControllerConfig{
+		SupportedCommands: []string{"next"},
+	})
+	s.Group().RegisterRole(ctrl)
+
+	got := s.activateRoles([]string{"player@v1", "controller@v1"})
+
+	gotSet := make(map[string]bool)
+	for _, r := range got {
+		gotSet[r] = true
+	}
+	if !gotSet["player@v1"] {
+		t.Error("player should be active (default)")
+	}
+	if !gotSet["controller@v1"] {
+		t.Error("controller should be active (registered via GroupRole)")
+	}
+}
+
 func TestServerDuplicateClientID(t *testing.T) {
 	source := NewTestTone(48000, 2)
 


### PR DESCRIPTION
Closes the M4 milestone of #61. One commit, one concept:  is now configurable and registry-aware instead of hardcoded.

## What changed

 gains a  field (defaults to  for backward compat).  now activates a role family if it appears in config OR has a  registered on the server's . This means registering a  (M3, #65) automatically makes `controller@v1` appear in `server/hello` `active_roles` — no config change needed.

## Why this matters

Before M4, registering a controller role had no effect on the hello handshake — the server still told connecting clients it only supported player and metadata. Now the handshake reflects reality. This is the last piece needed before M5 can start extracting player/metadata behavior into proper GroupRole implementations.

## Test plan
- [x] `go test ./... -count=1 -race` — all packages green
- [x] Three new tests: default backward compat, explicit config override, auto-activation from registered GroupRole
- [x] Existing `TestServerClientConnection` still passes (sends player@v1 which is in the default set)
