### PR TITLE
feat(protocol): add CGO-free ServerConn + binary frame helpers

### DIFF
--- a/pkg/protocol/server_conn.go
+++ b/pkg/protocol/server_conn.go
@@ -1,0 +1,145 @@
+// ABOUTME: ServerConn wraps a WebSocket for server-side typed message sending
+// ABOUTME: CGO-free alternative to sendspin.ServerClient for adapters and tools
+package protocol
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// ServerConn wraps an accepted WebSocket connection with typed Send and
+// SendBinary methods plus a background writer goroutine. It is the
+// lightweight, CGO-free counterpart to sendspin.ServerClient — use it
+// when you need typed protocol I/O without the full server runtime
+// (e.g., conformance adapters, CLI tools, test harnesses).
+//
+// The zero value is not usable — construct via NewServerConn.
+type ServerConn struct {
+	conn     *websocket.Conn
+	id       string
+	name     string
+	sendChan chan interface{}
+	done     chan struct{}
+	once     sync.Once
+}
+
+// NewServerConn wraps an existing WebSocket connection and starts a
+// background writer goroutine. Call Close() when done to stop the
+// writer. Does NOT close the underlying WebSocket — the caller owns
+// that lifecycle.
+func NewServerConn(conn *websocket.Conn, id, name string) *ServerConn {
+	sc := &ServerConn{
+		conn:     conn,
+		id:       id,
+		name:     name,
+		sendChan: make(chan interface{}, 100),
+		done:     make(chan struct{}),
+	}
+	go sc.runWriter()
+	return sc
+}
+
+// ID returns the identifier passed to NewServerConn.
+func (sc *ServerConn) ID() string { return sc.id }
+
+// Name returns the name passed to NewServerConn.
+func (sc *ServerConn) Name() string { return sc.name }
+
+// Send enqueues a typed control message (JSON envelope) for
+// transmission. Returns an error immediately if the send buffer is
+// full. The message is wrapped in a {"type": msgType, "payload": ...}
+// envelope by the writer goroutine.
+func (sc *ServerConn) Send(msgType string, payload interface{}) error {
+	msg := Message{
+		Type:    msgType,
+		Payload: payload,
+	}
+	select {
+	case sc.sendChan <- msg:
+		return nil
+	default:
+		return fmt.Errorf("send buffer full")
+	}
+}
+
+// SendBinary enqueues a raw binary frame for transmission. Returns an
+// error immediately if the send buffer is full.
+func (sc *ServerConn) SendBinary(data []byte) error {
+	select {
+	case sc.sendChan <- data:
+		return nil
+	default:
+		return fmt.Errorf("send buffer full")
+	}
+}
+
+// Close stops the writer goroutine. Safe to call multiple times. Does
+// NOT close the underlying WebSocket connection.
+func (sc *ServerConn) Close() {
+	sc.once.Do(func() {
+		close(sc.done)
+	})
+}
+
+func (sc *ServerConn) runWriter() {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	const writeDeadline = 10 * time.Second
+
+	for {
+		select {
+		case msg := <-sc.sendChan:
+			switch v := msg.(type) {
+			case []byte:
+				sc.conn.SetWriteDeadline(time.Now().Add(writeDeadline))
+				if err := sc.conn.WriteMessage(websocket.BinaryMessage, v); err != nil {
+					return
+				}
+			default:
+				data, err := json.Marshal(v)
+				if err != nil {
+					continue
+				}
+				sc.conn.SetWriteDeadline(time.Now().Add(writeDeadline))
+				if err := sc.conn.WriteMessage(websocket.TextMessage, data); err != nil {
+					return
+				}
+			}
+
+		case <-ticker.C:
+			if err := sc.conn.WriteControl(websocket.PingMessage, []byte{}, time.Now().Add(10*time.Second)); err != nil {
+				return
+			}
+
+		case <-sc.done:
+			return
+		}
+	}
+}
+
+// CreateAudioChunk packs timestamp + payload into a Sendspin binary audio
+// frame: [1 byte message type][8 byte big-endian timestamp (µs)][audio bytes].
+func CreateAudioChunk(timestamp int64, audioData []byte) []byte {
+	chunk := make([]byte, BinaryMessageHeaderSize+len(audioData))
+	chunk[0] = AudioChunkMessageType
+	binary.BigEndian.PutUint64(chunk[1:BinaryMessageHeaderSize], uint64(timestamp))
+	copy(chunk[BinaryMessageHeaderSize:], audioData)
+	return chunk
+}
+
+// CreateArtworkChunk packs an artwork frame: [1 byte message type][8 byte
+// timestamp (µs)][image bytes]. Channel is 0-3, mapping to the artwork
+// channel message types (8-11).
+func CreateArtworkChunk(channel int, timestamp int64, imageData []byte) []byte {
+	chunk := make([]byte, BinaryMessageHeaderSize+len(imageData))
+	chunk[0] = byte(ArtworkChannel0MessageType + channel)
+	binary.BigEndian.PutUint64(chunk[1:BinaryMessageHeaderSize], uint64(timestamp))
+	copy(chunk[BinaryMessageHeaderSize:], imageData)
+	return chunk
+}

--- a/pkg/protocol/server_conn_test.go
+++ b/pkg/protocol/server_conn_test.go
@@ -1,0 +1,146 @@
+// ABOUTME: Tests for ServerConn typed connection wrapper
+// ABOUTME: Verifies Send/SendBinary/Close lifecycle and frame helpers
+package protocol
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestServerConn_SendAndClose(t *testing.T) {
+	received := make(chan Message, 1)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			t.Errorf("server read: %v", err)
+			return
+		}
+		var msg Message
+		if err := json.Unmarshal(data, &msg); err != nil {
+			t.Errorf("unmarshal: %v", err)
+			return
+		}
+		received <- msg
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + server.URL[len("http"):]
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	sc := NewServerConn(conn, "test-id", "Test Server")
+
+	if err := sc.Send("server/hello", map[string]string{"name": "test"}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	select {
+	case msg := <-received:
+		if msg.Type != "server/hello" {
+			t.Errorf("type = %q, want server/hello", msg.Type)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for message")
+	}
+
+	sc.Close()
+	sc.Close() // double-close must not panic
+}
+
+func TestServerConn_SendBinary(t *testing.T) {
+	received := make(chan []byte, 1)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		msgType, data, err := conn.ReadMessage()
+		if err != nil {
+			t.Errorf("server read: %v", err)
+			return
+		}
+		if msgType != websocket.BinaryMessage {
+			t.Errorf("message type = %d, want binary", msgType)
+		}
+		received <- data
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + server.URL[len("http"):]
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	sc := NewServerConn(conn, "test-id", "Test")
+	defer sc.Close()
+
+	chunk := CreateAudioChunk(1000000, []byte{0xAA, 0xBB})
+	if err := sc.SendBinary(chunk); err != nil {
+		t.Fatalf("SendBinary: %v", err)
+	}
+
+	select {
+	case data := <-received:
+		if data[0] != AudioChunkMessageType {
+			t.Errorf("type byte = %d, want %d", data[0], AudioChunkMessageType)
+		}
+		if len(data) != BinaryMessageHeaderSize+2 {
+			t.Errorf("len = %d, want %d", len(data), BinaryMessageHeaderSize+2)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for binary message")
+	}
+}
+
+func TestServerConn_Accessors(t *testing.T) {
+	sc := &ServerConn{id: "abc", name: "Test"}
+	if sc.ID() != "abc" {
+		t.Errorf("ID() = %q, want abc", sc.ID())
+	}
+	if sc.Name() != "Test" {
+		t.Errorf("Name() = %q, want Test", sc.Name())
+	}
+}
+
+func TestCreateAudioChunk_Format(t *testing.T) {
+	chunk := CreateAudioChunk(1000000, []byte{0xAA, 0xBB})
+	if chunk[0] != AudioChunkMessageType {
+		t.Errorf("type = %d, want %d", chunk[0], AudioChunkMessageType)
+	}
+	if len(chunk) != BinaryMessageHeaderSize+2 {
+		t.Errorf("len = %d, want %d", len(chunk), BinaryMessageHeaderSize+2)
+	}
+}
+
+func TestCreateArtworkChunk_Format(t *testing.T) {
+	chunk := CreateArtworkChunk(2, 5000000, []byte{0xFF})
+	expectedType := byte(ArtworkChannel0MessageType + 2)
+	if chunk[0] != expectedType {
+		t.Errorf("type = %d, want %d", chunk[0], expectedType)
+	}
+	if len(chunk) != BinaryMessageHeaderSize+1 {
+		t.Errorf("len = %d, want %d", len(chunk), BinaryMessageHeaderSize+1)
+	}
+}


### PR DESCRIPTION
CGO-free server-side connection wrapper in `pkg/protocol`, replacing the `pkg/sendspin` exports from #68 that inadvertently pulled in opus/malgo CGO dependencies.

## What's new

- **`protocol.ServerConn`** — wraps a WebSocket with typed `Send(msgType, payload)` / `SendBinary(data)` + background writer goroutine. Same semantics as `sendspin.ServerClient` but zero CGO deps. For conformance adapters, CLI tools, and test harnesses.
- **`protocol.CreateAudioChunk(timestamp, audioData)`** — builds spec-compliant binary audio frames.
- **`protocol.CreateArtworkChunk(channel, timestamp, imageData)`** — builds artwork binary frames.

## Why not `pkg/sendspin`?

`pkg/sendspin.ServerClient` references `*server.OpusEncoder` and `*audio.Resampler` in its struct fields, so importing the package transitively pulls in CGO. The conformance adapter never needs those — it just needs typed message sending and frame building.

## Test plan
- [x] `go test ./... -count=1 -race` green
- [x] `go list -deps ./pkg/protocol/` confirms zero CGO/opus/malgo deps
- [x] 5 new tests: Send+Close lifecycle, SendBinary, accessors, audio chunk format, artwork chunk format
