### PR TITLE
feat: daemon mode + systemd integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # ABOUTME: Provides targets for building, testing, and cleaning binaries
 
 .PHONY: all build player server test test-verbose test-coverage lint clean install \
-	build-all build-linux build-darwin help conformance
+	build-all build-linux build-darwin help conformance install-daemon uninstall-daemon
 
 # Version from git tag or default
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -81,6 +81,34 @@ build-darwin:
 	GOOS=darwin GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o bin/sendspin-server-darwin-amd64 ./cmd/sendspin-server
 	GOOS=darwin GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o bin/sendspin-server-darwin-arm64 ./cmd/sendspin-server
 
+# Install as a systemd daemon (Linux only, requires root)
+install-daemon: player
+	@echo "Installing sendspin-player daemon..."
+	install -m 755 sendspin-player /usr/local/bin/sendspin-player
+	install -m 644 dist/systemd/sendspin-player.service /etc/systemd/system/sendspin-player.service
+	@if [ ! -f /etc/default/sendspin-player ]; then \
+		install -m 644 dist/systemd/sendspin-player.env /etc/default/sendspin-player; \
+		echo "Created /etc/default/sendspin-player — edit this file to configure."; \
+	else \
+		echo "/etc/default/sendspin-player already exists, not overwriting."; \
+	fi
+	systemctl daemon-reload
+	@echo ""
+	@echo "Installed. To start:"
+	@echo "  sudo systemctl enable --now sendspin-player"
+	@echo ""
+	@echo "Configure via /etc/default/sendspin-player"
+
+# Uninstall the systemd daemon
+uninstall-daemon:
+	@echo "Removing sendspin-player daemon..."
+	-systemctl stop sendspin-player 2>/dev/null
+	-systemctl disable sendspin-player 2>/dev/null
+	rm -f /etc/systemd/system/sendspin-player.service
+	rm -f /usr/local/bin/sendspin-player
+	systemctl daemon-reload
+	@echo "Removed. /etc/default/sendspin-player left in place (manual cleanup if desired)."
+
 # Conformance test suite — runs the Sendspin protocol conformance harness
 # against the local sendspin-go checkout. Mirrors what CI does so contributors
 # and conformance maintainers can reproduce CI results locally.
@@ -130,6 +158,8 @@ help:
 	@echo "  make build-all    - Build all platforms"
 	@echo "  make build-linux  - Build Linux binaries"
 	@echo "  make build-darwin - Build macOS binaries"
+	@echo "  make install-daemon   - Install as systemd service (Linux, requires root)"
+	@echo "  make uninstall-daemon - Remove systemd service"
 	@echo "  make conformance  - Run protocol conformance suite (clones ../conformance on first run)"
 	@echo ""
 	@echo "Version: $(VERSION)"

--- a/dist/systemd/sendspin-player.env
+++ b/dist/systemd/sendspin-player.env
@@ -1,0 +1,27 @@
+# /etc/default/sendspin-player
+#
+# Environment file for the sendspin-player systemd service.
+# Uncomment and adjust the options below as needed.
+#
+# All flags are passed via SENDSPIN_PLAYER_OPTS.
+
+# Player name shown on the server (default: <hostname>-sendspin-player)
+# SENDSPIN_PLAYER_OPTS="--name 'Living Room'"
+
+# Connect to a specific server instead of mDNS discovery
+# SENDSPIN_PLAYER_OPTS="--server 192.168.1.100:8927"
+
+# Playback buffer size in milliseconds (default: 150)
+# SENDSPIN_PLAYER_OPTS="--buffer-ms 200"
+
+# Static delay compensation for Bluetooth/AVR hardware latency (ms)
+# SENDSPIN_PLAYER_OPTS="--static-delay-ms 250"
+
+# Override device identity sent during handshake
+# SENDSPIN_PLAYER_OPTS="--product-name 'My Speaker' --manufacturer 'Acme'"
+
+# Disable automatic reconnect (player exits on connection loss)
+# SENDSPIN_PLAYER_OPTS="--no-reconnect"
+
+# Combine multiple options:
+# SENDSPIN_PLAYER_OPTS="--name 'Kitchen' --server 192.168.1.100:8927 --buffer-ms 200"

--- a/dist/systemd/sendspin-player.service
+++ b/dist/systemd/sendspin-player.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Sendspin Player
+Documentation=https://github.com/Sendspin/sendspin-go
+After=network-online.target sound.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/sendspin-player --daemon
+Restart=on-failure
+RestartSec=5
+EnvironmentFile=-/etc/default/sendspin-player
+# Pass CLI flags via SENDSPIN_PLAYER_OPTS in the environment file.
+# ExecStart is overridden below to append them.
+ExecStart=
+ExecStart=/usr/local/bin/sendspin-player --daemon $SENDSPIN_PLAYER_OPTS
+
+# Hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/main.go
+++ b/main.go
@@ -33,25 +33,32 @@ var (
 	productName   = flag.String("product-name", "", "Override the product name sent in device_info (default: compiled-in identity)")
 	manufacturer  = flag.String("manufacturer", "", "Override the manufacturer sent in device_info (default: compiled-in identity)")
 	noReconnect   = flag.Bool("no-reconnect", false, "Disable automatic reconnect on connection loss")
+	daemon        = flag.Bool("daemon", false, "Daemon mode: log to stdout only (journalctl-friendly), no TUI, no log file")
 )
 
 func main() {
 	flag.Parse()
 
-	// Use TUI if not explicitly disabled; -stream-logs is an alias for -no-tui
-	useTUI := !(*noTUI || *streamLogs)
+	// Use TUI if not explicitly disabled; -stream-logs and -daemon both imply -no-tui
+	useTUI := !(*noTUI || *streamLogs || *daemon)
 
-	f, err := os.OpenFile(*logFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0600)
-	if err != nil {
-		log.Fatalf("error opening log file: %v", err)
-	}
-	defer func() { _ = f.Close() }()
-
-	if useTUI {
-		// Log to file only when TUI is running; otherwise the log would stomp the TUI
-		log.SetOutput(f)
+	if *daemon {
+		// Daemon mode: log to stdout only. systemd/journalctl captures stdout
+		// and adds its own timestamps, so we keep ours for grep-ability.
+		log.SetOutput(os.Stdout)
 	} else {
-		log.SetOutput(io.MultiWriter(os.Stdout, f))
+		f, err := os.OpenFile(*logFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0600)
+		if err != nil {
+			log.Fatalf("error opening log file: %v", err)
+		}
+		defer func() { _ = f.Close() }()
+
+		if useTUI {
+			// Log to file only when TUI is running; otherwise the log would stomp the TUI
+			log.SetOutput(f)
+		} else {
+			log.SetOutput(io.MultiWriter(os.Stdout, f))
+		}
 	}
 
 	playerName := *name
@@ -68,8 +75,10 @@ func main() {
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 
 	if !useTUI {
-		log.Printf("Starting Sendspin Player: %s", playerName)
-		log.Printf("TUI disabled - logging to file for debugging")
+		log.Printf("Starting Sendspin Player: %s (version %s)", playerName, version.Version)
+		if *daemon {
+			log.Printf("Daemon mode: logging to stdout only")
+		}
 	}
 
 	var tuiProg *tea.Program
@@ -77,6 +86,7 @@ func main() {
 
 	if useTUI {
 		volumeCtrl = ui.NewVolumeControl()
+		var err error
 		tuiProg, err = ui.Run(volumeCtrl)
 		if err != nil {
 			log.Fatalf("Failed to start TUI: %v", err)


### PR DESCRIPTION
Closes #39. Adds `--daemon` flag and systemd integration for running sendspin-player as a background service.

## What changed

**`--daemon` flag** — logs to stdout only (journalctl captures it), no log file, implies `--no-tui`. Combined with the reconnect loop from #38 (on by default), the player retries forever on network blips while systemd handles process-level restarts via `Restart=on-failure`.

**`dist/systemd/sendspin-player.service`** — hardened unit file with:
- `EnvironmentFile=-/etc/default/sendspin-player` for CLI flag configuration
- `Restart=on-failure` + `RestartSec=5`
- Security hardening: `NoNewPrivileges`, `ProtectSystem=strict`, `ProtectHome=read-only`, `PrivateTmp`

**`dist/systemd/sendspin-player.env`** — documented env template showing all configurable options.

**`make install-daemon` / `make uninstall-daemon`** — copies binary + unit + env file, reloads systemd.

## Usage

```bash
make install-daemon
sudo systemctl enable --now sendspin-player
sudo vi /etc/default/sendspin-player
journalctl -u sendspin-player -f
```

## Test plan
- [x] `go test ./... -count=1` green
- [x] `--daemon` flag visible in help output
- [x] Build clean
