### PR TITLE
fix: clear scheduler buffer on pause/stop

### DIFF
--- a/pkg/sendspin/receiver.go
+++ b/pkg/sendspin/receiver.go
@@ -370,7 +370,11 @@ func (r *Receiver) handleGroupUpdates() {
 		select {
 		case update := <-r.client.GroupUpdate:
 			if update.PlaybackState != nil {
-				log.Printf("Group playback state: %s", *update.PlaybackState)
+				state := *update.PlaybackState
+				log.Printf("Group playback state: %s", state)
+				if (state == "paused" || state == "stopped") && r.scheduler != nil {
+					r.scheduler.Clear()
+				}
 			}
 			if update.GroupID != nil {
 				log.Printf("Joined group: %s", *update.GroupID)


### PR DESCRIPTION
Closes #74. Three-line fix.

When the server sends `group/update` with `playback_state: "paused"` or `"stopped"`, the receiver now calls `scheduler.Clear()` to immediately stop draining buffered audio. Previously the signal was logged but never acted on, so 200-500ms of buffered audio would continue playing after pause.

On resume, the server sends a fresh `stream/start` which rebuilds the decoder and scheduler from scratch — no stale buffer to worry about.