### PR TITLE
docs(player): ship annotated player.yaml starter and copy it on install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,12 +92,19 @@ install-daemon: player
 	else \
 		echo "/etc/default/sendspin-player already exists, not overwriting."; \
 	fi
+	@if [ ! -f /etc/sendspin/player.yaml ]; then \
+		install -d -m 755 /etc/sendspin; \
+		install -m 644 dist/config/player.example.yaml /etc/sendspin/player.yaml; \
+		echo "Created /etc/sendspin/player.yaml — edit this file to configure."; \
+	else \
+		echo "/etc/sendspin/player.yaml already exists, not overwriting."; \
+	fi
 	systemctl daemon-reload
 	@echo ""
 	@echo "Installed. To start:"
 	@echo "  sudo systemctl enable --now sendspin-player"
 	@echo ""
-	@echo "Configure via /etc/default/sendspin-player"
+	@echo "Configure via /etc/sendspin/player.yaml (preferred) or /etc/default/sendspin-player"
 
 # Uninstall the systemd daemon
 uninstall-daemon:
@@ -107,7 +114,7 @@ uninstall-daemon:
 	rm -f /etc/systemd/system/sendspin-player.service
 	rm -f /usr/local/bin/sendspin-player
 	systemctl daemon-reload
-	@echo "Removed. /etc/default/sendspin-player left in place (manual cleanup if desired)."
+	@echo "Removed. /etc/default/sendspin-player and /etc/sendspin/player.yaml left in place (manual cleanup if desired)."
 
 # Conformance test suite — runs the Sendspin protocol conformance harness
 # against the local sendspin-go checkout. Mirrors what CI does so contributors

--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ Connect to a specific server manually:
 
 Every CLI flag has a matching key in `player.yaml`. Keys use `snake_case` (`--buffer-ms` ↔ `buffer_ms`).
 
+A fully-commented starter file lives at [`dist/config/player.example.yaml`](dist/config/player.example.yaml) — copy it to `~/.config/sendspin/player.yaml` (user install) or `/etc/sendspin/player.yaml` (daemon) and uncomment the keys you want to set.
+
 **Search order** (first existing file wins; missing is not an error):
 
 1. `--config <path>` flag

--- a/dist/config/player.example.yaml
+++ b/dist/config/player.example.yaml
@@ -1,0 +1,85 @@
+# sendspin-player configuration
+#
+# Search order (first existing file wins; missing is not an error):
+#   1. --config <path>
+#   2. $SENDSPIN_PLAYER_CONFIG
+#   3. ~/.config/sendspin/player.yaml           (user install)
+#   4. /etc/sendspin/player.yaml                (daemon / system-wide)
+#
+# Per-value precedence for every key below:
+#   CLI flag > SENDSPIN_PLAYER_<UPPER_SNAKE> env > this file > built-in default
+#
+# Every key is optional. Uncomment and adjust as needed. The player will
+# write its auto-derived client_id back into this file on first launch so
+# Music Assistant keeps recognizing the same player across restarts.
+
+# ---------------------------------------------------------------------------
+# Identity
+# ---------------------------------------------------------------------------
+
+# Friendly name shown in Music Assistant and on the server.
+# Default: <hostname>-sendspin-player
+# name: "Living Room"
+
+# Stable identifier the server uses as the player_id. Leave unset and the
+# player derives it from the primary network interface MAC on first launch
+# and writes the result here. Set explicitly to seed a specific id, or to
+# run multiple players on one host (use a distinct --config file per
+# instance so each gets its own client_id).
+# client_id: "aa:bb:cc:dd:ee:ff"
+
+# ---------------------------------------------------------------------------
+# Network
+# ---------------------------------------------------------------------------
+
+# Manual server address (host:port). Leave empty to use mDNS discovery.
+# server: "192.168.1.100:8927"
+
+# UDP port advertised via mDNS.
+# port: 8927
+
+# ---------------------------------------------------------------------------
+# Audio
+# ---------------------------------------------------------------------------
+
+# Jitter buffer size in milliseconds. Higher tolerates more network jitter
+# at the cost of added latency.
+# buffer_ms: 150
+
+# Static playback delay in milliseconds applied to every scheduled play
+# time. Compensates for hardware that introduces a fixed downstream delay
+# (Bluetooth sinks, AVRs with DSP, some USB DACs).
+# static_delay_ms: 0
+
+# Preferred codec. The server picks this first if both sides support it.
+# One of: pcm, opus, flac. Empty = server default (pcm).
+# preferred_codec: "flac"
+
+# Receive buffer capacity in bytes advertised to the server. Controls how
+# far ahead the server may send audio.
+# buffer_capacity: 1048576
+
+# ---------------------------------------------------------------------------
+# Device identity (shown in Music Assistant's device registry)
+# ---------------------------------------------------------------------------
+
+# product_name: "Living Room Speaker"
+# manufacturer: "Acme"
+
+# ---------------------------------------------------------------------------
+# Behavior
+# ---------------------------------------------------------------------------
+
+# Disable automatic reconnect on connection loss. Default false (the player
+# reconnects with exponential backoff).
+# no_reconnect: false
+
+# Daemon mode: log to stdout only (journalctl-friendly), no TUI, no log file.
+# Recommended when running under systemd.
+# daemon: false
+
+# Disable the interactive terminal UI, stream logs to stdout instead.
+# no_tui: false
+
+# Log file path. Ignored when daemon mode is on.
+# log_file: "sendspin-player.log"


### PR DESCRIPTION
Follow-up to #88 — adds the starter example file that was called out as missing after the initial config-file PR landed.

## Summary

- **`dist/config/player.example.yaml`** (new): fully commented starter file. Every supported key is listed with its default and a short explanation, all commented out so the file itself is a no-op until keys are uncommented. Sections: Identity, Network, Audio, Device identity, Behavior.
- **`Makefile`**: `install-daemon` now copies the example to `/etc/sendspin/player.yaml` on first install, with the same \"don't overwrite if present\" guard the existing \`/etc/default/sendspin-player\` install uses. `uninstall-daemon` leaves it in place (user-owned config).
- **`README.md`**: one-line pointer to the example in the \"Configuration File\" subsection.

## Design notes

- **Every key commented out.** If the starter set any key we'd be inheriting that opinion into every install (\`buffer_ms: 150\` looks identical to the built-in default until you question it). Commented-out keys make the distinction explicit — the file is provably not overriding anything.
- **Force-added under `dist/`.** `dist/` is gitignored (originally for build artifacts), but the existing systemd unit and env file under `dist/systemd/` were already force-tracked as deployment templates. The example YAML sits naturally alongside them.
- **Idempotent install.** A user who edits `/etc/sendspin/player.yaml` and later runs `make install-daemon` to upgrade the binary does not get their config stomped — mirrors the same guard already used for `/etc/default/sendspin-player`.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [ ] `sudo make install-daemon` on a fresh host: confirm `/etc/sendspin/player.yaml` is created with contents identical to `dist/config/player.example.yaml`
- [ ] Run `make install-daemon` twice on the same host: second run logs `"/etc/sendspin/player.yaml already exists, not overwriting."` and leaves the file untouched
- [ ] Edit `/etc/sendspin/player.yaml` (e.g. uncomment and set `name: "Living Room"`), run `sudo systemctl start sendspin-player`, confirm the name shows up in Music Assistant