### PR TITLE
fix(player): persist a stable client_id across launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,35 @@ Connect to a specific server manually:
 - `--name` - Player friendly name (default: hostname-sendspin-player)
 - `--buffer-ms` - Jitter buffer size in milliseconds (default: 150)
 - `--log-file` - Log file path (default: sendspin-player.log)
+- `--client-id` - Override the persisted `client_id`. The value is written to the client-id file and reused on subsequent launches.
+- `--client-id-file` - Override the path to the client-id file (default: OS user config dir). Use a distinct path per instance to run multiple players on one host.
 - `--debug` - Enable debug logging
+
+#### Player Identity (`client_id`)
+
+The player sends a stable `client_id` to the server so controllers like Music Assistant treat it as the same player across restarts. Resolution order:
+
+1. `--client-id` flag (when set, also persisted to the client-id file)
+2. Persisted value from the client-id file
+3. MAC address of the primary network interface (`xx:xx:xx:xx:xx:xx`)
+4. Freshly generated UUID (written to the client-id file and reused next launch)
+
+Default client-id file location:
+
+- Linux / Raspberry Pi: `~/.config/sendspin-player/client-id`
+- macOS: `~/Library/Application Support/sendspin-player/client-id`
+- Windows: `%AppData%\sendspin-player\client-id`
+
+Deleting this file causes the next launch to re-derive a `client_id`, which the server will see as a new player.
+
+Running two players on the same host:
+
+```bash
+./sendspin-player --name "Kitchen"  --client-id-file ~/.config/sendspin-player/kitchen.id &
+./sendspin-player --name "Bedroom"  --client-id-file ~/.config/sendspin-player/bedroom.id &
+```
+
+Each instance resolves and persists its identity independently.
 
 #### Player TUI
 

--- a/main.go
+++ b/main.go
@@ -36,6 +36,8 @@ var (
 	daemon         = flag.Bool("daemon", false, "Daemon mode: log to stdout only (journalctl-friendly), no TUI, no log file")
 	preferredCodec = flag.String("preferred-codec", "", "Preferred codec: pcm (default), opus, or flac")
 	bufferCapacity = flag.Int("buffer-capacity", 1048576, "Buffer capacity in bytes advertised to server (default: 1MB)")
+	clientID       = flag.String("client-id", "", "Override the persisted client_id. When set, the value is written to the client-id file and reused on subsequent launches.")
+	clientIDFile   = flag.String("client-id-file", "", "Override the path to the client_id config file (default: OS user config dir). Use a distinct path per instance to run multiple players on one host.")
 )
 
 func main() {
@@ -145,6 +147,8 @@ func main() {
 		StaticDelayMs:  *staticDelayMs,
 		PreferredCodec: *preferredCodec,
 		BufferCapacity: *bufferCapacity,
+		ClientID:       *clientID,
+		ConfigPath:     *clientIDFile,
 		DeviceInfo: sendspin.DeviceInfo{
 			ProductName:     deviceProduct,
 			Manufacturer:    deviceManufacturer,

--- a/pkg/sendspin/client_id.go
+++ b/pkg/sendspin/client_id.go
@@ -1,0 +1,184 @@
+// ABOUTME: Stable client_id resolution for the player (override -> persisted -> MAC -> generated)
+// ABOUTME: Persists UUID fallback and overrides to the user config dir so identity survives restarts
+package sendspin
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const (
+	clientIDConfigSubdir = "sendspin-player"
+	clientIDConfigFile   = "client-id"
+)
+
+type clientIDSource string
+
+const (
+	sourceOverride  clientIDSource = "override"
+	sourcePersisted clientIDSource = "persisted"
+	sourceMAC       clientIDSource = "mac"
+	sourceGenerated clientIDSource = "generated"
+)
+
+// ResolveClientID returns a stable client_id for this player, following the
+// resolution order:
+//  1. override — used and persisted to the config file
+//  2. persisted value in the config file — used as-is
+//  3. MAC-derived from the primary network interface — not persisted
+//  4. freshly generated UUID — persisted for next launch
+//
+// Persisted value beats MAC on purpose: once Music Assistant has registered a
+// player under a given ID, switching to a different ID on a later launch would
+// create a duplicate player entry. Deleting the config file is the explicit
+// "re-derive" action.
+//
+// configPathOverride, if non-empty, replaces the default OS-specific config
+// path. Use this to run multiple players on a single host with distinct
+// identities (one file per instance).
+func ResolveClientID(override, configPathOverride string) (string, error) {
+	if configPathOverride != "" {
+		return resolveClientIDFrom(override, configPathOverride)
+	}
+	path, err := clientIDConfigPath()
+	if err != nil {
+		// No writable config dir; continue without persistence.
+		return resolveClientIDFrom(override, "")
+	}
+	return resolveClientIDFrom(override, path)
+}
+
+func resolveClientIDFrom(override, configPath string) (string, error) {
+	if override != "" {
+		persistIfPossible(configPath, override, "override")
+		logClientID(override, sourceOverride, configPath)
+		return override, nil
+	}
+
+	if configPath != "" {
+		if persisted, ok := readPersistedClientID(configPath); ok {
+			logClientID(persisted, sourcePersisted, configPath)
+			return persisted, nil
+		}
+	}
+
+	if mac, ok := pickStableMAC(allInterfaces()); ok {
+		logClientID(mac, sourceMAC, "")
+		return mac, nil
+	}
+
+	generated := uuid.New().String()
+	persistIfPossible(configPath, generated, "generated id")
+	logClientID(generated, sourceGenerated, configPath)
+	return generated, nil
+}
+
+func persistIfPossible(configPath, id, what string) {
+	if configPath == "" {
+		return
+	}
+	if err := writePersistedClientID(configPath, id); err != nil {
+		log.Printf("client_id: could not persist %s to %s: %v", what, configPath, err)
+	}
+}
+
+func logClientID(id string, source clientIDSource, path string) {
+	if path != "" && (source == sourceGenerated || source == sourceOverride) {
+		log.Printf("client_id: %s (source: %s, persisted: %s)", id, source, path)
+		return
+	}
+	log.Printf("client_id: %s (source: %s)", id, source)
+}
+
+// allInterfaces is a package-level var so tests can stub it.
+var allInterfaces = func() []net.Interface {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil
+	}
+	return ifaces
+}
+
+// pickStableMAC returns the MAC of the alphabetically-first eligible interface.
+// Eligible means: up, not loopback, 6-byte hardware address, not zero, not broadcast.
+// Alphabetical ordering gives deterministic selection across reboots and OSes
+// (eth0 < wlan0, Ethernet < Wi-Fi).
+func pickStableMAC(ifaces []net.Interface) (string, bool) {
+	eligible := make([]net.Interface, 0, len(ifaces))
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+		if iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		if len(iface.HardwareAddr) != 6 {
+			continue
+		}
+		if isZeroMAC(iface.HardwareAddr) || isBroadcastMAC(iface.HardwareAddr) {
+			continue
+		}
+		eligible = append(eligible, iface)
+	}
+	if len(eligible) == 0 {
+		return "", false
+	}
+	sort.Slice(eligible, func(i, j int) bool {
+		return eligible[i].Name < eligible[j].Name
+	})
+	return eligible[0].HardwareAddr.String(), true
+}
+
+func isZeroMAC(mac net.HardwareAddr) bool {
+	return bytes.Equal(mac, []byte{0, 0, 0, 0, 0, 0})
+}
+
+func isBroadcastMAC(mac net.HardwareAddr) bool {
+	return bytes.Equal(mac, []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff})
+}
+
+func clientIDConfigPath() (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("user config dir: %w", err)
+	}
+	return filepath.Join(dir, clientIDConfigSubdir, clientIDConfigFile), nil
+}
+
+func readPersistedClientID(path string) (string, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	id := strings.TrimSpace(string(data))
+	if id == "" {
+		return "", false
+	}
+	return id, true
+}
+
+// writePersistedClientID writes atomically via tempfile + rename so a crash
+// mid-write cannot leave an empty or truncated config file in place.
+func writePersistedClientID(path, id string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(id+"\n"), 0o600); err != nil {
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
+}

--- a/pkg/sendspin/client_id_test.go
+++ b/pkg/sendspin/client_id_test.go
@@ -1,0 +1,309 @@
+// ABOUTME: Tests for ResolveClientID precedence, MAC picker filter, and atomic file persistence
+package sendspin
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func mac(b ...byte) net.HardwareAddr { return net.HardwareAddr(b) }
+
+func TestPickStableMAC(t *testing.T) {
+	up := net.FlagUp
+	lo := net.FlagUp | net.FlagLoopback
+	down := net.Flags(0)
+
+	tests := []struct {
+		name   string
+		ifaces []net.Interface
+		want   string
+		wantOk bool
+	}{
+		{
+			name: "single eligible",
+			ifaces: []net.Interface{
+				{Name: "eth0", Flags: up, HardwareAddr: mac(0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff)},
+			},
+			want:   "aa:bb:cc:dd:ee:ff",
+			wantOk: true,
+		},
+		{
+			name: "skips loopback",
+			ifaces: []net.Interface{
+				{Name: "lo", Flags: lo, HardwareAddr: mac(1, 2, 3, 4, 5, 6)},
+				{Name: "eth0", Flags: up, HardwareAddr: mac(0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff)},
+			},
+			want:   "aa:bb:cc:dd:ee:ff",
+			wantOk: true,
+		},
+		{
+			name: "skips interfaces that are not up",
+			ifaces: []net.Interface{
+				{Name: "eth0", Flags: down, HardwareAddr: mac(1, 1, 1, 1, 1, 1)},
+				{Name: "wlan0", Flags: up, HardwareAddr: mac(2, 2, 2, 2, 2, 2)},
+			},
+			want:   "02:02:02:02:02:02",
+			wantOk: true,
+		},
+		{
+			name: "skips zero MAC",
+			ifaces: []net.Interface{
+				{Name: "eth0", Flags: up, HardwareAddr: mac(0, 0, 0, 0, 0, 0)},
+				{Name: "wlan0", Flags: up, HardwareAddr: mac(0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff)},
+			},
+			want:   "aa:bb:cc:dd:ee:ff",
+			wantOk: true,
+		},
+		{
+			name: "skips broadcast MAC",
+			ifaces: []net.Interface{
+				{Name: "eth0", Flags: up, HardwareAddr: mac(0xff, 0xff, 0xff, 0xff, 0xff, 0xff)},
+				{Name: "wlan0", Flags: up, HardwareAddr: mac(0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff)},
+			},
+			want:   "aa:bb:cc:dd:ee:ff",
+			wantOk: true,
+		},
+		{
+			name: "skips short hardware address",
+			ifaces: []net.Interface{
+				{Name: "eth0", Flags: up, HardwareAddr: mac(1, 2, 3, 4)},
+				{Name: "wlan0", Flags: up, HardwareAddr: mac(0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff)},
+			},
+			want:   "aa:bb:cc:dd:ee:ff",
+			wantOk: true,
+		},
+		{
+			name: "alphabetical sort: eth0 wins over wlan0",
+			ifaces: []net.Interface{
+				{Name: "wlan0", Flags: up, HardwareAddr: mac(0xaa, 0, 0, 0, 0, 0x01)},
+				{Name: "eth0", Flags: up, HardwareAddr: mac(0xbb, 0, 0, 0, 0, 0x02)},
+			},
+			want:   "bb:00:00:00:00:02",
+			wantOk: true,
+		},
+		{
+			name: "nothing eligible",
+			ifaces: []net.Interface{
+				{Name: "lo", Flags: lo, HardwareAddr: mac(0, 0, 0, 0, 0, 0)},
+				{Name: "eth0", Flags: down, HardwareAddr: mac(1, 1, 1, 1, 1, 1)},
+			},
+			want:   "",
+			wantOk: false,
+		},
+		{
+			name:   "empty input",
+			ifaces: nil,
+			want:   "",
+			wantOk: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := pickStableMAC(tt.ifaces)
+			if ok != tt.wantOk {
+				t.Errorf("ok = %v, want %v", ok, tt.wantOk)
+			}
+			if got != tt.want {
+				t.Errorf("mac = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPersistedClientID_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sendspin-player", "client-id")
+
+	if _, ok := readPersistedClientID(path); ok {
+		t.Fatal("read on nonexistent file should return ok=false")
+	}
+
+	if err := writePersistedClientID(path, "my-id-1234"); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	got, ok := readPersistedClientID(path)
+	if !ok || got != "my-id-1234" {
+		t.Errorf("after first write: ok=%v got=%q, want my-id-1234", ok, got)
+	}
+
+	if err := writePersistedClientID(path, "my-id-5678"); err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+	got, _ = readPersistedClientID(path)
+	if got != "my-id-5678" {
+		t.Errorf("after overwrite: got=%q, want my-id-5678", got)
+	}
+
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf("tempfile should have been renamed, stat err = %v", err)
+	}
+}
+
+func TestPersistedClientID_TrimsWhitespace(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "client-id")
+	if err := os.WriteFile(path, []byte("  padded-id\n\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	got, ok := readPersistedClientID(path)
+	if !ok || got != "padded-id" {
+		t.Errorf("got=%q ok=%v, want padded-id true", got, ok)
+	}
+}
+
+func TestPersistedClientID_EmptyFileIsNotUsed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "client-id")
+	if err := os.WriteFile(path, []byte("\n  \n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, ok := readPersistedClientID(path); ok {
+		t.Error("whitespace-only file should be treated as absent")
+	}
+}
+
+func withStubInterfaces(t *testing.T, stub func() []net.Interface) {
+	t.Helper()
+	prev := allInterfaces
+	allInterfaces = stub
+	t.Cleanup(func() { allInterfaces = prev })
+}
+
+func TestResolveClientIDFrom_OverrideWinsAndPersists(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "client-id")
+
+	id, err := resolveClientIDFrom("my-override", path)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if id != "my-override" {
+		t.Errorf("id = %q, want my-override", id)
+	}
+	persisted, ok := readPersistedClientID(path)
+	if !ok || persisted != "my-override" {
+		t.Errorf("override not persisted: ok=%v, persisted=%q", ok, persisted)
+	}
+}
+
+func TestResolveClientIDFrom_OverrideReplacesExistingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "client-id")
+	if err := writePersistedClientID(path, "stale-id"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	id, err := resolveClientIDFrom("fresh-override", path)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if id != "fresh-override" {
+		t.Errorf("id = %q, want fresh-override", id)
+	}
+	persisted, _ := readPersistedClientID(path)
+	if persisted != "fresh-override" {
+		t.Errorf("file still has %q, want fresh-override", persisted)
+	}
+}
+
+func TestResolveClientIDFrom_PersistedBeatsMAC(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "client-id")
+	if err := writePersistedClientID(path, "persisted-id"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	withStubInterfaces(t, func() []net.Interface {
+		return []net.Interface{
+			{Name: "eth0", Flags: net.FlagUp, HardwareAddr: mac(0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff)},
+		}
+	})
+
+	id, err := resolveClientIDFrom("", path)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if id != "persisted-id" {
+		t.Errorf("id = %q, want persisted-id (persisted must beat MAC)", id)
+	}
+}
+
+func TestResolveClientIDFrom_MACWhenNoPersistedValue(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "client-id")
+	withStubInterfaces(t, func() []net.Interface {
+		return []net.Interface{
+			{Name: "eth0", Flags: net.FlagUp, HardwareAddr: mac(0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff)},
+		}
+	})
+
+	id, err := resolveClientIDFrom("", path)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if id != "aa:bb:cc:dd:ee:ff" {
+		t.Errorf("id = %q, want MAC", id)
+	}
+	if _, ok := readPersistedClientID(path); ok {
+		t.Error("MAC-derived id should not be written to the config file")
+	}
+}
+
+func TestResolveClientIDFrom_GeneratedUUIDIsPersisted(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "client-id")
+	withStubInterfaces(t, func() []net.Interface { return nil })
+
+	id, err := resolveClientIDFrom("", path)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if id == "" {
+		t.Fatal("resolve returned empty id")
+	}
+	persisted, ok := readPersistedClientID(path)
+	if !ok {
+		t.Fatal("generated id should have been persisted")
+	}
+	if persisted != id {
+		t.Errorf("persisted=%q, returned=%q (must match)", persisted, id)
+	}
+}
+
+func TestResolveClientIDFrom_NoConfigPathStillReturnsID(t *testing.T) {
+	withStubInterfaces(t, func() []net.Interface { return nil })
+
+	id, err := resolveClientIDFrom("", "")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if id == "" {
+		t.Error("resolve with no persistence still must return a non-empty id")
+	}
+}
+
+// TestResolveClientID_ExplicitConfigPath verifies the public entry point
+// honors a caller-supplied path override, which is how --client-id-file
+// supports multiple instances on one host.
+func TestResolveClientID_ExplicitConfigPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "custom-id")
+	withStubInterfaces(t, func() []net.Interface { return nil })
+
+	id, err := ResolveClientID("", path)
+	if err != nil {
+		t.Fatalf("ResolveClientID: %v", err)
+	}
+	if id == "" {
+		t.Fatal("id is empty")
+	}
+	persisted, ok := readPersistedClientID(path)
+	if !ok {
+		t.Fatal("generated id not written to the override path")
+	}
+	if persisted != id {
+		t.Errorf("persisted=%q returned=%q", persisted, id)
+	}
+
+	// Second call should read from the same override path.
+	id2, err := ResolveClientID("", path)
+	if err != nil {
+		t.Fatalf("second ResolveClientID: %v", err)
+	}
+	if id2 != id {
+		t.Errorf("second resolve returned %q, want persisted %q", id2, id)
+	}
+}

--- a/pkg/sendspin/player.go
+++ b/pkg/sendspin/player.go
@@ -62,6 +62,17 @@ type PlayerConfig struct {
 	// it sends audio. Default: 1048576 (1MB).
 	BufferCapacity int
 
+	// ClientID optionally overrides the resolved client_id. Empty means
+	// resolve from the persisted config file, then the primary MAC, then
+	// a generated UUID. When set, the value is persisted so subsequent
+	// launches pick it up without the override flag.
+	ClientID string
+
+	// ConfigPath optionally overrides the path to the client_id config file.
+	// When empty, the default OS-specific user config path is used. Set this
+	// to run multiple player instances on the same host with distinct ids.
+	ConfigPath string
+
 	DeviceInfo DeviceInfo
 
 	OnMetadata func(Metadata)
@@ -200,6 +211,8 @@ func (p *Player) buildReceiver(addr string) (*Receiver, error) {
 		StaticDelayMs:  p.config.StaticDelayMs,
 		PreferredCodec: p.config.PreferredCodec,
 		BufferCapacity: p.config.BufferCapacity,
+		ClientID:       p.config.ClientID,
+		ConfigPath:     p.config.ConfigPath,
 		DeviceInfo:     p.config.DeviceInfo,
 		DecoderFactory: p.config.DecoderFactory,
 		OnMetadata:     p.config.OnMetadata,

--- a/pkg/sendspin/receiver.go
+++ b/pkg/sendspin/receiver.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Sendspin/sendspin-go/pkg/audio/decode"
 	"github.com/Sendspin/sendspin-go/pkg/protocol"
 	"github.com/Sendspin/sendspin-go/pkg/sync"
-	"github.com/google/uuid"
 )
 
 type ReceiverConfig struct {
@@ -23,6 +22,15 @@ type ReceiverConfig struct {
 	StaticDelayMs  int    // optional static latency compensation (ms) applied to every scheduled play time
 	PreferredCodec string // "pcm", "opus", or "flac" — reorders the advertised format list so the server picks this codec first
 	BufferCapacity int    // buffer_capacity in bytes advertised to the server (default: 1048576 = 1MB)
+	// ClientID optionally overrides the resolved client_id. When empty, the
+	// receiver calls ResolveClientID() to fall through persisted -> MAC -> UUID.
+	// When non-empty, the value is persisted by ResolveClientID so later
+	// launches pick it up without the override flag.
+	ClientID string
+	// ConfigPath optionally overrides the path to the client_id config file.
+	// When empty, the default OS-specific user config path is used. Set this
+	// to run multiple player instances on the same host with distinct ids.
+	ConfigPath     string
 	DeviceInfo     DeviceInfo
 	DecoderFactory func(audio.Format) (decode.Decoder, error)
 	OnMetadata     func(Metadata)
@@ -138,7 +146,10 @@ func (r *Receiver) Stats() ReceiverStats {
 // Connect establishes a connection to the server, performs initial clock sync,
 // and starts background goroutines for connection watching and clock sync.
 func (r *Receiver) Connect() error {
-	clientID := uuid.New().String()
+	clientID, err := ResolveClientID(r.config.ClientID, r.config.ConfigPath)
+	if err != nil {
+		return fmt.Errorf("resolve client_id: %w", err)
+	}
 
 	clientConfig := protocol.Config{
 		ServerAddr: r.serverAddr,


### PR DESCRIPTION
## Summary

Every player launch called `uuid.New()` for the `client_id` sent in `client/hello`. Music Assistant uses that value as the durable `player_id`, so each restart registered a brand-new player entity — producing duplicate entries and breaking cross-protocol device linking.

This change resolves the `client_id` once at `Connect()` with an explicit precedence:

1. `--client-id` flag (persisted)
2. Value already persisted in the client-id file
3. Primary network interface MAC (`xx:xx:xx:xx:xx:xx`)
4. Freshly generated UUID (persisted for next launch)

Path 3 is the normal case on a Pi with a NIC. The MAC format is deliberately chosen to hit MA's `is_valid_mac_address` branch in `providers/sendspin/player.py`, which auto-populates `IdentifierType.MAC_ADDRESS` — so the Sendspin player now links correctly with its AirPlay/Chromecast shadow when one exists.

## Design decisions

- **Persisted value beats MAC.** Once MA has registered a player under a given id, switching to a different id later would recreate the duplicate-player bug. Deleting the client-id file is the explicit "re-derive" action.
- **MAC path does not write to disk.** The MAC is already stable; writing would freeze the player to a dead NIC on hardware swap.
- **Alphabetical interface sort.** `net.Interfaces()` ordering is not stable across OSes/reboots; sorting by name gives `eth0 < wlan0`, `Ethernet < Wi-Fi`, which is deterministic.
- **Zero/broadcast MAC filter matches MA's validator.** Anything we send passes the server-side validation unchanged.
- **Atomic writes** (tempfile + rename, `0600`/`0700`) so a crash mid-write cannot leave a truncated file that triggers the UUID fallback next boot.
- **`--client-id-file` for multi-instance hosts.** Different config files per launch let a single machine host multiple players with independent identities.

## Files

- `pkg/sendspin/client_id.go` — new: `ResolveClientID`, `pickStableMAC`, persistence helpers
- `pkg/sendspin/client_id_test.go` — new: 9-case table test on the picker, file I/O round-trip, precedence integration (override > persisted > MAC > UUID), explicit-path override
- `pkg/sendspin/receiver.go` — `ReceiverConfig.{ClientID, ConfigPath}` added; `Connect()` now calls `ResolveClientID`
- `pkg/sendspin/player.go` — `PlayerConfig.{ClientID, ConfigPath}` added, threaded through
- `main.go` — `--client-id` and `--client-id-file` flags
- `README.md` — new "Player Identity" section with resolution order, default paths per OS, and a two-player-on-one-host example

## Test plan

- [x] `go test ./...` passes locally (pkg/sendspin 4.0s, all others cached-green)
- [x] `go vet ./...` clean
- [x] `go build ./...` clean; `sendspin-player --help` shows both new flags
- [ ] On a Raspberry Pi with a stable NIC: delete the config file, launch, confirm log line `client_id: xx:xx:xx:xx:xx:xx (source: mac)` and that MA registers a single player with a MAC device identifier
- [ ] On a container with loopback only: confirm `(source: generated, persisted: ...)` on first launch and `(source: persisted)` on the next
- [ ] Multi-instance: two concurrent players with distinct `--client-id-file` values register as two players in MA