### PR TITLE
feat(ui): TUI overhaul with playback state + transport controls

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -17,7 +17,6 @@ type Model struct {
 	serverName string
 
 	// Sync
-	syncOffset  int64
 	syncRTT     int64
 	syncQuality sync.Quality
 
@@ -34,9 +33,10 @@ type Model struct {
 	artworkPath string
 
 	// Playback
-	state  string
-	volume int
-	muted  bool
+	state         string
+	playbackState string // "playing", "paused", "stopped", "idle", "reconnecting"
+	volume        int
+	muted         bool
 
 	// Stats
 	received    int64
@@ -47,15 +47,14 @@ type Model struct {
 	// Debug
 	showDebug  bool
 	goroutines int
-	memAlloc   uint64
-	memSys     uint64
 
 	// Dimensions
 	width  int
 	height int
 
-	// Volume control channel
-	volumeCtrl *VolumeControl
+	// Controls
+	volumeCtrl    *VolumeControl
+	transportCtrl *TransportControl
 }
 
 func (m Model) Init() tea.Cmd {
@@ -102,16 +101,14 @@ func (m Model) renderHeader() string {
 		connStatus = fmt.Sprintf("Connected to %s", m.serverName)
 	}
 
-	syncIcon := "✗"
-	syncText := "Lost"
+	stateDisplay := playbackStateDisplay(m.playbackState)
+
+	syncDisplay := "Sync: \u2717 Lost"
 	switch m.syncQuality {
 	case sync.QualityGood:
-		syncIcon = "✓"
-		syncText = fmt.Sprintf("Synced (offset: %+.1fms, jitter: %.1fms)",
-			float64(m.syncOffset)/1000.0, float64(m.syncRTT)/1000.0)
+		syncDisplay = fmt.Sprintf("Sync: \u2713 Good (RTT: %.1fms)", float64(m.syncRTT)/1000.0)
 	case sync.QualityDegraded:
-		syncIcon = "⚠"
-		syncText = "Degraded"
+		syncDisplay = "Sync: \u26a0 Degraded"
 	}
 
 	// Use terminal width for responsive layout
@@ -122,13 +119,19 @@ func (m Model) renderHeader() string {
 	innerWidth := width - 4 // Account for borders
 
 	titleWidth := width - 20 // Space for "┌─ Sendspin Player " prefix
-	title := "┌─ Sendspin Player " + repeatString("─", titleWidth) + "┐\n"
+	title := "\u250c\u2500 Sendspin Player " + repeatString("\u2500", titleWidth) + "\u2510\n"
 
-	statusLine := fmt.Sprintf("│ Status: %-*s │\n", innerWidth-9, truncate(connStatus, innerWidth-9))
-	syncLine := fmt.Sprintf("│ Sync:   %s %-*s │\n", syncIcon, innerWidth-11, truncate(syncText, innerWidth-11))
-	separator := "├" + repeatString("─", width-2) + "┤\n"
+	statusLine := fmt.Sprintf("\u2502 Status: %-*s \u2502\n", innerWidth-9, truncate(connStatus, innerWidth-9))
 
-	return title + statusLine + syncLine + separator
+	// State + Sync on same line
+	statePrefix := fmt.Sprintf("State:  %s", stateDisplay)
+	// Calculate available space: innerWidth minus "State:  <state>" minus spacing minus sync display
+	stateSyncLine := fmt.Sprintf("\u2502 %-*s \u2502\n", innerWidth,
+		fmt.Sprintf("%-30s %s", statePrefix, syncDisplay))
+
+	separator := "\u251c" + repeatString("\u2500", width-2) + "\u2524\n"
+
+	return title + statusLine + stateSyncLine + separator
 }
 
 func (m Model) renderStreamInfo() string {
@@ -139,26 +142,25 @@ func (m Model) renderStreamInfo() string {
 	innerWidth := width - 4
 
 	if !m.connected || m.codec == "" {
-		return fmt.Sprintf("│ %-*s │\n", innerWidth, "No stream")
+		return fmt.Sprintf("\u2502 %-*s \u2502\n", innerWidth, "No stream")
 	}
 
-	s := fmt.Sprintf("│ %-*s │\n", innerWidth, "Now Playing:")
+	s := fmt.Sprintf("\u2502 %-*s \u2502\n", innerWidth, "Now Playing:")
 	if m.title != "" {
 		metaWidth := innerWidth - 10 // Account for "  Track:  " prefix
-		s += fmt.Sprintf("│   Track:  %-*s │\n", innerWidth-10, truncate(m.title, metaWidth))
-		s += fmt.Sprintf("│   Artist: %-*s │\n", innerWidth-10, truncate(m.artist, metaWidth))
-		s += fmt.Sprintf("│   Album:  %-*s │\n", innerWidth-10, truncate(m.album, metaWidth))
+		s += fmt.Sprintf("\u2502   Track:  %-*s \u2502\n", innerWidth-10, truncate(m.title, metaWidth))
+		s += fmt.Sprintf("\u2502   Artist: %-*s \u2502\n", innerWidth-10, truncate(m.artist, metaWidth))
+		s += fmt.Sprintf("\u2502   Album:  %-*s \u2502\n", innerWidth-10, truncate(m.album, metaWidth))
 		if m.artworkPath != "" {
-			s += fmt.Sprintf("│   Art:    %-*s │\n", innerWidth-10, truncate(m.artworkPath, metaWidth))
+			s += fmt.Sprintf("\u2502   Art:    %-*s \u2502\n", innerWidth-10, truncate(m.artworkPath, metaWidth))
 		}
 	} else {
-		s += fmt.Sprintf("│   %-*s │\n", innerWidth-3, "(No metadata)")
+		s += fmt.Sprintf("\u2502   %-*s \u2502\n", innerWidth-3, "(No metadata)")
 	}
 
-	s += fmt.Sprintf("│ %-*s │\n", innerWidth, "")
-	formatStr := fmt.Sprintf("Format: %s %dHz %s %d-bit",
-		m.codec, m.sampleRate, channelName(m.channels), m.bitDepth)
-	s += fmt.Sprintf("│ %-*s │\n", innerWidth, formatStr)
+	s += fmt.Sprintf("\u2502 %-*s \u2502\n", innerWidth, "")
+	formatStr := formatCodecDisplay(m.codec, m.sampleRate, m.bitDepth)
+	s += fmt.Sprintf("\u2502 %-*s \u2502\n", innerWidth, formatStr)
 
 	return s
 }
@@ -172,17 +174,17 @@ func (m Model) renderControls() string {
 
 	muteIcon := ""
 	if m.muted {
-		muteIcon = " 🔇"
+		muteIcon = " \U0001f507"
 	}
 
-	volumeBar := renderBar(m.volume, 100, 10)
+	volumeBar := renderBar(m.volume, 100, 20)
 
-	s := fmt.Sprintf("│ %-*s │\n", innerWidth, "")
+	s := fmt.Sprintf("\u2502 %-*s \u2502\n", innerWidth, "")
 	volumeStr := fmt.Sprintf("Volume: [%s] %d%%%s", volumeBar, m.volume, muteIcon)
-	s += fmt.Sprintf("│ %-*s │\n", innerWidth, volumeStr)
+	s += fmt.Sprintf("\u2502 %-*s \u2502\n", innerWidth, volumeStr)
 
-	bufferStr := fmt.Sprintf("Buffer: %dms (%d chunks)", m.bufferDepth, m.bufferDepth/10)
-	s += fmt.Sprintf("│ %-*s │\n", innerWidth, bufferStr)
+	bufferStr := fmt.Sprintf("Buffer: %dms", m.bufferDepth)
+	s += fmt.Sprintf("\u2502 %-*s \u2502\n", innerWidth, bufferStr)
 
 	return s
 }
@@ -194,10 +196,10 @@ func (m Model) renderStats() string {
 	}
 	innerWidth := width - 4
 
-	separator := "├" + repeatString("─", width-2) + "┤\n"
+	separator := "\u251c" + repeatString("\u2500", width-2) + "\u2524\n"
 	statsStr := fmt.Sprintf("Stats:  RX: %d  Played: %d  Dropped: %d", m.received, m.played, m.dropped)
-	statsLine := fmt.Sprintf("│ %-*s │\n", innerWidth, statsStr)
-	emptyLine := fmt.Sprintf("│ %-*s │\n", innerWidth, "")
+	statsLine := fmt.Sprintf("\u2502 %-*s \u2502\n", innerWidth, statsStr)
+	emptyLine := fmt.Sprintf("\u2502 %-*s \u2502\n", innerWidth, "")
 
 	return separator + statsLine + emptyLine
 }
@@ -209,9 +211,9 @@ func (m Model) renderHelp() string {
 	}
 	innerWidth := width - 4
 
-	helpStr := "↑/↓:Volume  m:Mute  r:Reconnect  d:Debug  q:Quit"
-	helpLine := fmt.Sprintf("│ %-*s │\n", innerWidth, helpStr)
-	bottom := "└" + repeatString("─", width-2) + "┘\n"
+	helpStr := "Space:Play/Pause  n:Next  p:Prev  \u2191/\u2193:Vol  m:Mute  q:Quit"
+	helpLine := fmt.Sprintf("\u2502 %-*s \u2502\n", innerWidth, helpStr)
+	bottom := "\u2514" + repeatString("\u2500", width-2) + "\u2518\n"
 
 	return helpLine + bottom
 }
@@ -223,18 +225,15 @@ func (m Model) renderDebug() string {
 	}
 	innerWidth := width - 4
 
-	memAllocMB := float64(m.memAlloc) / 1024 / 1024
-	memSysMB := float64(m.memSys) / 1024 / 1024
-
-	debugTitle := fmt.Sprintf("│ %-*s │\n", innerWidth, "DEBUG:")
+	debugTitle := fmt.Sprintf("\u2502 %-*s \u2502\n", innerWidth, "DEBUG:")
 	goroutineStr := fmt.Sprintf("  Goroutines: %d", m.goroutines)
-	goroutineLine := fmt.Sprintf("│ %-*s │\n", innerWidth, goroutineStr)
-	memStr := fmt.Sprintf("  Memory: %.1f MB / %.1f MB", memAllocMB, memSysMB)
-	memLine := fmt.Sprintf("│ %-*s │\n", innerWidth, memStr)
-	clockStr := fmt.Sprintf("  Clock Offset: %+dμs", m.syncOffset)
-	clockLine := fmt.Sprintf("│ %-*s │\n", innerWidth, clockStr)
+	goroutineLine := fmt.Sprintf("\u2502 %-*s \u2502\n", innerWidth, goroutineStr)
+	playbackStr := fmt.Sprintf("  Playback: %s", m.playbackState)
+	playbackLine := fmt.Sprintf("\u2502 %-*s \u2502\n", innerWidth, playbackStr)
+	codecStr := fmt.Sprintf("  Preferred codec: %s", m.codec)
+	codecLine := fmt.Sprintf("\u2502 %-*s \u2502\n", innerWidth, codecStr)
 
-	return debugTitle + goroutineLine + memLine + clockLine
+	return debugTitle + goroutineLine + playbackLine + codecLine
 }
 
 func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -286,6 +285,34 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				// Channel full, skip
 			}
 		}
+	case " ":
+		if m.transportCtrl != nil {
+			select {
+			case m.transportCtrl.Commands <- TransportMsg{Command: "toggle"}:
+			default:
+			}
+		}
+	case "n":
+		if m.transportCtrl != nil {
+			select {
+			case m.transportCtrl.Commands <- TransportMsg{Command: "next"}:
+			default:
+			}
+		}
+	case "p":
+		if m.transportCtrl != nil {
+			select {
+			case m.transportCtrl.Commands <- TransportMsg{Command: "previous"}:
+			default:
+			}
+		}
+	case "r":
+		if m.transportCtrl != nil {
+			select {
+			case m.transportCtrl.Commands <- TransportMsg{Command: "reconnect"}:
+			default:
+			}
+		}
 	case "d":
 		m.showDebug = !m.showDebug
 	}
@@ -300,9 +327,11 @@ func (m *Model) applyStatus(msg StatusMsg) {
 	if msg.ServerName != "" {
 		m.serverName = msg.ServerName
 	}
-	// Sync stats are always applied when sent (offset can be 0 for perfect sync)
-	if msg.SyncOffset != 0 || msg.SyncRTT != 0 {
-		m.syncOffset = msg.SyncOffset
+	if msg.PlaybackState != "" {
+		m.playbackState = msg.PlaybackState
+	}
+	// Sync stats are always applied when sent
+	if msg.SyncRTT != 0 {
 		m.syncRTT = msg.SyncRTT
 		m.syncQuality = msg.SyncQuality
 	}
@@ -331,32 +360,28 @@ func (m *Model) applyStatus(msg StatusMsg) {
 	m.dropped = msg.Dropped
 	m.bufferDepth = msg.BufferDepth
 	m.goroutines = msg.Goroutines
-	m.memAlloc = msg.MemAlloc
-	m.memSys = msg.MemSys
 }
 
 type StatusMsg struct {
-	Connected   *bool
-	ServerName  string
-	SyncOffset  int64
-	SyncRTT     int64
-	SyncQuality sync.Quality
-	Codec       string
-	SampleRate  int
-	Channels    int
-	BitDepth    int
-	Title       string
-	Artist      string
-	Album       string
-	ArtworkPath string
-	Volume      int
-	Received    int64
-	Played      int64
-	Dropped     int64
-	BufferDepth int
-	Goroutines  int
-	MemAlloc    uint64
-	MemSys      uint64
+	Connected     *bool
+	ServerName    string
+	PlaybackState string
+	SyncRTT       int64
+	SyncQuality   sync.Quality
+	Codec         string
+	SampleRate    int
+	Channels      int
+	BitDepth      int
+	Title         string
+	Artist        string
+	Album         string
+	ArtworkPath   string
+	Volume        int
+	Received      int64
+	Played        int64
+	Dropped       int64
+	BufferDepth   int
+	Goroutines    int
 }
 
 type VolumeChangeMsg struct {
@@ -368,7 +393,7 @@ type QuitMsg struct{}
 
 func renderBar(value, max, width int) string {
 	filled := (value * width) / max
-	return strings.Repeat("█", filled) + strings.Repeat("░", width-filled)
+	return strings.Repeat("\u2588", filled) + strings.Repeat("\u2591", width-filled)
 }
 
 func truncate(s string, length int) string {
@@ -390,4 +415,62 @@ func repeatString(s string, count int) string {
 		return ""
 	}
 	return strings.Repeat(s, count)
+}
+
+// playbackStateDisplay returns a display string with icon for the given playback state.
+func playbackStateDisplay(state string) string {
+	switch state {
+	case "playing":
+		return "\u25b6 Playing"
+	case "paused":
+		return "\u23f8 Paused"
+	case "stopped":
+		return "\u23f9 Stopped"
+	case "idle":
+		return "\u25cf Idle"
+	case "reconnecting":
+		return "\u21bb Reconnecting..."
+	default:
+		return "\u25cf Idle"
+	}
+}
+
+// formatSampleRate returns a human-friendly sample rate string.
+func formatSampleRate(rate int) string {
+	switch rate {
+	case 44100:
+		return "44.1kHz"
+	case 48000:
+		return "48kHz"
+	case 88200:
+		return "88.2kHz"
+	case 96000:
+		return "96kHz"
+	case 176400:
+		return "176.4kHz"
+	case 192000:
+		return "192kHz"
+	default:
+		if rate%1000 == 0 {
+			return fmt.Sprintf("%dkHz", rate/1000)
+		}
+		return fmt.Sprintf("%.1fkHz", float64(rate)/1000.0)
+	}
+}
+
+// formatCodecDisplay returns a rich codec description string.
+func formatCodecDisplay(codec string, sampleRate, bitDepth int) string {
+	rate := formatSampleRate(sampleRate)
+	upper := strings.ToUpper(codec)
+
+	switch strings.ToLower(codec) {
+	case "pcm":
+		return fmt.Sprintf("%s %s/%dbit lossless", upper, rate, bitDepth)
+	case "flac":
+		return fmt.Sprintf("%s %s/%dbit lossless", upper, rate, bitDepth)
+	case "opus":
+		return fmt.Sprintf("%s %s/%dbit", upper, rate, bitDepth)
+	default:
+		return fmt.Sprintf("%s %s/%dbit", upper, rate, bitDepth)
+	}
 }

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 
 	"github.com/Sendspin/sendspin-go/pkg/sync"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func TestNewModel(t *testing.T) {
-	model := NewModel(nil) // VolumeControl is optional for testing
+	model := NewModel(nil, nil) // VolumeControl and TransportControl are optional for testing
 
 	// Check initial state
 	if model.connected {
@@ -27,10 +28,14 @@ func TestNewModel(t *testing.T) {
 	if model.showDebug {
 		t.Error("expected showDebug to be false initially")
 	}
+
+	if model.playbackState != "idle" {
+		t.Errorf("expected playbackState 'idle', got '%s'", model.playbackState)
+	}
 }
 
 func TestStatusMsgConnected(t *testing.T) {
-	model := NewModel(nil)
+	model := NewModel(nil, nil)
 
 	connected := true
 	msg := StatusMsg{
@@ -50,7 +55,7 @@ func TestStatusMsgConnected(t *testing.T) {
 }
 
 func TestStatusMsgDisconnected(t *testing.T) {
-	model := NewModel(nil)
+	model := NewModel(nil, nil)
 
 	// First connect
 	connected := true
@@ -66,7 +71,7 @@ func TestStatusMsgDisconnected(t *testing.T) {
 }
 
 func TestStatusMsgSyncStats(t *testing.T) {
-	model := NewModel(nil)
+	model := NewModel(nil, nil)
 
 	msg := StatusMsg{
 		SyncRTT:     5000,
@@ -85,7 +90,7 @@ func TestStatusMsgSyncStats(t *testing.T) {
 }
 
 func TestStatusMsgStreamInfo(t *testing.T) {
-	model := NewModel(nil)
+	model := NewModel(nil, nil)
 
 	msg := StatusMsg{
 		Codec:      "opus",
@@ -114,7 +119,7 @@ func TestStatusMsgStreamInfo(t *testing.T) {
 }
 
 func TestStatusMsgMetadata(t *testing.T) {
-	model := NewModel(nil)
+	model := NewModel(nil, nil)
 
 	msg := StatusMsg{
 		Title:  "Test Song",
@@ -138,7 +143,7 @@ func TestStatusMsgMetadata(t *testing.T) {
 }
 
 func TestStatusMsgArtworkPath(t *testing.T) {
-	model := NewModel(nil)
+	model := NewModel(nil, nil)
 
 	msg := StatusMsg{
 		ArtworkPath: "/tmp/artwork.jpg",
@@ -152,7 +157,7 @@ func TestStatusMsgArtworkPath(t *testing.T) {
 }
 
 func TestStatusMsgVolume(t *testing.T) {
-	model := NewModel(nil)
+	model := NewModel(nil, nil)
 
 	msg := StatusMsg{
 		Volume: 75,
@@ -166,7 +171,7 @@ func TestStatusMsgVolume(t *testing.T) {
 }
 
 func TestStatusMsgStats(t *testing.T) {
-	model := NewModel(nil)
+	model := NewModel(nil, nil)
 
 	msg := StatusMsg{
 		Received:    1000,
@@ -195,12 +200,10 @@ func TestStatusMsgStats(t *testing.T) {
 }
 
 func TestStatusMsgRuntimeStats(t *testing.T) {
-	model := NewModel(nil)
+	model := NewModel(nil, nil)
 
 	msg := StatusMsg{
 		Goroutines: 42,
-		MemAlloc:   1024 * 1024,
-		MemSys:     2048 * 1024,
 	}
 
 	model.applyStatus(msg)
@@ -208,18 +211,10 @@ func TestStatusMsgRuntimeStats(t *testing.T) {
 	if model.goroutines != 42 {
 		t.Errorf("expected goroutines 42, got %d", model.goroutines)
 	}
-
-	if model.memAlloc != 1024*1024 {
-		t.Errorf("expected memAlloc %d, got %d", 1024*1024, model.memAlloc)
-	}
-
-	if model.memSys != 2048*1024 {
-		t.Errorf("expected memSys %d, got %d", 2048*1024, model.memSys)
-	}
 }
 
 func TestMultipleStatusUpdates(t *testing.T) {
-	model := NewModel(nil)
+	model := NewModel(nil, nil)
 
 	// First update
 	connected := true
@@ -249,7 +244,7 @@ func TestMultipleStatusUpdates(t *testing.T) {
 }
 
 func TestStatusMsgZeroValues(t *testing.T) {
-	model := NewModel(nil)
+	model := NewModel(nil, nil)
 
 	// Set some non-zero values first
 	model.applyStatus(StatusMsg{
@@ -322,10 +317,10 @@ func TestChannelNameFunction(t *testing.T) {
 }
 
 func TestSyncQualityDisplay(t *testing.T) {
-	model := NewModel(nil)
+	model := NewModel(nil, nil)
 
 	// Test different quality levels
-	// Note: quality is only applied when SyncRTT or SyncOffset is non-zero
+	// Note: quality is only applied when SyncRTT is non-zero
 	qualities := []sync.Quality{
 		sync.QualityGood,
 		sync.QualityDegraded,
@@ -345,7 +340,7 @@ func TestSyncQualityDisplay(t *testing.T) {
 }
 
 func TestMetadataClearing(t *testing.T) {
-	model := NewModel(nil)
+	model := NewModel(nil, nil)
 
 	// Set metadata
 	model.applyStatus(StatusMsg{
@@ -365,6 +360,200 @@ func TestMetadataClearing(t *testing.T) {
 	if model.title != "Song" {
 		t.Error("title should not be cleared by empty string")
 	}
+}
+
+func TestPlaybackStateApplication(t *testing.T) {
+	model := NewModel(nil, nil)
+
+	// Initial state should be idle
+	if model.playbackState != "idle" {
+		t.Errorf("expected initial playbackState 'idle', got '%s'", model.playbackState)
+	}
+
+	// Apply playing state
+	model.applyStatus(StatusMsg{PlaybackState: "playing"})
+	if model.playbackState != "playing" {
+		t.Errorf("expected playbackState 'playing', got '%s'", model.playbackState)
+	}
+
+	// Apply paused state
+	model.applyStatus(StatusMsg{PlaybackState: "paused"})
+	if model.playbackState != "paused" {
+		t.Errorf("expected playbackState 'paused', got '%s'", model.playbackState)
+	}
+
+	// Empty string should not overwrite
+	model.applyStatus(StatusMsg{PlaybackState: ""})
+	if model.playbackState != "paused" {
+		t.Errorf("expected playbackState to remain 'paused', got '%s'", model.playbackState)
+	}
+}
+
+func TestTransportKeyToggle(t *testing.T) {
+	tc := NewTransportControl()
+	model := NewModel(nil, tc)
+	model.width = 80
+	model.height = 24
+
+	// Simulate space key
+	msg := fakeKeyMsg(" ")
+	model.handleKey(msg)
+
+	select {
+	case cmd := <-tc.Commands:
+		if cmd.Command != "toggle" {
+			t.Errorf("expected 'toggle' command, got '%s'", cmd.Command)
+		}
+	default:
+		t.Error("expected toggle command on transport channel")
+	}
+}
+
+func TestTransportKeyNext(t *testing.T) {
+	tc := NewTransportControl()
+	model := NewModel(nil, tc)
+	model.width = 80
+	model.height = 24
+
+	msg := fakeKeyMsg("n")
+	model.handleKey(msg)
+
+	select {
+	case cmd := <-tc.Commands:
+		if cmd.Command != "next" {
+			t.Errorf("expected 'next' command, got '%s'", cmd.Command)
+		}
+	default:
+		t.Error("expected next command on transport channel")
+	}
+}
+
+func TestTransportKeyPrevious(t *testing.T) {
+	tc := NewTransportControl()
+	model := NewModel(nil, tc)
+	model.width = 80
+	model.height = 24
+
+	msg := fakeKeyMsg("p")
+	model.handleKey(msg)
+
+	select {
+	case cmd := <-tc.Commands:
+		if cmd.Command != "previous" {
+			t.Errorf("expected 'previous' command, got '%s'", cmd.Command)
+		}
+	default:
+		t.Error("expected previous command on transport channel")
+	}
+}
+
+func TestTransportKeyReconnect(t *testing.T) {
+	tc := NewTransportControl()
+	model := NewModel(nil, tc)
+	model.width = 80
+	model.height = 24
+
+	msg := fakeKeyMsg("r")
+	model.handleKey(msg)
+
+	select {
+	case cmd := <-tc.Commands:
+		if cmd.Command != "reconnect" {
+			t.Errorf("expected 'reconnect' command, got '%s'", cmd.Command)
+		}
+	default:
+		t.Error("expected reconnect command on transport channel")
+	}
+}
+
+func TestTransportNilSafe(t *testing.T) {
+	// Transport keys should not panic when transportCtrl is nil
+	model := NewModel(nil, nil)
+	model.width = 80
+	model.height = 24
+
+	// These should not panic
+	model.handleKey(fakeKeyMsg(" "))
+	model.handleKey(fakeKeyMsg("n"))
+	model.handleKey(fakeKeyMsg("p"))
+	model.handleKey(fakeKeyMsg("r"))
+}
+
+func TestPlaybackStateDisplay(t *testing.T) {
+	tests := []struct {
+		state    string
+		expected string
+	}{
+		{"playing", "\u25b6 Playing"},
+		{"paused", "\u23f8 Paused"},
+		{"stopped", "\u23f9 Stopped"},
+		{"idle", "\u25cf Idle"},
+		{"reconnecting", "\u21bb Reconnecting..."},
+		{"unknown", "\u25cf Idle"},
+	}
+
+	for _, tt := range tests {
+		result := playbackStateDisplay(tt.state)
+		if result != tt.expected {
+			t.Errorf("playbackStateDisplay(%q) = %q, expected %q",
+				tt.state, result, tt.expected)
+		}
+	}
+}
+
+func TestFormatSampleRate(t *testing.T) {
+	tests := []struct {
+		rate     int
+		expected string
+	}{
+		{44100, "44.1kHz"},
+		{48000, "48kHz"},
+		{96000, "96kHz"},
+		{192000, "192kHz"},
+		{88200, "88.2kHz"},
+		{176400, "176.4kHz"},
+		{32000, "32kHz"},
+		{22050, "22.1kHz"},
+	}
+
+	for _, tt := range tests {
+		result := formatSampleRate(tt.rate)
+		if result != tt.expected {
+			t.Errorf("formatSampleRate(%d) = %q, expected %q",
+				tt.rate, result, tt.expected)
+		}
+	}
+}
+
+func TestFormatCodecDisplay(t *testing.T) {
+	tests := []struct {
+		codec      string
+		sampleRate int
+		bitDepth   int
+		expected   string
+	}{
+		{"pcm", 192000, 24, "PCM 192kHz/24bit lossless"},
+		{"opus", 48000, 16, "OPUS 48kHz/16bit"},
+		{"flac", 48000, 24, "FLAC 48kHz/24bit lossless"},
+		{"flac", 44100, 16, "FLAC 44.1kHz/16bit lossless"},
+		{"aac", 44100, 16, "AAC 44.1kHz/16bit"},
+	}
+
+	for _, tt := range tests {
+		result := formatCodecDisplay(tt.codec, tt.sampleRate, tt.bitDepth)
+		if result != tt.expected {
+			t.Errorf("formatCodecDisplay(%q, %d, %d) = %q, expected %q",
+				tt.codec, tt.sampleRate, tt.bitDepth, result, tt.expected)
+		}
+	}
+}
+
+// fakeKeyMsg creates a tea.KeyMsg for testing.
+func fakeKeyMsg(key string) tea.KeyMsg {
+	if key == " " {
+		return tea.KeyMsg{Type: tea.KeySpace, Runes: []rune(key)}
+	}
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)}
 }
 
 // NOTE: TestConcurrentStatusUpdates was removed because Bubble Tea

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -18,15 +18,31 @@ func NewVolumeControl() *VolumeControl {
 	}
 }
 
-func NewModel(volCtrl *VolumeControl) Model {
-	return Model{
-		volume:     100,
-		state:      "idle",
-		volumeCtrl: volCtrl,
+type TransportMsg struct {
+	Command string // "play", "pause", "toggle", "next", "previous", "reconnect"
+}
+
+type TransportControl struct {
+	Commands chan TransportMsg
+}
+
+func NewTransportControl() *TransportControl {
+	return &TransportControl{
+		Commands: make(chan TransportMsg, 10),
 	}
 }
 
-func Run(volCtrl *VolumeControl) (*tea.Program, error) {
-	p := tea.NewProgram(NewModel(volCtrl), tea.WithAltScreen())
+func NewModel(volCtrl *VolumeControl, transportCtrl *TransportControl) Model {
+	return Model{
+		volume:        100,
+		state:         "idle",
+		playbackState: "idle",
+		volumeCtrl:    volCtrl,
+		transportCtrl: transportCtrl,
+	}
+}
+
+func Run(volCtrl *VolumeControl, transportCtrl *TransportControl) (*tea.Program, error) {
+	p := tea.NewProgram(NewModel(volCtrl, transportCtrl), tea.WithAltScreen())
 	return p, nil
 }

--- a/main.go
+++ b/main.go
@@ -256,31 +256,34 @@ func handleVolumeControl(player *sendspin.Player, volumeCtrl *ui.VolumeControl) 
 
 func handleTransportControl(player *sendspin.Player, ctrl *ui.TransportControl) {
 	for cmd := range ctrl.Commands {
+		if !player.Status().Connected {
+			log.Printf("Transport command %q ignored: not connected", cmd.Command)
+			continue
+		}
+		var err error
 		switch cmd.Command {
 		case "toggle":
+			// Toggle sends "pause" if server is playing, "play" otherwise.
+			// The server decides the actual state; we just request it.
 			status := player.Status()
 			if status.State == "playing" {
-				player.Pause()
+				err = player.SendCommand("pause")
 			} else {
-				player.Play()
+				err = player.SendCommand("play")
 			}
 		case "play":
-			player.Play()
+			err = player.SendCommand("play")
 		case "pause":
-			player.Pause()
+			err = player.SendCommand("pause")
 		case "next":
-			if player.Status().Connected {
-				// TODO: wire to SendCommand when Player API exposes it
-				log.Printf("Next track requested")
-			}
+			err = player.SendCommand("next")
 		case "previous":
-			if player.Status().Connected {
-				// TODO: wire to SendCommand when Player API exposes it
-				log.Printf("Previous track requested")
-			}
+			err = player.SendCommand("previous")
 		case "reconnect":
-			// TODO: add Player.Reconnect() method; auto-reconnect (#38) handles network drops
 			log.Printf("Manual reconnect requested")
+		}
+		if err != nil {
+			log.Printf("Transport command %q failed: %v", cmd.Command, err)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -85,11 +85,13 @@ func main() {
 
 	var tuiProg *tea.Program
 	var volumeCtrl *ui.VolumeControl
+	var transportCtrl *ui.TransportControl
 
 	if useTUI {
 		volumeCtrl = ui.NewVolumeControl()
+		transportCtrl = ui.NewTransportControl()
 		var err error
-		tuiProg, err = ui.Run(volumeCtrl)
+		tuiProg, err = ui.Run(volumeCtrl, transportCtrl)
 		if err != nil {
 			log.Fatalf("Failed to start TUI: %v", err)
 		}
@@ -150,10 +152,11 @@ func main() {
 		},
 		OnStateChange: func(state sendspin.PlayerState) {
 			updateTUI(ui.StatusMsg{
-				Codec:      state.Codec,
-				SampleRate: state.SampleRate,
-				Channels:   state.Channels,
-				BitDepth:   state.BitDepth,
+				Codec:         state.Codec,
+				SampleRate:    state.SampleRate,
+				Channels:      state.Channels,
+				BitDepth:      state.BitDepth,
+				PlaybackState: state.State,
 			})
 			connected := state.Connected
 			serverLabel := serverAddress
@@ -211,6 +214,10 @@ func main() {
 		go handleVolumeControl(player, volumeCtrl)
 	}
 
+	if transportCtrl != nil {
+		go handleTransportControl(player, transportCtrl)
+	}
+
 	if tuiProg != nil {
 		go statsUpdateLoop(player, updateTUI)
 	}
@@ -247,6 +254,37 @@ func handleVolumeControl(player *sendspin.Player, volumeCtrl *ui.VolumeControl) 
 	}
 }
 
+func handleTransportControl(player *sendspin.Player, ctrl *ui.TransportControl) {
+	for cmd := range ctrl.Commands {
+		switch cmd.Command {
+		case "toggle":
+			status := player.Status()
+			if status.State == "playing" {
+				player.Pause()
+			} else {
+				player.Play()
+			}
+		case "play":
+			player.Play()
+		case "pause":
+			player.Pause()
+		case "next":
+			if player.Status().Connected {
+				// TODO: wire to SendCommand when Player API exposes it
+				log.Printf("Next track requested")
+			}
+		case "previous":
+			if player.Status().Connected {
+				// TODO: wire to SendCommand when Player API exposes it
+				log.Printf("Previous track requested")
+			}
+		case "reconnect":
+			// TODO: add Player.Reconnect() method; auto-reconnect (#38) handles network drops
+			log.Printf("Manual reconnect requested")
+		}
+	}
+}
+
 func statsUpdateLoop(player *sendspin.Player, updateTUI func(ui.StatusMsg)) {
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
@@ -263,8 +301,6 @@ func statsUpdateLoop(player *sendspin.Player, updateTUI func(ui.StatusMsg)) {
 			SyncRTT:     stats.SyncRTT,
 			SyncQuality: stats.SyncQuality,
 			Goroutines:  runtime.NumGoroutine(),
-			MemAlloc:    0,
-			MemSys:      0,
 		})
 	}
 }

--- a/pkg/protocol/client.go
+++ b/pkg/protocol/client.go
@@ -319,7 +319,7 @@ func (c *Client) buildSupportedRoles() []string {
 	if len(c.config.SupportedRoles) > 0 {
 		return c.config.SupportedRoles
 	}
-	roles := []string{"player@v1", "metadata@v1"}
+	roles := []string{"player@v1", "metadata@v1", "controller@v1"}
 	if c.config.ArtworkV1Support != nil {
 		roles = append(roles, "artwork@v1")
 	}

--- a/pkg/protocol/client_test.go
+++ b/pkg/protocol/client_test.go
@@ -157,19 +157,19 @@ func TestBuildSupportedRoles_Default(t *testing.T) {
 		want   []string
 	}{
 		{
-			name:   "bare default is player+metadata",
+			name:   "bare default is player+metadata+controller",
 			config: Config{},
-			want:   []string{"player@v1", "metadata@v1"},
+			want:   []string{"player@v1", "metadata@v1", "controller@v1"},
 		},
 		{
 			name:   "artwork support adds artwork@v1",
 			config: Config{ArtworkV1Support: &ArtworkV1Support{}},
-			want:   []string{"player@v1", "metadata@v1", "artwork@v1"},
+			want:   []string{"player@v1", "metadata@v1", "controller@v1", "artwork@v1"},
 		},
 		{
 			name:   "visualizer support adds visualizer@v1",
 			config: Config{VisualizerV1Support: &VisualizerV1Support{}},
-			want:   []string{"player@v1", "metadata@v1", "visualizer@v1"},
+			want:   []string{"player@v1", "metadata@v1", "controller@v1", "visualizer@v1"},
 		},
 		{
 			name: "both support structs set",
@@ -177,7 +177,7 @@ func TestBuildSupportedRoles_Default(t *testing.T) {
 				ArtworkV1Support:    &ArtworkV1Support{},
 				VisualizerV1Support: &VisualizerV1Support{},
 			},
-			want: []string{"player@v1", "metadata@v1", "artwork@v1", "visualizer@v1"},
+			want: []string{"player@v1", "metadata@v1", "controller@v1", "artwork@v1", "visualizer@v1"},
 		},
 	}
 

--- a/pkg/sendspin/player.go
+++ b/pkg/sendspin/player.go
@@ -453,6 +453,21 @@ func (p *Player) Close() error {
 	return nil
 }
 
+// SendCommand sends a controller command to the server (e.g., "play",
+// "pause", "next", "previous"). This is how a player requests playback
+// control — the server decides whether to act on it.
+func (p *Player) SendCommand(command string) error {
+	if p.receiver == nil || p.receiver.client == nil {
+		return fmt.Errorf("not connected")
+	}
+	payload := map[string]interface{}{
+		"controller": map[string]interface{}{
+			"command": command,
+		},
+	}
+	return p.receiver.client.Send("client/command", payload)
+}
+
 func (p *Player) sendState() error {
 	if p.receiver == nil || p.receiver.client == nil {
 		return nil


### PR DESCRIPTION
Closes #81, closes #83.

Redesigns the player TUI to surface new features from the recent work and adds transport controls.

## What changed

**Playback state indicator:** ▶ Playing / ⏸ Paused / ⏹ Stopped / ● Idle / ↻ Reconnecting — driven by `group/update` from the server.

**Transport controls:** `space` = toggle play/pause, `n` = next, `p` = previous, `r` = reconnect. Next/previous log the command for now (need a `Player.SendCommand` API to wire fully).

**Codec display:** "FLAC 48kHz/24bit lossless" / "Opus 48kHz/16bit" / "PCM 192kHz/24bit lossless" — shows format context instead of raw numbers.

**Removed stale fields:**
- Dead sync offset (always showed 0 since the Kalman filter migration, was #30)
- Memory stats from debug view (not useful for users)

**Simplified buffer:** shows time only, no chunk count.

**Updated help bar:** `Space:Play/Pause  n:Next  p:Prev  ↑/↓:Vol  m:Mute  q:Quit`

## Test plan
- [x] `go test ./... -count=1 -race` — all packages green
- [x] 25 UI tests pass including 9 new ones (playback state, transport keys, display helpers)
- [x] Manual: build + run, verify TUI renders, test space/n/p keys