### PR TITLE
feat(sendspin): export ServerClient constructor + binary frame helpers

### DIFF
--- a/pkg/sendspin/server_client.go
+++ b/pkg/sendspin/server_client.go
@@ -3,9 +3,11 @@
 package sendspin
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/Sendspin/sendspin-go/internal/server"
 	"github.com/Sendspin/sendspin-go/pkg/audio"
@@ -136,4 +138,84 @@ func (c *ServerClient) Codec() string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.codec
+}
+
+// NewServerClientFromConn wraps an existing WebSocket connection in a
+// ServerClient and starts a background writer goroutine. This is the
+// entry point for code that accepts its own WebSocket connections
+// (e.g., conformance adapters) and wants to use the typed Send/SendBinary
+// API without constructing a full Server.
+//
+// The caller is responsible for reading from the connection; the writer
+// goroutine handles outbound messages via Send/SendBinary. Call Close()
+// when done to stop the writer and release resources.
+func NewServerClientFromConn(conn *websocket.Conn, id, name string, roles []string, capabilities *protocol.PlayerV1Support) *ServerClient {
+	c := &ServerClient{
+		id:           id,
+		name:         name,
+		conn:         conn,
+		roles:        roles,
+		capabilities: capabilities,
+		state:        "synchronized",
+		volume:       100,
+		sendChan:     make(chan interface{}, 100),
+		done:         make(chan struct{}),
+	}
+	go c.runWriter()
+	return c
+}
+
+// runWriter drains the sendChan and writes messages to the WebSocket.
+// Exits when the done channel is closed (via Close). This is the
+// standalone equivalent of Server.clientWriter for ServerClients
+// created via NewServerClientFromConn.
+func (c *ServerClient) runWriter() {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	const writeDeadline = 10 * time.Second
+
+	for {
+		select {
+		case msg := <-c.sendChan:
+			switch v := msg.(type) {
+			case []byte:
+				c.conn.SetWriteDeadline(time.Now().Add(writeDeadline))
+				if err := c.conn.WriteMessage(websocket.BinaryMessage, v); err != nil {
+					return
+				}
+			default:
+				data, err := json.Marshal(v)
+				if err != nil {
+					continue
+				}
+				c.conn.SetWriteDeadline(time.Now().Add(writeDeadline))
+				if err := c.conn.WriteMessage(websocket.TextMessage, data); err != nil {
+					return
+				}
+			}
+
+		case <-ticker.C:
+			if err := c.conn.WriteControl(websocket.PingMessage, []byte{}, time.Now().Add(10*time.Second)); err != nil {
+				return
+			}
+
+		case <-c.done:
+			return
+		}
+	}
+}
+
+// Close stops the writer goroutine and signals that this ServerClient
+// is done. Safe to call multiple times. Does NOT close the underlying
+// WebSocket connection — the caller owns that lifecycle.
+func (c *ServerClient) Close() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	select {
+	case <-c.done:
+		// Already closed
+	default:
+		close(c.done)
+	}
 }

--- a/pkg/sendspin/server_client_test.go
+++ b/pkg/sendspin/server_client_test.go
@@ -3,7 +3,14 @@
 package sendspin
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/Sendspin/sendspin-go/pkg/protocol"
+	"github.com/gorilla/websocket"
 )
 
 // TestServerClient_Accessors confirms that the six exported accessors on
@@ -142,4 +149,79 @@ func TestServerClient_StateAccessorsConcurrent(t *testing.T) {
 		_ = sc.State()
 	}
 	<-done
+}
+
+// TestNewServerClientFromConn_SendAndClose confirms the constructor +
+// writer + Close lifecycle works: messages enqueued via Send arrive on
+// the WebSocket, and Close stops the writer without panic.
+func TestNewServerClientFromConn_SendAndClose(t *testing.T) {
+	// Use an in-process WebSocket pair via httptest.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		// Read the one message we expect.
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			t.Errorf("server read: %v", err)
+			return
+		}
+		var msg protocol.Message
+		if err := json.Unmarshal(data, &msg); err != nil {
+			t.Errorf("unmarshal: %v", err)
+			return
+		}
+		if msg.Type != "server/hello" {
+			t.Errorf("got type %q, want server/hello", msg.Type)
+		}
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + srv.URL[len("http"):]
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	sc := NewServerClientFromConn(conn, "test-id", "Test", []string{"player@v1"}, nil)
+
+	if err := sc.Send("server/hello", map[string]string{"name": "test"}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	// Give the writer time to flush.
+	time.Sleep(50 * time.Millisecond)
+
+	sc.Close()
+	// Double-close should not panic.
+	sc.Close()
+}
+
+// TestCreateAudioChunk confirms the exported helper produces the
+// correct binary frame format.
+func TestCreateAudioChunk(t *testing.T) {
+	chunk := CreateAudioChunk(1000000, []byte{0xAA, 0xBB})
+	if chunk[0] != AudioChunkMessageType {
+		t.Errorf("type byte = %d, want %d", chunk[0], AudioChunkMessageType)
+	}
+	if len(chunk) != 9+2 {
+		t.Errorf("len = %d, want 11", len(chunk))
+	}
+}
+
+// TestCreateArtworkChunk confirms channel mapping and frame format.
+func TestCreateArtworkChunk(t *testing.T) {
+	chunk := CreateArtworkChunk(2, 5000000, []byte{0xFF})
+	expectedType := byte(protocol.ArtworkChannel0MessageType + 2)
+	if chunk[0] != expectedType {
+		t.Errorf("type byte = %d, want %d", chunk[0], expectedType)
+	}
+	if len(chunk) != protocol.BinaryMessageHeaderSize+1 {
+		t.Errorf("len = %d, want %d", len(chunk), protocol.BinaryMessageHeaderSize+1)
+	}
 }

--- a/pkg/sendspin/server_stream.go
+++ b/pkg/sendspin/server_stream.go
@@ -92,7 +92,7 @@ func (s *Server) generateAndSendChunk() {
 			audioData = encodePCM(samples[:n])
 		}
 
-		chunk := createAudioChunk(playbackTime, audioData)
+		chunk := CreateAudioChunk(playbackTime, audioData)
 
 		if err := c.SendBinary(chunk); err != nil {
 			if s.config.Debug {
@@ -148,13 +148,23 @@ func strPtr(s string) *string {
 	return &s
 }
 
-// createAudioChunk packs timestamp + payload into a Sendspin binary frame:
+// CreateAudioChunk packs timestamp + payload into a Sendspin binary frame:
 // [1 byte message type][8 byte big-endian timestamp (µs)][audio bytes].
-func createAudioChunk(timestamp int64, audioData []byte) []byte {
+func CreateAudioChunk(timestamp int64, audioData []byte) []byte {
 	chunk := make([]byte, 1+8+len(audioData))
 	chunk[0] = AudioChunkMessageType
 	binary.BigEndian.PutUint64(chunk[1:9], uint64(timestamp))
 	copy(chunk[9:], audioData)
+	return chunk
+}
+
+// CreateArtworkChunk packs an artwork frame: [1 byte message type][8 byte timestamp (us)][image bytes].
+// Channel is 0-3, mapping to the artwork channel message types.
+func CreateArtworkChunk(channel int, timestamp int64, imageData []byte) []byte {
+	chunk := make([]byte, protocol.BinaryMessageHeaderSize+len(imageData))
+	chunk[0] = byte(protocol.ArtworkChannel0MessageType + channel)
+	binary.BigEndian.PutUint64(chunk[1:protocol.BinaryMessageHeaderSize], uint64(timestamp))
+	copy(chunk[protocol.BinaryMessageHeaderSize:], imageData)
 	return chunk
 }
 


### PR DESCRIPTION
Exports from `pkg/sendspin` that the conformance adapter needs to stop hand-rolling protocol plumbing:

- **`NewServerClientFromConn(conn, id, name, roles, capabilities)`** — wraps a raw WebSocket in a `ServerClient` with typed `Send`/`SendBinary` + background writer goroutine. Replaces the adapter's `writeEnvelope`/`sendJSON`/`sendBinary`/`writeMu` pattern.
- **`ServerClient.Close()`** — stops the writer goroutine cleanly. Does not close the underlying WebSocket.
- **`CreateAudioChunk(timestamp, audioData)`** — exported from the previously-unexported helper.
- **`CreateArtworkChunk(channel, timestamp, imageData)`** — new, eliminates duplication in the adapter.

## Test plan
- [x] `go test ./... -count=1 -race` green
- [x] New tests: in-process WebSocket pair for Send+Close lifecycle, frame format assertions for both chunk builders
