### PR TITLE
fix: make buffer_capacity configurable

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ var (
 	noReconnect    = flag.Bool("no-reconnect", false, "Disable automatic reconnect on connection loss")
 	daemon         = flag.Bool("daemon", false, "Daemon mode: log to stdout only (journalctl-friendly), no TUI, no log file")
 	preferredCodec = flag.String("preferred-codec", "", "Preferred codec: pcm (default), opus, or flac")
+	bufferCapacity = flag.Int("buffer-capacity", 1048576, "Buffer capacity in bytes advertised to server (default: 1MB)")
 )
 
 func main() {
@@ -141,6 +142,7 @@ func main() {
 		BufferMs:       *bufferMs,
 		StaticDelayMs:  *staticDelayMs,
 		PreferredCodec: *preferredCodec,
+		BufferCapacity: *bufferCapacity,
 		DeviceInfo: sendspin.DeviceInfo{
 			ProductName:     deviceProduct,
 			Manufacturer:    deviceManufacturer,

--- a/pkg/sendspin/player.go
+++ b/pkg/sendspin/player.go
@@ -57,6 +57,11 @@ type PlayerConfig struct {
 	// picks this codec first. Values: "pcm" (default), "opus", "flac".
 	PreferredCodec string
 
+	// BufferCapacity is the buffer_capacity (bytes) advertised to the
+	// server in client/hello. The server uses this to pace how far ahead
+	// it sends audio. Default: 1048576 (1MB).
+	BufferCapacity int
+
 	DeviceInfo DeviceInfo
 
 	OnMetadata func(Metadata)
@@ -194,6 +199,7 @@ func (p *Player) buildReceiver(addr string) (*Receiver, error) {
 		BufferMs:       p.config.BufferMs,
 		StaticDelayMs:  p.config.StaticDelayMs,
 		PreferredCodec: p.config.PreferredCodec,
+		BufferCapacity: p.config.BufferCapacity,
 		DeviceInfo:     p.config.DeviceInfo,
 		DecoderFactory: p.config.DecoderFactory,
 		OnMetadata:     p.config.OnMetadata,

--- a/pkg/sendspin/receiver.go
+++ b/pkg/sendspin/receiver.go
@@ -22,6 +22,7 @@ type ReceiverConfig struct {
 	BufferMs       int
 	StaticDelayMs  int    // optional static latency compensation (ms) applied to every scheduled play time
 	PreferredCodec string // "pcm", "opus", or "flac" — reorders the advertised format list so the server picks this codec first
+	BufferCapacity int    // buffer_capacity in bytes advertised to the server (default: 1048576 = 1MB)
 	DeviceInfo     DeviceInfo
 	DecoderFactory func(audio.Format) (decode.Decoder, error)
 	OnMetadata     func(Metadata)
@@ -66,6 +67,9 @@ func NewReceiver(config ReceiverConfig) (*Receiver, error) {
 
 	if config.BufferMs == 0 {
 		config.BufferMs = 500
+	}
+	if config.BufferCapacity == 0 {
+		config.BufferCapacity = 1048576 // 1MB default
 	}
 	if config.DeviceInfo.ProductName == "" {
 		config.DeviceInfo.ProductName = "Sendspin Player"
@@ -148,7 +152,7 @@ func (r *Receiver) Connect() error {
 		},
 		PlayerV1Support: protocol.PlayerV1Support{
 			SupportedFormats:  buildSupportedFormats(r.config.PreferredCodec),
-			BufferCapacity:    1048576,
+			BufferCapacity:    r.config.BufferCapacity,
 			SupportedCommands: []string{"volume", "mute"},
 		},
 		ArtworkV1Support: &protocol.ArtworkV1Support{
@@ -157,7 +161,7 @@ func (r *Receiver) Connect() error {
 			},
 		},
 		VisualizerV1Support: &protocol.VisualizerV1Support{
-			BufferCapacity: 1048576,
+			BufferCapacity: r.config.BufferCapacity,
 		},
 	}
 


### PR DESCRIPTION
Closes #73. The `buffer_capacity` in `client/hello` was hardcoded to 1MB (1048576 bytes). Now configurable at every level:

- `ReceiverConfig.BufferCapacity` / `PlayerConfig.BufferCapacity` (library API)
- `--buffer-capacity` CLI flag (bytes, default 1MB)
- Applied to both `PlayerV1Support` and `VisualizerV1Support` in the hello

Server-side backpressure (making the server actually respect this value for send-ahead pacing) is tracked in #77.