### PR TITLE
fix: rename stale resonate reference to sendspin

### DIFF
--- a/pkg/audio/doc.go
+++ b/pkg/audio/doc.go
@@ -2,7 +2,7 @@
 // ABOUTME: Defines Format, Buffer types and sample conversion functions
 // Package audio provides fundamental audio types and utilities for hi-res audio processing.
 //
-// This package defines core types used throughout the resonate library:
+// This package defines core types used throughout the sendspin library:
 //   - Format: Describes audio stream format (codec, sample rate, channels, bit depth)
 //   - Buffer: Represents decoded PCM audio with timestamp information
 //


### PR DESCRIPTION
Closes #33. The `internal/artwork/` directory (with the `resonate-artwork` cache dir) no longer exists — it was removed in a prior cleanup. The only remaining "resonate" string was in `pkg/audio/doc.go`. One-word fix.