### PR TITLE
fix: send client/goodbye before context cancellation on shutdown

### DIFF
--- a/pkg/sendspin/receiver.go
+++ b/pkg/sendspin/receiver.go
@@ -502,10 +502,15 @@ func (r *Receiver) notifyError(err error) {
 }
 
 func (r *Receiver) Close() error {
+	// Send goodbye BEFORE cancelling the context so the message
+	// reaches the server while the connection is still alive.
+	if r.client != nil {
+		r.client.SendGoodbye("shutdown")
+	}
+
 	r.cancel()
 
 	if r.client != nil {
-		r.client.SendGoodbye("shutdown")
 		r.client.Close()
 	}
 


### PR DESCRIPTION
The player wasn't properly notifying the server on quit. `Receiver.Close()` called `r.cancel()` (cancelling the context and tearing down goroutines) BEFORE `r.client.SendGoodbye("shutdown")`, so the goodbye raced the connection teardown and often never reached the server.

The server then thought the client was still alive, requiring the user to manually reselect it on reconnect.

Fix: send goodbye first while the connection is healthy, then cancel + close.