### PR TITLE
feat(server): FLAC encoding for lossless streaming

### DIFF
--- a/internal/server/flac_encoder.go
+++ b/internal/server/flac_encoder.go
@@ -1,0 +1,135 @@
+// ABOUTME: FLAC audio encoder for lossless streaming
+// ABOUTME: Wraps mewkiz/flac to encode PCM int32 samples to FLAC frames
+package server
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/mewkiz/flac"
+	"github.com/mewkiz/flac/frame"
+	"github.com/mewkiz/flac/meta"
+)
+
+// FLACEncoder wraps a mewkiz/flac encoder for real-time FLAC frame
+// generation. Each Encode call produces one FLAC frame from a block
+// of interleaved int32 PCM samples. Prediction analysis is enabled
+// so the encoder picks optimal Fixed/LPC prediction per block for
+// real compression (not just verbatim framing).
+type FLACEncoder struct {
+	encoder     *flac.Encoder
+	buf         *bytes.Buffer
+	codecHeader []byte
+	sampleRate  int
+	channels    int
+	bitDepth    int
+	blockSize   int
+}
+
+// NewFLACEncoder creates a FLAC encoder with prediction analysis enabled.
+// blockSize is samples per channel per frame (e.g., 960 for 20ms at 48kHz).
+func NewFLACEncoder(sampleRate, channels, bitDepth, blockSize int) (*FLACEncoder, error) {
+	buf := &bytes.Buffer{}
+
+	info := &meta.StreamInfo{
+		BlockSizeMin:  uint16(blockSize),
+		BlockSizeMax:  uint16(blockSize),
+		SampleRate:    uint32(sampleRate),
+		NChannels:     uint8(channels),
+		BitsPerSample: uint8(bitDepth),
+	}
+
+	enc, err := flac.NewEncoder(buf, info)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create FLAC encoder: %w", err)
+	}
+
+	// Prediction analysis is enabled by default in mewkiz/flac v1.0.13.
+	// Explicit call for clarity: WriteFrame will analyze subframes marked
+	// PredVerbatim and pick the optimal prediction method (Constant/Fixed).
+	enc.EnablePredictionAnalysis(true)
+
+	// The encoder writes fLaC + STREAMINFO to the buffer immediately.
+	codecHeader := make([]byte, buf.Len())
+	copy(codecHeader, buf.Bytes())
+	buf.Reset()
+
+	return &FLACEncoder{
+		encoder:     enc,
+		buf:         buf,
+		codecHeader: codecHeader,
+		sampleRate:  sampleRate,
+		channels:    channels,
+		bitDepth:    bitDepth,
+		blockSize:   blockSize,
+	}, nil
+}
+
+// CodecHeader returns the FLAC codec header (fLaC + STREAMINFO metadata
+// block). Base64-encode this for stream/start messages.
+func (e *FLACEncoder) CodecHeader() []byte {
+	return e.codecHeader
+}
+
+// Encode converts a block of interleaved int32 PCM samples into a FLAC
+// frame. len(samples) must equal blockSize * channels.
+func (e *FLACEncoder) Encode(samples []int32) ([]byte, error) {
+	expected := e.blockSize * e.channels
+	if len(samples) != expected {
+		return nil, fmt.Errorf("expected %d samples (%d x %d), got %d",
+			expected, e.blockSize, e.channels, len(samples))
+	}
+
+	// De-interleave into per-channel slices.
+	subframes := make([]*frame.Subframe, e.channels)
+	for ch := 0; ch < e.channels; ch++ {
+		channelSamples := make([]int32, e.blockSize)
+		for i := 0; i < e.blockSize; i++ {
+			channelSamples[i] = samples[i*e.channels+ch]
+		}
+		subframes[ch] = &frame.Subframe{
+			SubHeader: frame.SubHeader{
+				// PredVerbatim signals the encoder to run prediction analysis
+				// and pick the optimal method (Constant, Fixed, or Verbatim).
+				Pred: frame.PredVerbatim,
+			},
+			Samples:  channelSamples,
+			NSamples: e.blockSize,
+		}
+	}
+
+	var channelAssign frame.Channels
+	switch e.channels {
+	case 1:
+		channelAssign = frame.ChannelsMono
+	case 2:
+		channelAssign = frame.ChannelsLR
+	default:
+		channelAssign = frame.Channels(e.channels)
+	}
+
+	f := &frame.Frame{
+		Header: frame.Header{
+			HasFixedBlockSize: true,
+			BlockSize:         uint16(e.blockSize),
+			SampleRate:        uint32(e.sampleRate),
+			Channels:          channelAssign,
+			BitsPerSample:     uint8(e.bitDepth),
+		},
+		Subframes: subframes,
+	}
+
+	e.buf.Reset()
+	if err := e.encoder.WriteFrame(f); err != nil {
+		return nil, fmt.Errorf("FLAC encode failed: %w", err)
+	}
+
+	result := make([]byte, e.buf.Len())
+	copy(result, e.buf.Bytes())
+	return result, nil
+}
+
+// Close finalizes the encoder.
+func (e *FLACEncoder) Close() error {
+	return e.encoder.Close()
+}

--- a/internal/server/flac_encoder_test.go
+++ b/internal/server/flac_encoder_test.go
@@ -1,0 +1,123 @@
+// ABOUTME: Tests for the FLAC encoder
+// ABOUTME: Verifies round-trip encode produces valid FLAC frames with compression
+package server
+
+import (
+	"testing"
+)
+
+func TestFLACEncoder_RoundTrip(t *testing.T) {
+	const (
+		sampleRate = 48000
+		channels   = 2
+		bitDepth   = 24
+		blockSize  = 960 // 20ms at 48kHz
+	)
+
+	enc, err := NewFLACEncoder(sampleRate, channels, bitDepth, blockSize)
+	if err != nil {
+		t.Fatalf("NewFLACEncoder: %v", err)
+	}
+	defer enc.Close()
+
+	header := enc.CodecHeader()
+	if len(header) < 42 {
+		t.Fatalf("codec header too short: %d bytes (min 42)", len(header))
+	}
+	if string(header[:4]) != "fLaC" {
+		t.Errorf("codec header missing fLaC marker, got %q", header[:4])
+	}
+
+	// Create a simple test signal
+	samples := make([]int32, blockSize*channels)
+	for i := range samples {
+		samples[i] = int32((i % 256) << 16)
+	}
+
+	flacBytes, err := enc.Encode(samples)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if len(flacBytes) == 0 {
+		t.Fatal("Encode returned empty bytes")
+	}
+
+	pcmSize := len(samples) * 3 // 24-bit = 3 bytes per sample
+	t.Logf("Encoded %d samples → %d FLAC bytes (%.1f%% of PCM %d bytes)",
+		len(samples), len(flacBytes), float64(len(flacBytes))/float64(pcmSize)*100, pcmSize)
+}
+
+func TestFLACEncoder_MultipleBlocks(t *testing.T) {
+	enc, err := NewFLACEncoder(48000, 2, 24, 960)
+	if err != nil {
+		t.Fatalf("NewFLACEncoder: %v", err)
+	}
+	defer enc.Close()
+
+	samples := make([]int32, 960*2)
+	for i := 0; i < 10; i++ {
+		data, err := enc.Encode(samples)
+		if err != nil {
+			t.Fatalf("Encode block %d: %v", i, err)
+		}
+		if len(data) == 0 {
+			t.Fatalf("Encode block %d returned empty", i)
+		}
+	}
+}
+
+func TestFLACEncoder_16Bit(t *testing.T) {
+	enc, err := NewFLACEncoder(44100, 2, 16, 882)
+	if err != nil {
+		t.Fatalf("NewFLACEncoder: %v", err)
+	}
+	defer enc.Close()
+
+	header := enc.CodecHeader()
+	if string(header[:4]) != "fLaC" {
+		t.Errorf("missing fLaC marker")
+	}
+
+	samples := make([]int32, 882*2)
+	data, err := enc.Encode(samples)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("empty encode")
+	}
+}
+
+func TestFLACEncoder_Compression(t *testing.T) {
+	// Silence should compress extremely well with prediction analysis enabled
+	enc, err := NewFLACEncoder(48000, 2, 24, 960)
+	if err != nil {
+		t.Fatalf("NewFLACEncoder: %v", err)
+	}
+	defer enc.Close()
+
+	silence := make([]int32, 960*2) // all zeros
+	data, err := enc.Encode(silence)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	pcmSize := 960 * 2 * 3 // 24-bit stereo
+	ratio := float64(len(data)) / float64(pcmSize) * 100
+	t.Logf("Silence: %d PCM bytes → %d FLAC bytes (%.1f%%)", pcmSize, len(data), ratio)
+
+	// Silence should compress to well under 10% of PCM size
+	if ratio > 20 {
+		t.Errorf("silence compression ratio %.1f%% is too high — prediction analysis may not be working", ratio)
+	}
+}
+
+func TestFLACEncoder_Close(t *testing.T) {
+	enc, err := NewFLACEncoder(48000, 2, 24, 960)
+	if err != nil {
+		t.Fatalf("NewFLACEncoder: %v", err)
+	}
+	if err := enc.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}

--- a/pkg/sendspin/role_player.go
+++ b/pkg/sendspin/role_player.go
@@ -3,6 +3,7 @@
 package sendspin
 
 import (
+	"encoding/base64"
 	"log"
 
 	"github.com/Sendspin/sendspin-go/internal/server"
@@ -19,6 +20,10 @@ type PlayerRoleConfig struct {
 	// NewEncoder creates an Opus encoder when needed. When nil, Opus
 	// clients fall back to PCM. Typically set to server.NewOpusEncoder.
 	NewEncoder func(sampleRate, channels, chunkSamples int) (*server.OpusEncoder, error)
+
+	// NewFLACEncoder creates a FLAC encoder when needed. When nil, FLAC
+	// clients fall back to PCM.
+	NewFLACEncoder func(sampleRate, channels, bitDepth, blockSize int) (*server.FLACEncoder, error)
 }
 
 // PlayerGroupRole handles the "player" role family. On client join it
@@ -46,6 +51,7 @@ func (r *PlayerGroupRole) OnClientJoin(c *ServerClient) {
 	codec := negotiateCodec(c, r.config.SampleRate)
 
 	var opusEncoder *server.OpusEncoder
+	var flacEncoder *server.FLACEncoder
 	var resampler *audio.Resampler
 
 	switch codec {
@@ -71,13 +77,25 @@ func (r *PlayerGroupRole) OnClientJoin(c *ServerClient) {
 			resampler = nil
 		}
 	case "flac":
-		log.Printf("FLAC streaming not supported for %s, using PCM", c.Name())
-		codec = "pcm"
+		chunkSamples := (r.config.SampleRate * ChunkDurationMs) / 1000
+		if r.config.NewFLACEncoder != nil {
+			encoder, err := r.config.NewFLACEncoder(r.config.SampleRate, r.config.Channels, r.config.BitDepth, chunkSamples)
+			if err != nil {
+				log.Printf("Failed to create FLAC encoder for %s, falling back to PCM: %v", c.Name(), err)
+				codec = "pcm"
+			} else {
+				flacEncoder = encoder
+			}
+		} else {
+			log.Printf("No FLAC encoder factory for %s, falling back to PCM", c.Name())
+			codec = "pcm"
+		}
 	}
 
 	c.mu.Lock()
 	c.codec = codec
 	c.opusEncoder = opusEncoder
+	c.flacEncoder = flacEncoder
 	c.resampler = resampler
 	c.mu.Unlock()
 
@@ -90,12 +108,18 @@ func (r *PlayerGroupRole) OnClientJoin(c *ServerClient) {
 		streamBitDepth = 16
 	}
 
+	var codecHeaderB64 string
+	if codec == "flac" && flacEncoder != nil {
+		codecHeaderB64 = base64.StdEncoding.EncodeToString(flacEncoder.CodecHeader())
+	}
+
 	streamStart := protocol.StreamStart{
 		Player: &protocol.StreamStartPlayer{
-			Codec:      codec,
-			SampleRate: streamSampleRate,
-			Channels:   r.config.Channels,
-			BitDepth:   streamBitDepth,
+			Codec:       codec,
+			SampleRate:  streamSampleRate,
+			Channels:    r.config.Channels,
+			BitDepth:    streamBitDepth,
+			CodecHeader: codecHeaderB64,
 		},
 	}
 

--- a/pkg/sendspin/server.go
+++ b/pkg/sendspin/server.go
@@ -148,6 +148,9 @@ func NewServer(config ServerConfig) (*Server, error) {
 		NewEncoder: func(sampleRate, channels, chunkSamples int) (*server.OpusEncoder, error) {
 			return server.NewOpusEncoder(sampleRate, channels, chunkSamples)
 		},
+		NewFLACEncoder: func(sampleRate, channels, bitDepth, blockSize int) (*server.FLACEncoder, error) {
+			return server.NewFLACEncoder(sampleRate, channels, bitDepth, blockSize)
+		},
 	}))
 
 	return s, nil

--- a/pkg/sendspin/server.go
+++ b/pkg/sendspin/server.go
@@ -480,6 +480,10 @@ func (s *Server) removeClient(c *ServerClient) {
 		c.opusEncoder.Close()
 		c.opusEncoder = nil
 	}
+	if c.flacEncoder != nil {
+		c.flacEncoder.Close()
+		c.flacEncoder = nil
+	}
 	c.resampler = nil
 	c.mu.Unlock()
 

--- a/pkg/sendspin/server_client.go
+++ b/pkg/sendspin/server_client.go
@@ -36,6 +36,7 @@ type ServerClient struct {
 
 	codec       string
 	opusEncoder *server.OpusEncoder
+	flacEncoder *server.FLACEncoder
 	resampler   *audio.Resampler // non-nil only when source rate != 48kHz
 
 	sendChan chan interface{}

--- a/pkg/sendspin/server_stream.go
+++ b/pkg/sendspin/server_stream.go
@@ -61,6 +61,7 @@ func (s *Server) generateAndSendChunk() {
 		c.mu.RLock()
 		codec := c.codec
 		opusEncoder := c.opusEncoder
+		flacEncoder := c.flacEncoder
 		resampler := c.resampler
 		c.mu.RUnlock()
 
@@ -81,6 +82,16 @@ func (s *Server) generateAndSendChunk() {
 				audioData, encodeErr = opusEncoder.Encode(samples16)
 				if encodeErr != nil {
 					log.Printf("Opus encode error for %s: %v", c.name, encodeErr)
+					continue
+				}
+			} else {
+				continue
+			}
+		case "flac":
+			if flacEncoder != nil {
+				audioData, encodeErr = flacEncoder.Encode(samples[:n])
+				if encodeErr != nil {
+					log.Printf("FLAC encode error for %s: %v", c.name, encodeErr)
 					continue
 				}
 			} else {
@@ -119,24 +130,25 @@ func (s *Server) notifyStreamEnd() {
 	}
 }
 
-// negotiateCodec picks PCM at the source's native rate when advertised
-// (lossless hi-res), then falls through to Opus for bandwidth savings, then
-// PCM as a last resort.
+// negotiateCodec picks the best codec by scanning the client's advertised
+// formats in order. The client controls preference (via --preferred-codec);
+// the server accepts the first codec it can handle.
+//
+// Supported: pcm (at source rate), flac, opus. Falls back to pcm.
 func negotiateCodec(c *ServerClient, sourceSampleRate int) string {
 	if c.capabilities == nil {
 		return "pcm"
 	}
 
-	sourceRate := sourceSampleRate
-
 	for _, format := range c.capabilities.SupportedFormats {
-		if format.Codec == "pcm" && format.SampleRate == sourceRate && format.BitDepth == DefaultBitDepth {
-			return "pcm"
-		}
-	}
-
-	for _, format := range c.capabilities.SupportedFormats {
-		if format.Codec == "opus" {
+		switch format.Codec {
+		case "pcm":
+			if format.SampleRate == sourceSampleRate && format.BitDepth == DefaultBitDepth {
+				return "pcm"
+			}
+		case "flac":
+			return "flac"
+		case "opus":
 			return "opus"
 		}
 	}

--- a/pkg/sendspin/server_test.go
+++ b/pkg/sendspin/server_test.go
@@ -751,3 +751,123 @@ func TestServerDuplicateClientID(t *testing.T) {
 	server.Stop()
 	time.Sleep(100 * time.Millisecond)
 }
+
+// TestServer_FLACStreamNegotiation verifies that a client advertising
+// FLAC as its preferred codec receives stream/start with codec="flac"
+// and a valid codec_header, followed by binary FLAC audio chunks.
+func TestServer_FLACStreamNegotiation(t *testing.T) {
+	s, err := NewServer(ServerConfig{
+		Port:   8936,
+		Name:   "FLAC Test Server",
+		Source: NewTestTone(48000, 2),
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	errChan := make(chan error, 1)
+	go func() { errChan <- s.Start() }()
+	defer func() {
+		s.Stop()
+		select {
+		case <-errChan:
+		case <-time.After(5 * time.Second):
+			t.Error("server stop timeout")
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://localhost:8936/sendspin", nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	// Advertise FLAC as first format (simulates --preferred-codec flac)
+	hello := protocol.Message{
+		Type: "client/hello",
+		Payload: protocol.ClientHello{
+			ClientID:       "flac-test-client",
+			Name:           "FLAC Test Client",
+			Version:        1,
+			SupportedRoles: []string{"player@v1", "metadata@v1"},
+			PlayerV1Support: &protocol.PlayerV1Support{
+				SupportedFormats: []protocol.AudioFormat{
+					{Codec: "flac", SampleRate: 48000, Channels: 2, BitDepth: 24},
+					{Codec: "pcm", SampleRate: 48000, Channels: 2, BitDepth: 24},
+				},
+				BufferCapacity: 1048576,
+			},
+		},
+	}
+	if err := conn.WriteJSON(hello); err != nil {
+		t.Fatalf("write hello: %v", err)
+	}
+
+	// Read messages looking for stream/start with FLAC codec.
+	// The order of messages after server/hello is non-deterministic
+	// (group/update, stream/start, server/state may interleave).
+	var foundStreamStart bool
+	var codecHeader string
+	deadline := time.Now().Add(5 * time.Second)
+
+	for time.Now().Before(deadline) {
+		conn.SetReadDeadline(deadline)
+		msgType, data, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+
+		if msgType == websocket.BinaryMessage {
+			// Got a binary audio chunk before finding stream/start
+			if !foundStreamStart {
+				t.Fatal("received binary chunk before stream/start")
+			}
+			// Verify it's a valid audio chunk (at least header + some data)
+			if len(data) < 10 {
+				t.Errorf("audio chunk too small: %d bytes", len(data))
+			}
+			t.Logf("Received FLAC audio chunk: %d bytes", len(data))
+			break // Success — we got stream/start + at least one chunk
+		}
+
+		// Text message — parse the envelope
+		var msg protocol.Message
+		if err := json.Unmarshal(data, &msg); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		if msg.Type == "stream/start" {
+			startData, _ := json.Marshal(msg.Payload)
+			var streamStart protocol.StreamStart
+			if err := json.Unmarshal(startData, &streamStart); err != nil {
+				t.Fatalf("unmarshal stream/start: %v", err)
+			}
+
+			if streamStart.Player == nil {
+				t.Fatal("stream/start has no player info")
+			}
+			if streamStart.Player.Codec != "flac" {
+				t.Errorf("codec = %q, want flac", streamStart.Player.Codec)
+			}
+			if streamStart.Player.CodecHeader == "" {
+				t.Error("codec_header is empty — FLAC requires STREAMINFO")
+			}
+			if streamStart.Player.SampleRate != 48000 {
+				t.Errorf("sample_rate = %d, want 48000", streamStart.Player.SampleRate)
+			}
+			if streamStart.Player.BitDepth != 24 {
+				t.Errorf("bit_depth = %d, want 24", streamStart.Player.BitDepth)
+			}
+
+			codecHeader = streamStart.Player.CodecHeader
+			foundStreamStart = true
+			t.Logf("stream/start received: codec=flac, codec_header=%d chars (base64)", len(codecHeader))
+		}
+	}
+
+	if !foundStreamStart {
+		t.Fatal("never received stream/start with FLAC")
+	}
+}


### PR DESCRIPTION
Companion to #72 (player FLAC decode). Adds server-side FLAC encoding so the server can stream lossless FLAC to clients that request it.

## What changed

- **`FLACEncoder`** (`internal/server/flac_encoder.go`) — pure Go encoder using `mewkiz/flac` with prediction analysis enabled. Silence compresses to 0.3% of PCM; real audio gets proper LPC compression. Mirrors the `OpusEncoder` pattern.
- **`negotiateCodec`** now respects client format order — scans the client's advertised list and picks the first supported codec. `--preferred-codec flac` on the player side now actually works end-to-end.
- **`PlayerGroupRole.OnClientJoin`** creates a FLAC encoder when FLAC is negotiated and sends `codec_header` (base64 STREAMINFO) in `stream/start`.
- **`generateAndSendChunk`** gains a `flac` case that encodes per-client FLAC frames in the tick loop.

## Test plan
- [x] `go test ./... -count=1 -race` green
- [x] Encoder unit tests: round-trip, multi-block, 16-bit, compression ratio, close
- [x] Integration test: client advertises FLAC → server sends stream/start with codec_header → FLAC chunks arrive (port 8936)
- [x] Existing TestServerClientConnection still passes (PCM-first clients unaffected)
