### PR TITLE
feat(player): YAML config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,40 +257,80 @@ Connect to a specific server manually:
 
 #### Player Options
 
+- `--config` - Path to player.yaml config file. Default search: `$SENDSPIN_PLAYER_CONFIG`, `~/.config/sendspin/player.yaml`, `/etc/sendspin/player.yaml`.
 - `--server` - Manual server WebSocket address (skips mDNS discovery)
 - `--port` - Port for mDNS advertisement (default: 8927)
 - `--name` - Player friendly name (default: hostname-sendspin-player)
 - `--buffer-ms` - Jitter buffer size in milliseconds (default: 150)
 - `--log-file` - Log file path (default: sendspin-player.log)
-- `--client-id` - Override the persisted `client_id`. The value is written to the client-id file and reused on subsequent launches.
-- `--client-id-file` - Override the path to the client-id file (default: OS user config dir). Use a distinct path per instance to run multiple players on one host.
+- `--client-id` - Override the persisted `client_id`. When set, the value is written to the config file and reused on subsequent launches.
 - `--debug` - Enable debug logging
+
+#### Configuration File (`player.yaml`)
+
+Every CLI flag has a matching key in `player.yaml`. Keys use `snake_case` (`--buffer-ms` ↔ `buffer_ms`).
+
+**Search order** (first existing file wins; missing is not an error):
+
+1. `--config <path>` flag
+2. `$SENDSPIN_PLAYER_CONFIG`
+3. `~/.config/sendspin/player.yaml` (macOS: `~/Library/Application Support/sendspin/player.yaml`; Windows: `%AppData%\sendspin\player.yaml`)
+4. `/etc/sendspin/player.yaml` (daemon/system-wide)
+
+**Value precedence**, for every flag:
+
+1. CLI flag if passed
+2. Env var `SENDSPIN_PLAYER_<UPPER_SNAKE>` (e.g. `SENDSPIN_PLAYER_BUFFER_MS=200`)
+3. Config file key
+4. Built-in default
+
+**Example `player.yaml`:**
+
+```yaml
+# Identity
+name:       "Living Room"
+client_id:  "aa:bb:cc:dd:ee:ff"    # auto-derived from MAC if unset
+
+# Network
+server: ""                          # empty = use mDNS
+port:   8927
+
+# Audio
+buffer_ms:       150
+static_delay_ms: 0
+preferred_codec: ""                 # pcm (default), opus, flac
+buffer_capacity: 1048576
+
+# Device identity (shown in Music Assistant)
+product_name: ""
+manufacturer: ""
+
+# Behavior
+no_reconnect: false
+daemon:       false
+no_tui:       false
+log_file:     "sendspin-player.log"
+```
 
 #### Player Identity (`client_id`)
 
-The player sends a stable `client_id` to the server so controllers like Music Assistant treat it as the same player across restarts. Resolution order:
+The player sends a stable `client_id` so controllers like Music Assistant recognize it as the same player across restarts. Resolution order:
 
-1. `--client-id` flag (when set, also persisted to the client-id file)
-2. Persisted value from the client-id file
+1. `--client-id` flag (when set, also persisted to the config file as `client_id`)
+2. `client_id` key in the loaded `player.yaml`
 3. MAC address of the primary network interface (`xx:xx:xx:xx:xx:xx`)
-4. Freshly generated UUID (written to the client-id file and reused next launch)
+4. Freshly generated UUID (written to `player.yaml` as `client_id` and reused next launch)
 
-Default client-id file location:
+Removing `client_id` from `player.yaml` causes the next launch to re-derive, which the server will see as a new player.
 
-- Linux / Raspberry Pi: `~/.config/sendspin-player/client-id`
-- macOS: `~/Library/Application Support/sendspin-player/client-id`
-- Windows: `%AppData%\sendspin-player\client-id`
-
-Deleting this file causes the next launch to re-derive a `client_id`, which the server will see as a new player.
-
-Running two players on the same host:
+Running multiple players on one host:
 
 ```bash
-./sendspin-player --name "Kitchen"  --client-id-file ~/.config/sendspin-player/kitchen.id &
-./sendspin-player --name "Bedroom"  --client-id-file ~/.config/sendspin-player/bedroom.id &
+./sendspin-player --name "Kitchen" --config ~/.config/sendspin/kitchen.yaml &
+./sendspin-player --name "Bedroom" --config ~/.config/sendspin/bedroom.yaml &
 ```
 
-Each instance resolves and persists its identity independently.
+Each config file holds its own `client_id`, so the two instances register as two distinct players.
 
 #### Player TUI
 

--- a/dist/systemd/sendspin-player.env
+++ b/dist/systemd/sendspin-player.env
@@ -1,9 +1,14 @@
 # /etc/default/sendspin-player
 #
 # Environment file for the sendspin-player systemd service.
-# Uncomment and adjust the options below as needed.
 #
-# All flags are passed via SENDSPIN_PLAYER_OPTS.
+# For persistent configuration, prefer /etc/sendspin/player.yaml — every CLI
+# flag has a matching YAML key, and the player auto-discovers that file.
+# This env file is still useful for ad-hoc overrides.
+#
+# All flags here are passed via SENDSPIN_PLAYER_OPTS. Individual settings
+# can also be set via SENDSPIN_PLAYER_<UPPER_SNAKE> env vars (e.g.
+# SENDSPIN_PLAYER_BUFFER_MS=200), which take precedence over the YAML file.
 
 # Player name shown on the server (default: <hostname>-sendspin-player)
 # SENDSPIN_PLAYER_OPTS="--name 'Living Room'"

--- a/go.mod
+++ b/go.mod
@@ -40,4 +40,5 @@ require (
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -142,5 +142,8 @@ golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58
 golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d h1:vU5i/LfpvrRCpgM/VPfJLg5KjxD3E+hfT1SH+d9zLwg=
 golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/hraban/opus.v2 v2.0.0-20230925203106-0188a62cb302 h1:xeVptzkP8BuJhoIjNizd2bRHfq9KB9HfOLZu90T04XM=
 gopkg.in/hraban/opus.v2 v2.0.0-20230925203106-0188a62cb302/go.mod h1:/L5E7a21VWl8DeuCPKxQBdVG5cy+L0MRZ08B1wnqt7g=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -36,12 +36,26 @@ var (
 	daemon         = flag.Bool("daemon", false, "Daemon mode: log to stdout only (journalctl-friendly), no TUI, no log file")
 	preferredCodec = flag.String("preferred-codec", "", "Preferred codec: pcm (default), opus, or flac")
 	bufferCapacity = flag.Int("buffer-capacity", 1048576, "Buffer capacity in bytes advertised to server (default: 1MB)")
-	clientID       = flag.String("client-id", "", "Override the persisted client_id. When set, the value is written to the client-id file and reused on subsequent launches.")
-	clientIDFile   = flag.String("client-id-file", "", "Override the path to the client_id config file (default: OS user config dir). Use a distinct path per instance to run multiple players on one host.")
+	clientID       = flag.String("client-id", "", "Override the persisted client_id. When set, the value is written to the config file and reused on subsequent launches.")
+	configPath     = flag.String("config", "", "Path to player.yaml config file. Default search: $SENDSPIN_PLAYER_CONFIG, ~/.config/sendspin/player.yaml, /etc/sendspin/player.yaml.")
 )
 
 func main() {
 	flag.Parse()
+
+	// Overlay YAML file and SENDSPIN_PLAYER_* env vars onto flag vars for
+	// anything the user didn't set on the CLI. client_id is handled
+	// separately below because it has its own resolver and persistence.
+	setByUser := map[string]bool{"client-id": true, "config": true}
+	flag.Visit(func(f *flag.Flag) { setByUser[f.Name] = true })
+
+	cfg, loadedConfigPath, err := sendspin.LoadPlayerConfig(*configPath)
+	if err != nil {
+		log.Fatalf("config: %v", err)
+	}
+	if err := sendspin.ApplyEnvAndFile(flag.CommandLine, setByUser, cfg); err != nil {
+		log.Fatalf("config overlay: %v", err)
+	}
 
 	// Use TUI if not explicitly disabled; -stream-logs and -daemon both imply -no-tui
 	useTUI := !(*noTUI || *streamLogs || *daemon)
@@ -139,6 +153,11 @@ func main() {
 		deviceManufacturer = *manufacturer
 	}
 
+	resolvedClientID, err := resolveClientID(*clientID, cfg, loadedConfigPath)
+	if err != nil {
+		log.Fatalf("client_id: %v", err)
+	}
+
 	config := sendspin.PlayerConfig{
 		ServerAddr:     serverAddress,
 		PlayerName:     playerName,
@@ -147,8 +166,7 @@ func main() {
 		StaticDelayMs:  *staticDelayMs,
 		PreferredCodec: *preferredCodec,
 		BufferCapacity: *bufferCapacity,
-		ClientID:       *clientID,
-		ConfigPath:     *clientIDFile,
+		ClientID:       resolvedClientID,
 		DeviceInfo: sendspin.DeviceInfo{
 			ProductName:     deviceProduct,
 			Manufacturer:    deviceManufacturer,
@@ -290,6 +308,40 @@ func handleTransportControl(player *sendspin.Player, ctrl *ui.TransportControl) 
 			log.Printf("Transport command %q failed: %v", cmd.Command, err)
 		}
 	}
+}
+
+// resolveClientID chooses the player's client_id and arranges for it to be
+// persisted to the config file when a new value is generated or when a CLI
+// override differs from the on-disk value. Separated from main() purely for
+// readability — this is the only place the three inputs (flag, file, MAC)
+// and the write-back path come together.
+func resolveClientID(override string, cfg *sendspin.PlayerConfigFile, loadedConfigPath string) (string, error) {
+	persistPath := loadedConfigPath
+	if persistPath == "" {
+		p, err := sendspin.DefaultPlayerConfigPath()
+		if err != nil {
+			// No writable config dir. Proceed without write-back; a generated
+			// UUID will be stable for this session only, and the log line from
+			// ResolveClientID will show (source: generated) with no "persisted".
+			log.Printf("client_id: no config path available for persistence: %v", err)
+		} else {
+			persistPath = p
+		}
+	}
+
+	var persist sendspin.PersistFn
+	if persistPath != "" {
+		persist = func(id string) error {
+			return sendspin.WriteStringKey(persistPath, "client_id", id)
+		}
+	}
+
+	var fromConfig string
+	if cfg != nil {
+		fromConfig = cfg.ClientID
+	}
+
+	return sendspin.ResolveClientID(override, fromConfig, persist)
 }
 
 func statsUpdateLoop(player *sendspin.Player, updateTUI func(ui.StatusMsg)) {

--- a/pkg/sendspin/client_id.go
+++ b/pkg/sendspin/client_id.go
@@ -1,98 +1,82 @@
-// ABOUTME: Stable client_id resolution for the player (override -> persisted -> MAC -> generated)
-// ABOUTME: Persists UUID fallback and overrides to the user config dir so identity survives restarts
+// ABOUTME: Stable client_id resolution (override -> config value -> MAC -> generated UUID)
+// ABOUTME: Persistence of new values is delegated to a caller-supplied callback
 package sendspin
 
 import (
 	"bytes"
-	"fmt"
 	"log"
 	"net"
-	"os"
-	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/google/uuid"
-)
-
-const (
-	clientIDConfigSubdir = "sendspin-player"
-	clientIDConfigFile   = "client-id"
 )
 
 type clientIDSource string
 
 const (
 	sourceOverride  clientIDSource = "override"
-	sourcePersisted clientIDSource = "persisted"
+	sourceConfig    clientIDSource = "config"
 	sourceMAC       clientIDSource = "mac"
 	sourceGenerated clientIDSource = "generated"
 )
 
-// ResolveClientID returns a stable client_id for this player, following the
-// resolution order:
-//  1. override — used and persisted to the config file
-//  2. persisted value in the config file — used as-is
-//  3. MAC-derived from the primary network interface — not persisted
-//  4. freshly generated UUID — persisted for next launch
-//
-// Persisted value beats MAC on purpose: once Music Assistant has registered a
-// player under a given ID, switching to a different ID on a later launch would
-// create a duplicate player entry. Deleting the config file is the explicit
-// "re-derive" action.
-//
-// configPathOverride, if non-empty, replaces the default OS-specific config
-// path. Use this to run multiple players on a single host with distinct
-// identities (one file per instance).
-func ResolveClientID(override, configPathOverride string) (string, error) {
-	if configPathOverride != "" {
-		return resolveClientIDFrom(override, configPathOverride)
-	}
-	path, err := clientIDConfigPath()
-	if err != nil {
-		// No writable config dir; continue without persistence.
-		return resolveClientIDFrom(override, "")
-	}
-	return resolveClientIDFrom(override, path)
-}
+// PersistFn is called by ResolveClientID whenever a new client_id needs to be
+// written back to the config file. Implementations typically call
+// WriteStringKey(path, "client_id", id). Returning an error is logged but not
+// fatal — the player will still boot with the resolved id; the id just won't
+// survive a restart.
+type PersistFn func(id string) error
 
-func resolveClientIDFrom(override, configPath string) (string, error) {
+// ResolveClientID returns a stable client_id, following this precedence:
+//  1. override  — used as-is and persisted via persist (so a one-time seed sticks)
+//  2. fromConfig — used as-is, no persistence (value came from the file we'd write to)
+//  3. primary network interface MAC (xx:xx:xx:xx:xx:xx) — not persisted; MAC is inherently stable
+//  4. freshly generated UUID — persisted so the next launch takes path 2
+//
+// Persisted value beating MAC is deliberate: once Music Assistant has
+// registered a player under one id, switching to another creates a duplicate
+// entry. Deleting client_id from the config file is the explicit "re-derive".
+//
+// persist may be nil if the caller cannot write back (e.g. no config path
+// resolvable). In that case generated/override ids still work for the session
+// but won't survive a restart.
+func ResolveClientID(override, fromConfig string, persist PersistFn) (string, error) {
 	if override != "" {
-		persistIfPossible(configPath, override, "override")
-		logClientID(override, sourceOverride, configPath)
+		if override != fromConfig {
+			tryPersist(persist, override, "override")
+		}
+		logClientID(override, sourceOverride, persist != nil && override != fromConfig)
 		return override, nil
 	}
 
-	if configPath != "" {
-		if persisted, ok := readPersistedClientID(configPath); ok {
-			logClientID(persisted, sourcePersisted, configPath)
-			return persisted, nil
-		}
+	if fromConfig != "" {
+		logClientID(fromConfig, sourceConfig, false)
+		return fromConfig, nil
 	}
 
 	if mac, ok := pickStableMAC(allInterfaces()); ok {
-		logClientID(mac, sourceMAC, "")
+		logClientID(mac, sourceMAC, false)
 		return mac, nil
 	}
 
 	generated := uuid.New().String()
-	persistIfPossible(configPath, generated, "generated id")
-	logClientID(generated, sourceGenerated, configPath)
+	tryPersist(persist, generated, "generated id")
+	logClientID(generated, sourceGenerated, persist != nil)
 	return generated, nil
 }
 
-func persistIfPossible(configPath, id, what string) {
-	if configPath == "" {
+func tryPersist(persist PersistFn, id, what string) {
+	if persist == nil {
 		return
 	}
-	if err := writePersistedClientID(configPath, id); err != nil {
-		log.Printf("client_id: could not persist %s to %s: %v", what, configPath, err)
+	if err := persist(id); err != nil {
+		log.Printf("client_id: could not persist %s: %v", what, err)
 	}
 }
 
-func logClientID(id string, source clientIDSource, path string) {
-	if path != "" && (source == sourceGenerated || source == sourceOverride) {
-		log.Printf("client_id: %s (source: %s, persisted: %s)", id, source, path)
+func logClientID(id string, source clientIDSource, persisted bool) {
+	if persisted {
+		log.Printf("client_id: %s (source: %s, persisted)", id, source)
 		return
 	}
 	log.Printf("client_id: %s (source: %s)", id, source)
@@ -143,42 +127,4 @@ func isZeroMAC(mac net.HardwareAddr) bool {
 
 func isBroadcastMAC(mac net.HardwareAddr) bool {
 	return bytes.Equal(mac, []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff})
-}
-
-func clientIDConfigPath() (string, error) {
-	dir, err := os.UserConfigDir()
-	if err != nil {
-		return "", fmt.Errorf("user config dir: %w", err)
-	}
-	return filepath.Join(dir, clientIDConfigSubdir, clientIDConfigFile), nil
-}
-
-func readPersistedClientID(path string) (string, bool) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return "", false
-	}
-	id := strings.TrimSpace(string(data))
-	if id == "" {
-		return "", false
-	}
-	return id, true
-}
-
-// writePersistedClientID writes atomically via tempfile + rename so a crash
-// mid-write cannot leave an empty or truncated config file in place.
-func writePersistedClientID(path, id string) error {
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return fmt.Errorf("mkdir %s: %w", dir, err)
-	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, []byte(id+"\n"), 0o600); err != nil {
-		return fmt.Errorf("write temp: %w", err)
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
-		return fmt.Errorf("rename: %w", err)
-	}
-	return nil
 }

--- a/pkg/sendspin/client_id_test.go
+++ b/pkg/sendspin/client_id_test.go
@@ -1,10 +1,9 @@
-// ABOUTME: Tests for ResolveClientID precedence, MAC picker filter, and atomic file persistence
+// ABOUTME: Tests for ResolveClientID precedence and the MAC picker filter
 package sendspin
 
 import (
+	"errors"
 	"net"
-	"os"
-	"path/filepath"
 	"testing"
 )
 
@@ -113,53 +112,14 @@ func TestPickStableMAC(t *testing.T) {
 	}
 }
 
-func TestPersistedClientID_RoundTrip(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "sendspin-player", "client-id")
-
-	if _, ok := readPersistedClientID(path); ok {
-		t.Fatal("read on nonexistent file should return ok=false")
-	}
-
-	if err := writePersistedClientID(path, "my-id-1234"); err != nil {
-		t.Fatalf("first write: %v", err)
-	}
-	got, ok := readPersistedClientID(path)
-	if !ok || got != "my-id-1234" {
-		t.Errorf("after first write: ok=%v got=%q, want my-id-1234", ok, got)
-	}
-
-	if err := writePersistedClientID(path, "my-id-5678"); err != nil {
-		t.Fatalf("overwrite: %v", err)
-	}
-	got, _ = readPersistedClientID(path)
-	if got != "my-id-5678" {
-		t.Errorf("after overwrite: got=%q, want my-id-5678", got)
-	}
-
-	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
-		t.Errorf("tempfile should have been renamed, stat err = %v", err)
-	}
+type persistRecorder struct {
+	calls []string
+	err   error
 }
 
-func TestPersistedClientID_TrimsWhitespace(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "client-id")
-	if err := os.WriteFile(path, []byte("  padded-id\n\n"), 0o600); err != nil {
-		t.Fatalf("seed: %v", err)
-	}
-	got, ok := readPersistedClientID(path)
-	if !ok || got != "padded-id" {
-		t.Errorf("got=%q ok=%v, want padded-id true", got, ok)
-	}
-}
-
-func TestPersistedClientID_EmptyFileIsNotUsed(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "client-id")
-	if err := os.WriteFile(path, []byte("\n  \n"), 0o600); err != nil {
-		t.Fatalf("seed: %v", err)
-	}
-	if _, ok := readPersistedClientID(path); ok {
-		t.Error("whitespace-only file should be treated as absent")
-	}
+func (p *persistRecorder) persist(id string) error {
+	p.calls = append(p.calls, id)
+	return p.err
 }
 
 func withStubInterfaces(t *testing.T, stub func() []net.Interface) {
@@ -169,141 +129,116 @@ func withStubInterfaces(t *testing.T, stub func() []net.Interface) {
 	t.Cleanup(func() { allInterfaces = prev })
 }
 
-func TestResolveClientIDFrom_OverrideWinsAndPersists(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "client-id")
+func TestResolveClientID_OverrideWinsAndPersistsWhenDifferent(t *testing.T) {
+	rec := &persistRecorder{}
 
-	id, err := resolveClientIDFrom("my-override", path)
+	id, err := ResolveClientID("my-override", "", rec.persist)
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
 	if id != "my-override" {
 		t.Errorf("id = %q, want my-override", id)
 	}
-	persisted, ok := readPersistedClientID(path)
-	if !ok || persisted != "my-override" {
-		t.Errorf("override not persisted: ok=%v, persisted=%q", ok, persisted)
+	if len(rec.calls) != 1 || rec.calls[0] != "my-override" {
+		t.Errorf("persist calls = %v, want [my-override]", rec.calls)
 	}
 }
 
-func TestResolveClientIDFrom_OverrideReplacesExistingFile(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "client-id")
-	if err := writePersistedClientID(path, "stale-id"); err != nil {
-		t.Fatalf("seed: %v", err)
-	}
+func TestResolveClientID_OverrideMatchingConfigDoesNotPersist(t *testing.T) {
+	rec := &persistRecorder{}
 
-	id, err := resolveClientIDFrom("fresh-override", path)
+	id, err := ResolveClientID("same-id", "same-id", rec.persist)
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
-	if id != "fresh-override" {
-		t.Errorf("id = %q, want fresh-override", id)
+	if id != "same-id" {
+		t.Errorf("id = %q, want same-id", id)
 	}
-	persisted, _ := readPersistedClientID(path)
-	if persisted != "fresh-override" {
-		t.Errorf("file still has %q, want fresh-override", persisted)
+	if len(rec.calls) != 0 {
+		t.Errorf("persist calls = %v, want no-op when override matches config", rec.calls)
 	}
 }
 
-func TestResolveClientIDFrom_PersistedBeatsMAC(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "client-id")
-	if err := writePersistedClientID(path, "persisted-id"); err != nil {
-		t.Fatalf("seed: %v", err)
-	}
+func TestResolveClientID_ConfigBeatsMAC(t *testing.T) {
+	rec := &persistRecorder{}
 	withStubInterfaces(t, func() []net.Interface {
 		return []net.Interface{
 			{Name: "eth0", Flags: net.FlagUp, HardwareAddr: mac(0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff)},
 		}
 	})
 
-	id, err := resolveClientIDFrom("", path)
+	id, err := ResolveClientID("", "from-config", rec.persist)
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
-	if id != "persisted-id" {
-		t.Errorf("id = %q, want persisted-id (persisted must beat MAC)", id)
+	if id != "from-config" {
+		t.Errorf("id = %q, want from-config (config must beat MAC)", id)
+	}
+	if len(rec.calls) != 0 {
+		t.Errorf("persist calls = %v, want none (config path uses as-is)", rec.calls)
 	}
 }
 
-func TestResolveClientIDFrom_MACWhenNoPersistedValue(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "client-id")
+func TestResolveClientID_MACNotPersisted(t *testing.T) {
+	rec := &persistRecorder{}
 	withStubInterfaces(t, func() []net.Interface {
 		return []net.Interface{
 			{Name: "eth0", Flags: net.FlagUp, HardwareAddr: mac(0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff)},
 		}
 	})
 
-	id, err := resolveClientIDFrom("", path)
+	id, err := ResolveClientID("", "", rec.persist)
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
 	if id != "aa:bb:cc:dd:ee:ff" {
 		t.Errorf("id = %q, want MAC", id)
 	}
-	if _, ok := readPersistedClientID(path); ok {
-		t.Error("MAC-derived id should not be written to the config file")
+	if len(rec.calls) != 0 {
+		t.Errorf("persist calls = %v, want none (MAC is inherently stable)", rec.calls)
 	}
 }
 
-func TestResolveClientIDFrom_GeneratedUUIDIsPersisted(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "client-id")
+func TestResolveClientID_GeneratedUUIDPersisted(t *testing.T) {
+	rec := &persistRecorder{}
 	withStubInterfaces(t, func() []net.Interface { return nil })
 
-	id, err := resolveClientIDFrom("", path)
+	id, err := ResolveClientID("", "", rec.persist)
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
 	if id == "" {
 		t.Fatal("resolve returned empty id")
 	}
-	persisted, ok := readPersistedClientID(path)
-	if !ok {
-		t.Fatal("generated id should have been persisted")
-	}
-	if persisted != id {
-		t.Errorf("persisted=%q, returned=%q (must match)", persisted, id)
+	if len(rec.calls) != 1 || rec.calls[0] != id {
+		t.Errorf("persist calls = %v, want [%q]", rec.calls, id)
 	}
 }
 
-func TestResolveClientIDFrom_NoConfigPathStillReturnsID(t *testing.T) {
+func TestResolveClientID_NilPersistStillReturnsID(t *testing.T) {
 	withStubInterfaces(t, func() []net.Interface { return nil })
 
-	id, err := resolveClientIDFrom("", "")
+	id, err := ResolveClientID("", "", nil)
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
 	if id == "" {
-		t.Error("resolve with no persistence still must return a non-empty id")
+		t.Error("resolve with nil persist must still return a non-empty id")
 	}
 }
 
-// TestResolveClientID_ExplicitConfigPath verifies the public entry point
-// honors a caller-supplied path override, which is how --client-id-file
-// supports multiple instances on one host.
-func TestResolveClientID_ExplicitConfigPath(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "custom-id")
+func TestResolveClientID_PersistErrorIsNotFatal(t *testing.T) {
+	rec := &persistRecorder{err: errors.New("disk full")}
 	withStubInterfaces(t, func() []net.Interface { return nil })
 
-	id, err := ResolveClientID("", path)
+	id, err := ResolveClientID("", "", rec.persist)
 	if err != nil {
-		t.Fatalf("ResolveClientID: %v", err)
+		t.Fatalf("resolve should not fail when persist fails: %v", err)
 	}
 	if id == "" {
-		t.Fatal("id is empty")
+		t.Error("resolve returned empty id")
 	}
-	persisted, ok := readPersistedClientID(path)
-	if !ok {
-		t.Fatal("generated id not written to the override path")
-	}
-	if persisted != id {
-		t.Errorf("persisted=%q returned=%q", persisted, id)
-	}
-
-	// Second call should read from the same override path.
-	id2, err := ResolveClientID("", path)
-	if err != nil {
-		t.Fatalf("second ResolveClientID: %v", err)
-	}
-	if id2 != id {
-		t.Errorf("second resolve returned %q, want persisted %q", id2, id)
+	if len(rec.calls) != 1 {
+		t.Errorf("persist should have been attempted once, got %d calls", len(rec.calls))
 	}
 }

--- a/pkg/sendspin/config.go
+++ b/pkg/sendspin/config.go
@@ -1,0 +1,257 @@
+// ABOUTME: YAML config-file support for the player (paths, env overlay, write-back)
+// ABOUTME: Flat keys 1:1 with CLI flags; precedence CLI > env > file > built-in default
+package sendspin
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// PlayerEnvPrefix is the namespace for environment overrides of player config
+// values. Env key = PlayerEnvPrefix + upper-snake(flag name). Example:
+// "-buffer-ms" -> SENDSPIN_PLAYER_BUFFER_MS.
+const PlayerEnvPrefix = "SENDSPIN_PLAYER_"
+
+// PlayerConfigFile mirrors the player's CLI flags. Fields with "zero" values
+// that could reasonably be meaningful (bool, int) are pointers so absence in
+// the YAML can be distinguished from an explicit false/0.
+type PlayerConfigFile struct {
+	Name           string `yaml:"name,omitempty"`
+	Server         string `yaml:"server,omitempty"`
+	Port           *int   `yaml:"port,omitempty"`
+	BufferMs       *int   `yaml:"buffer_ms,omitempty"`
+	StaticDelayMs  *int   `yaml:"static_delay_ms,omitempty"`
+	LogFile        string `yaml:"log_file,omitempty"`
+	NoTUI          *bool  `yaml:"no_tui,omitempty"`
+	StreamLogs     *bool  `yaml:"stream_logs,omitempty"`
+	ProductName    string `yaml:"product_name,omitempty"`
+	Manufacturer   string `yaml:"manufacturer,omitempty"`
+	NoReconnect    *bool  `yaml:"no_reconnect,omitempty"`
+	Daemon         *bool  `yaml:"daemon,omitempty"`
+	PreferredCodec string `yaml:"preferred_codec,omitempty"`
+	BufferCapacity *int   `yaml:"buffer_capacity,omitempty"`
+	ClientID       string `yaml:"client_id,omitempty"`
+}
+
+// LoadPlayerConfig searches for a player.yaml and returns its parsed contents
+// along with the path that was loaded (empty if none was found).
+//
+// Search order (first existing wins):
+//  1. explicitPath if non-empty
+//  2. $SENDSPIN_PLAYER_CONFIG if set
+//  3. $XDG_CONFIG_HOME or OS equivalent + /sendspin/player.yaml
+//  4. /etc/sendspin/player.yaml
+//
+// A missing file is not an error; the caller gets (nil, "", nil).
+func LoadPlayerConfig(explicitPath string) (*PlayerConfigFile, string, error) {
+	for _, candidate := range playerConfigSearchPaths(explicitPath) {
+		if candidate == "" {
+			continue
+		}
+		data, err := os.ReadFile(candidate)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return nil, candidate, fmt.Errorf("read %s: %w", candidate, err)
+		}
+		var cfg PlayerConfigFile
+		if err := yaml.Unmarshal(data, &cfg); err != nil {
+			return nil, candidate, fmt.Errorf("parse %s: %w", candidate, err)
+		}
+		return &cfg, candidate, nil
+	}
+	return nil, "", nil
+}
+
+// DefaultPlayerConfigPath returns the canonical user-level player.yaml path
+// for this OS. Used when we need to auto-create the config for write-back.
+func DefaultPlayerConfigPath() (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("user config dir: %w", err)
+	}
+	return filepath.Join(dir, "sendspin", "player.yaml"), nil
+}
+
+func playerConfigSearchPaths(explicit string) []string {
+	paths := make([]string, 0, 4)
+	if explicit != "" {
+		paths = append(paths, explicit)
+	}
+	if env := os.Getenv("SENDSPIN_PLAYER_CONFIG"); env != "" {
+		paths = append(paths, env)
+	}
+	if dir, err := os.UserConfigDir(); err == nil {
+		paths = append(paths, filepath.Join(dir, "sendspin", "player.yaml"))
+	}
+	paths = append(paths, "/etc/sendspin/player.yaml")
+	return paths
+}
+
+// ApplyEnvAndFile overlays SENDSPIN_PLAYER_* env vars and YAML config-file
+// values into the given FlagSet, but only for flags the user did NOT set on
+// the CLI. Precedence: CLI (untouched here) > env > file > flag default.
+//
+// setByUser is typically built with flag.Visit before calling this.
+func ApplyEnvAndFile(fs *flag.FlagSet, setByUser map[string]bool, cfg *PlayerConfigFile) error {
+	configValues := cfg.asStringMap()
+	var firstErr error
+	fs.VisitAll(func(f *flag.Flag) {
+		if firstErr != nil || setByUser[f.Name] {
+			return
+		}
+		envKey := PlayerEnvPrefix + strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
+		if val, ok := os.LookupEnv(envKey); ok {
+			if err := fs.Set(f.Name, val); err != nil {
+				firstErr = fmt.Errorf("env %s -> -%s: %w", envKey, f.Name, err)
+			}
+			return
+		}
+		configKey := strings.ReplaceAll(f.Name, "-", "_")
+		if val, ok := configValues[configKey]; ok {
+			if err := fs.Set(f.Name, val); err != nil {
+				firstErr = fmt.Errorf("config %s -> -%s: %w", configKey, f.Name, err)
+			}
+		}
+	})
+	return firstErr
+}
+
+// asStringMap returns only the keys the user actually set in the YAML, as
+// strings suitable for flag.Set. Absent keys are omitted so the overlay
+// correctly falls through to the flag default.
+func (c *PlayerConfigFile) asStringMap() map[string]string {
+	m := make(map[string]string)
+	if c == nil {
+		return m
+	}
+	if c.Name != "" {
+		m["name"] = c.Name
+	}
+	if c.Server != "" {
+		m["server"] = c.Server
+	}
+	if c.Port != nil {
+		m["port"] = strconv.Itoa(*c.Port)
+	}
+	if c.BufferMs != nil {
+		m["buffer_ms"] = strconv.Itoa(*c.BufferMs)
+	}
+	if c.StaticDelayMs != nil {
+		m["static_delay_ms"] = strconv.Itoa(*c.StaticDelayMs)
+	}
+	if c.LogFile != "" {
+		m["log_file"] = c.LogFile
+	}
+	if c.NoTUI != nil {
+		m["no_tui"] = strconv.FormatBool(*c.NoTUI)
+	}
+	if c.StreamLogs != nil {
+		m["stream_logs"] = strconv.FormatBool(*c.StreamLogs)
+	}
+	if c.ProductName != "" {
+		m["product_name"] = c.ProductName
+	}
+	if c.Manufacturer != "" {
+		m["manufacturer"] = c.Manufacturer
+	}
+	if c.NoReconnect != nil {
+		m["no_reconnect"] = strconv.FormatBool(*c.NoReconnect)
+	}
+	if c.Daemon != nil {
+		m["daemon"] = strconv.FormatBool(*c.Daemon)
+	}
+	if c.PreferredCodec != "" {
+		m["preferred_codec"] = c.PreferredCodec
+	}
+	if c.BufferCapacity != nil {
+		m["buffer_capacity"] = strconv.Itoa(*c.BufferCapacity)
+	}
+	if c.ClientID != "" {
+		m["client_id"] = c.ClientID
+	}
+	return m
+}
+
+// WriteStringKey reads the YAML at path (if any), sets the given top-level
+// string key to value, and atomically writes the result back. Comments and
+// existing keys are preserved via yaml.Node round-tripping. Used to persist
+// the auto-generated client_id and the --client-id override.
+func WriteStringKey(path, key, value string) error {
+	var root yaml.Node
+
+	if data, err := os.ReadFile(path); err == nil {
+		if err := yaml.Unmarshal(data, &root); err != nil {
+			return fmt.Errorf("parse existing config %s: %w", path, err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+
+	mapping := topLevelMapping(&root)
+
+	setOrAppendStringKey(mapping, key, value)
+
+	buf, err := yaml.Marshal(&root)
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	return atomicWriteFile(path, buf)
+}
+
+// topLevelMapping returns the mapping node that backs the top of a YAML
+// document. If root is empty or non-document, it's initialized in place.
+func topLevelMapping(root *yaml.Node) *yaml.Node {
+	if root.Kind == yaml.DocumentNode && len(root.Content) > 0 && root.Content[0].Kind == yaml.MappingNode {
+		return root.Content[0]
+	}
+	mapping := &yaml.Node{Kind: yaml.MappingNode}
+	root.Kind = yaml.DocumentNode
+	root.Content = []*yaml.Node{mapping}
+	return mapping
+}
+
+// setOrAppendStringKey updates the value for key in a MappingNode, or appends
+// a new key/value pair if the key is not present. Leaves all other entries
+// (and their comments) untouched.
+func setOrAppendStringKey(mapping *yaml.Node, key, value string) {
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			mapping.Content[i+1].Kind = yaml.ScalarNode
+			mapping.Content[i+1].Tag = "!!str"
+			mapping.Content[i+1].Value = value
+			mapping.Content[i+1].Style = 0
+			return
+		}
+	}
+	mapping.Content = append(mapping.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value},
+	)
+}
+
+// atomicWriteFile writes data to path via tempfile + rename. Matches the
+// atomicity guarantees the old writePersistedClientID used to provide.
+func atomicWriteFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
+}

--- a/pkg/sendspin/config_test.go
+++ b/pkg/sendspin/config_test.go
@@ -1,0 +1,304 @@
+// ABOUTME: Tests for YAML config loading, env/file overlay precedence, and write-back round-trip
+package sendspin
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadPlayerConfig_ExplicitPathWithAllKeys(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "player.yaml")
+	body := `# My config
+name: "Kitchen"
+server: "192.168.1.100:8927"
+port: 8999
+buffer_ms: 250
+static_delay_ms: 10
+log_file: "custom.log"
+no_tui: true
+stream_logs: false
+product_name: "Test Speaker"
+manufacturer: "Acme"
+no_reconnect: true
+daemon: false
+preferred_codec: "flac"
+buffer_capacity: 2097152
+client_id: "aa:bb:cc:dd:ee:ff"
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	cfg, used, err := LoadPlayerConfig(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if used != path {
+		t.Errorf("used path = %q, want %q", used, path)
+	}
+	if cfg == nil {
+		t.Fatal("cfg is nil")
+	}
+	if cfg.Name != "Kitchen" || cfg.Server != "192.168.1.100:8927" {
+		t.Errorf("string keys: %+v", cfg)
+	}
+	if cfg.Port == nil || *cfg.Port != 8999 {
+		t.Errorf("port = %v, want 8999", cfg.Port)
+	}
+	if cfg.NoTUI == nil || !*cfg.NoTUI {
+		t.Errorf("no_tui = %v, want true", cfg.NoTUI)
+	}
+	if cfg.StreamLogs == nil || *cfg.StreamLogs {
+		t.Errorf("stream_logs = %v, want false", cfg.StreamLogs)
+	}
+	if cfg.ClientID != "aa:bb:cc:dd:ee:ff" {
+		t.Errorf("client_id = %q", cfg.ClientID)
+	}
+}
+
+func TestLoadPlayerConfig_MissingFileIsNotAnError(t *testing.T) {
+	cfg, used, err := LoadPlayerConfig(filepath.Join(t.TempDir(), "does-not-exist.yaml"))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg != nil || used != "" {
+		t.Errorf("expected nil/empty for missing file, got cfg=%v path=%q", cfg, used)
+	}
+}
+
+func TestLoadPlayerConfig_InvalidYAMLIsAnError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "player.yaml")
+	if err := os.WriteFile(path, []byte("not: valid: : yaml"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	_, _, err := LoadPlayerConfig(path)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestLoadPlayerConfig_EnvPathHonored(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, "from-env.yaml")
+	if err := os.WriteFile(envPath, []byte("name: EnvName\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	t.Setenv("SENDSPIN_PLAYER_CONFIG", envPath)
+
+	cfg, used, err := LoadPlayerConfig("")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if used != envPath {
+		t.Errorf("used = %q, want %q", used, envPath)
+	}
+	if cfg.Name != "EnvName" {
+		t.Errorf("name = %q", cfg.Name)
+	}
+}
+
+// applyPlayerFlags builds a flag.FlagSet mirroring the real player CLI so
+// ApplyEnvAndFile can be tested end-to-end.
+func newTestFlagSet() (*flag.FlagSet, map[string]*string, map[string]*int, map[string]*bool) {
+	fs := flag.NewFlagSet("player", flag.ContinueOnError)
+	strs := map[string]*string{
+		"name":            fs.String("name", "", "player name"),
+		"server":          fs.String("server", "", "server addr"),
+		"log-file":        fs.String("log-file", "default.log", "log file"),
+		"product-name":    fs.String("product-name", "", "product name"),
+		"manufacturer":    fs.String("manufacturer", "", "mfg"),
+		"preferred-codec": fs.String("preferred-codec", "", "codec"),
+		"client-id":       fs.String("client-id", "", "client id"),
+	}
+	ints := map[string]*int{
+		"port":            fs.Int("port", 8927, "port"),
+		"buffer-ms":       fs.Int("buffer-ms", 150, "buffer ms"),
+		"static-delay-ms": fs.Int("static-delay-ms", 0, "static delay"),
+		"buffer-capacity": fs.Int("buffer-capacity", 1048576, "buffer cap"),
+	}
+	bools := map[string]*bool{
+		"no-tui":       fs.Bool("no-tui", false, "no tui"),
+		"stream-logs":  fs.Bool("stream-logs", false, "stream logs"),
+		"no-reconnect": fs.Bool("no-reconnect", false, "no reconnect"),
+		"daemon":       fs.Bool("daemon", false, "daemon"),
+	}
+	return fs, strs, ints, bools
+}
+
+func TestApplyEnvAndFile_FileFillsUnsetFlags(t *testing.T) {
+	fs, strs, ints, bools := newTestFlagSet()
+	// Simulate user passing only "-name Foo"
+	if err := fs.Parse([]string{"-name", "CLI-Name"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	setByUser := map[string]bool{"name": true}
+
+	port := 9000
+	noTUI := true
+	cfg := &PlayerConfigFile{
+		Server: "file.example:1234",
+		Port:   &port,
+		NoTUI:  &noTUI,
+	}
+
+	if err := ApplyEnvAndFile(fs, setByUser, cfg); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if *strs["name"] != "CLI-Name" {
+		t.Errorf("CLI should win: name = %q", *strs["name"])
+	}
+	if *strs["server"] != "file.example:1234" {
+		t.Errorf("file should fill: server = %q", *strs["server"])
+	}
+	if *ints["port"] != 9000 {
+		t.Errorf("file should fill: port = %d", *ints["port"])
+	}
+	if !*bools["no-tui"] {
+		t.Errorf("file should fill: no_tui = %v", *bools["no-tui"])
+	}
+	// Unset elsewhere keeps default
+	if *ints["buffer-ms"] != 150 {
+		t.Errorf("default should stick: buffer-ms = %d", *ints["buffer-ms"])
+	}
+}
+
+func TestApplyEnvAndFile_EnvBeatsFile(t *testing.T) {
+	fs, strs, ints, _ := newTestFlagSet()
+	if err := fs.Parse(nil); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	t.Setenv("SENDSPIN_PLAYER_SERVER", "env.example:9999")
+	t.Setenv("SENDSPIN_PLAYER_PORT", "5555")
+
+	port := 9000
+	cfg := &PlayerConfigFile{
+		Server: "file.example:1234",
+		Port:   &port,
+	}
+
+	if err := ApplyEnvAndFile(fs, map[string]bool{}, cfg); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if *strs["server"] != "env.example:9999" {
+		t.Errorf("env should beat file: server = %q", *strs["server"])
+	}
+	if *ints["port"] != 5555 {
+		t.Errorf("env should beat file: port = %d", *ints["port"])
+	}
+}
+
+func TestApplyEnvAndFile_NilConfigStillHonorsEnv(t *testing.T) {
+	fs, strs, _, _ := newTestFlagSet()
+	if err := fs.Parse(nil); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	t.Setenv("SENDSPIN_PLAYER_NAME", "env-only")
+
+	if err := ApplyEnvAndFile(fs, map[string]bool{}, nil); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if *strs["name"] != "env-only" {
+		t.Errorf("name = %q, want env-only", *strs["name"])
+	}
+}
+
+func TestApplyEnvAndFile_InvalidEnvReturnsError(t *testing.T) {
+	fs, _, _, _ := newTestFlagSet()
+	if err := fs.Parse(nil); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	t.Setenv("SENDSPIN_PLAYER_PORT", "not-a-number")
+
+	err := ApplyEnvAndFile(fs, map[string]bool{}, nil)
+	if err == nil {
+		t.Fatal("expected error on invalid env int")
+	}
+	if !strings.Contains(err.Error(), "port") {
+		t.Errorf("error should mention the offending flag: %v", err)
+	}
+}
+
+func TestWriteStringKey_CreatesFileWithSingleKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "player.yaml")
+
+	if err := WriteStringKey(path, "client_id", "aa:bb:cc:dd:ee:ff"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cfg, _, err := LoadPlayerConfig(path)
+	if err != nil {
+		t.Fatalf("load after write: %v", err)
+	}
+	if cfg.ClientID != "aa:bb:cc:dd:ee:ff" {
+		t.Errorf("client_id = %q", cfg.ClientID)
+	}
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf("tempfile should be cleaned up: %v", err)
+	}
+}
+
+func TestWriteStringKey_UpdatesExistingKeyPreservingOthersAndComments(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "player.yaml")
+	initial := `# Living room speaker
+name: "Living Room"
+server: "192.168.1.100:8927"
+client_id: "old-id"
+buffer_ms: 250
+`
+	if err := os.WriteFile(path, []byte(initial), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := WriteStringKey(path, "client_id", "new-id"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	text := string(got)
+
+	if !strings.Contains(text, `client_id: "new-id"`) && !strings.Contains(text, `client_id: new-id`) {
+		t.Errorf("client_id not updated in file:\n%s", text)
+	}
+	if strings.Contains(text, "old-id") {
+		t.Errorf("old value still present:\n%s", text)
+	}
+	// Other keys preserved.
+	for _, want := range []string{"Living Room", "192.168.1.100:8927", "buffer_ms"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("missing preserved content %q in:\n%s", want, text)
+		}
+	}
+	// The leading comment survives round-trip.
+	if !strings.Contains(text, "# Living room speaker") {
+		t.Errorf("leading comment lost:\n%s", text)
+	}
+}
+
+func TestWriteStringKey_AppendsKeyWhenAbsent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "player.yaml")
+	initial := "name: Kitchen\n"
+	if err := os.WriteFile(path, []byte(initial), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := WriteStringKey(path, "client_id", "new-value"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cfg, _, err := LoadPlayerConfig(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.Name != "Kitchen" {
+		t.Errorf("original key lost: name = %q", cfg.Name)
+	}
+	if cfg.ClientID != "new-value" {
+		t.Errorf("new key missing: client_id = %q", cfg.ClientID)
+	}
+}

--- a/pkg/sendspin/player.go
+++ b/pkg/sendspin/player.go
@@ -62,16 +62,10 @@ type PlayerConfig struct {
 	// it sends audio. Default: 1048576 (1MB).
 	BufferCapacity int
 
-	// ClientID optionally overrides the resolved client_id. Empty means
-	// resolve from the persisted config file, then the primary MAC, then
-	// a generated UUID. When set, the value is persisted so subsequent
-	// launches pick it up without the override flag.
+	// ClientID is the already-resolved client_id to advertise in client/hello.
+	// Required — callers should compute this once at startup (typically via
+	// ResolveClientID) and reuse the same value across reconnects.
 	ClientID string
-
-	// ConfigPath optionally overrides the path to the client_id config file.
-	// When empty, the default OS-specific user config path is used. Set this
-	// to run multiple player instances on the same host with distinct ids.
-	ConfigPath string
 
 	DeviceInfo DeviceInfo
 
@@ -212,7 +206,6 @@ func (p *Player) buildReceiver(addr string) (*Receiver, error) {
 		PreferredCodec: p.config.PreferredCodec,
 		BufferCapacity: p.config.BufferCapacity,
 		ClientID:       p.config.ClientID,
-		ConfigPath:     p.config.ConfigPath,
 		DeviceInfo:     p.config.DeviceInfo,
 		DecoderFactory: p.config.DecoderFactory,
 		OnMetadata:     p.config.OnMetadata,

--- a/pkg/sendspin/receiver.go
+++ b/pkg/sendspin/receiver.go
@@ -22,15 +22,10 @@ type ReceiverConfig struct {
 	StaticDelayMs  int    // optional static latency compensation (ms) applied to every scheduled play time
 	PreferredCodec string // "pcm", "opus", or "flac" — reorders the advertised format list so the server picks this codec first
 	BufferCapacity int    // buffer_capacity in bytes advertised to the server (default: 1048576 = 1MB)
-	// ClientID optionally overrides the resolved client_id. When empty, the
-	// receiver calls ResolveClientID() to fall through persisted -> MAC -> UUID.
-	// When non-empty, the value is persisted by ResolveClientID so later
-	// launches pick it up without the override flag.
-	ClientID string
-	// ConfigPath optionally overrides the path to the client_id config file.
-	// When empty, the default OS-specific user config path is used. Set this
-	// to run multiple player instances on the same host with distinct ids.
-	ConfigPath     string
+	// ClientID is the already-resolved client_id to advertise in client/hello.
+	// Required — callers should compute this once at startup (typically via
+	// ResolveClientID) and thread the same value through reconnects.
+	ClientID       string
 	DeviceInfo     DeviceInfo
 	DecoderFactory func(audio.Format) (decode.Decoder, error)
 	OnMetadata     func(Metadata)
@@ -146,14 +141,13 @@ func (r *Receiver) Stats() ReceiverStats {
 // Connect establishes a connection to the server, performs initial clock sync,
 // and starts background goroutines for connection watching and clock sync.
 func (r *Receiver) Connect() error {
-	clientID, err := ResolveClientID(r.config.ClientID, r.config.ConfigPath)
-	if err != nil {
-		return fmt.Errorf("resolve client_id: %w", err)
+	if r.config.ClientID == "" {
+		return fmt.Errorf("ReceiverConfig.ClientID is required (resolve via sendspin.ResolveClientID)")
 	}
 
 	clientConfig := protocol.Config{
 		ServerAddr: r.serverAddr,
-		ClientID:   clientID,
+		ClientID:   r.config.ClientID,
 		Name:       r.config.PlayerName,
 		Version:    1,
 		DeviceInfo: protocol.DeviceInfo{


### PR DESCRIPTION
Closes #40.

## Summary

Adds a YAML config file (`player.yaml`) whose keys map 1:1 to the player's CLI flags. Per-value precedence is **CLI > `SENDSPIN_PLAYER_*` env > file > built-in default**. The `client_id` plumbing from #87 (unreleased) is folded in as the `client_id` key — the standalone `client-id` file and `--client-id-file` flag are dropped.

Quality-of-life for daemon/headless deploys: drop a populated `/etc/sendspin/player.yaml` onto a Pi, install the binary, start the systemd unit. No CLI invocation needed.

## Resolution details

**Config file search** (first existing file wins; missing is fine):

1. `--config <path>`
2. `$SENDSPIN_PLAYER_CONFIG`
3. `~/.config/sendspin/player.yaml` (`%AppData%\sendspin\player.yaml` on Windows, `~/Library/Application Support/sendspin/player.yaml` on macOS)
4. `/etc/sendspin/player.yaml`

**Per-value precedence**, for every flag:

1. CLI flag if the user passed it (detected via `flag.Visit`)
2. Env var `SENDSPIN_PLAYER_<UPPER_SNAKE>` (e.g. `SENDSPIN_PLAYER_BUFFER_MS=200`)
3. Config file key
4. Built-in default

**`client_id` lifecycle**, folded into the same file:

1. `--client-id` flag → used and persisted to `player.yaml` if different from what's there
2. `client_id` key in the YAML → used as-is
3. Primary-interface MAC (`xx:xx:xx:xx:xx:xx`) → used as-is, not persisted (MAC is inherently stable)
4. Freshly generated UUID → persisted so the next launch takes path 2

`client_id` is deliberately NOT routed through the env/file overlay so setting `SENDSPIN_PLAYER_CLIENT_ID` temporarily doesn't silently write to disk. The `-client-id` CLI flag remains the one persisting path.

## Design decisions worth a second look

- **Pointer types (`*int`, `*bool`) in `PlayerConfigFile`.** Needed to distinguish "absent from YAML" from "explicitly false/0." Strings use `""` as the sentinel, matching existing main.go conventions.
- **`yaml.Node` for write-back.** Re-marshalling the struct would reshuffle keys and drop comments. Walking the node tree and mutating just the `client_id` key preserves everything else; test `TestWriteStringKey_UpdatesExistingKeyPreservingOthersAndComments` asserts this round-trip.
- **Atomic write** via tempfile + rename, `0600` file / `0700` dir.
- **`BurntSushi/toml` was the alternative** — YAML was chosen to match the sendspin ecosystem's existing format; `gopkg.in/yaml.v3` is the only new dep.

## Files

- `pkg/sendspin/config.go` *(new)* — `PlayerConfigFile`, `LoadPlayerConfig`, `ApplyEnvAndFile`, `WriteStringKey`, `DefaultPlayerConfigPath`, atomic write
- `pkg/sendspin/config_test.go` *(new)* — YAML load (all keys, missing, invalid, env-path), overlay precedence (file-fills-unset, env-beats-file, nil-config-still-honors-env, invalid-env-errors), write-back (create, update-preserving-comments, append-when-absent)
- `pkg/sendspin/client_id.go` — `ResolveClientID(override, fromConfig, persist)`; I/O moved to the caller. `persist` is a `PersistFn` callback.
- `pkg/sendspin/client_id_test.go` — precedence tests via in-memory `persistRecorder` stub; no filesystem dependencies
- `pkg/sendspin/receiver.go` / `pkg/sendspin/player.go` — `ConfigPath` field removed from both configs; `ClientID` is now required at Connect time
- `main.go` — new `--config` flag; `--client-id-file` removed; `ApplyEnvAndFile` overlay wired into startup; `resolveClientID` helper glues the three inputs and write-back closure
- `dist/systemd/sendspin-player.env` — header points operators at `/etc/sendspin/player.yaml` as the preferred surface
- `README.md` — "Configuration File" subsection with search order, precedence ladder, example YAML; "Player Identity" updated to the YAML-key model
- `go.mod` / `go.sum` — `+ gopkg.in/yaml.v3 v3.0.1`

## Example `player.yaml`

```yaml
# Identity
name:       "Living Room"
client_id:  "aa:bb:cc:dd:ee:ff"    # auto-derived from MAC if unset

# Network
server: ""                          # empty = use mDNS
port:   8927

# Audio
buffer_ms:       150
static_delay_ms: 0
preferred_codec: ""                 # pcm (default), opus, flac
buffer_capacity: 1048576

# Device identity (shown in Music Assistant)
product_name: ""
manufacturer: ""

# Behavior
no_reconnect: false
daemon:       false
no_tui:       false
log_file:     "sendspin-player.log"
```

## Test plan

- [x] `go test ./...` clean
- [x] `go vet ./...` clean
- [x] `go build ./...` clean; `--help` shows `--config`, `--client-id`, no `--client-id-file`
- [ ] Fresh Pi install: drop `/etc/sendspin/player.yaml` with just `name: "Living Room"`; start systemd unit; confirm Music Assistant picks up a single player with a MAC-derived `client_id`
- [ ] Precedence: file has `name: File`, run `SENDSPIN_PLAYER_NAME=Env ./sendspin-player --name CLI` → log shows `CLI`
- [ ] Write-back preserves a user-added comment: hand-edit `player.yaml` with `# my note` above `name`, run player without `client_id`, confirm file is updated with `client_id: <uuid>` and the comment survives
- [ ] Multi-instance: two `./sendspin-player --config <path>` invocations with distinct paths register as two players in MA

## Scope not covered

- **Server** (`cmd/sendspin-server`) is unchanged — the player/server config work is split per the issue discussion; server follow-up PR.
- **No `--print-config` subcommand** for generating a starter YAML. Easy to add later.