### PR TITLE
feat(player): audio device selection and enumeration

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ Connect to a specific server manually:
 - `--buffer-ms` - Jitter buffer size in milliseconds (default: 150)
 - `--log-file` - Log file path (default: sendspin-player.log)
 - `--client-id` - Override the persisted `client_id`. When set, the value is written to the config file and reused on subsequent launches.
+- `--audio-device` - Playback device name (see `--list-audio-devices`). Empty = miniaudio default.
+- `--list-audio-devices` - Print every playback device miniaudio can see and exit.
 - `--debug` - Enable debug logging
 
 #### Configuration File (`player.yaml`)
@@ -312,7 +314,36 @@ no_reconnect: false
 daemon:       false
 no_tui:       false
 log_file:     "sendspin-player.log"
+audio_device: ""                    # see --list-audio-devices; empty = miniaudio default
 ```
+
+#### Selecting a playback device
+
+On Linux/macOS miniaudio picks its first-choice backend and that backend's default sink, which is usually fine on desktops but can route to the wrong card on a headless Pi (e.g. HDMI instead of a USB DAC or speaker HAT). To see what miniaudio sees and pick a specific device:
+
+```bash
+$ sendspin-player --list-audio-devices
+Playback devices:
+  [*] HDA Intel PCH: ALC257 Analog (hw:0,0)
+  [ ] HDMI 0 (hw:0,3)
+  [ ] USB Audio Device (hw:1,0)
+
+[*] = current default. Use --audio-device "<name>" or set audio_device: in player.yaml.
+```
+
+Then either:
+
+```bash
+./sendspin-player --audio-device "USB Audio Device"
+```
+
+Or in `player.yaml`:
+
+```yaml
+audio_device: "USB Audio Device"
+```
+
+The name must match exactly (case-sensitive, including any `(hw:X,Y)` suffix ALSA appends). If the name doesn't match, the player fails to start and lists every available device — silent fallback is deliberately not offered, because "it's not playing" is harder to debug than "it refused to start."
 
 #### Player Identity (`client_id`)
 

--- a/dist/config/player.example.yaml
+++ b/dist/config/player.example.yaml
@@ -83,3 +83,11 @@
 
 # Log file path. Ignored when daemon mode is on.
 # log_file: "sendspin-player.log"
+
+# Playback device name. Leave unset to let miniaudio pick its default sink.
+# To see available devices on this host, run:
+#   sendspin-player --list-audio-devices
+# The name must match exactly. If it doesn't match, the player refuses to
+# start and lists every available device — silent fallback would defeat the
+# point of setting this key.
+# audio_device: "USB Audio Device"

--- a/internal/ui/device_picker.go
+++ b/internal/ui/device_picker.go
@@ -1,0 +1,208 @@
+// ABOUTME: Modal picker for audio output devices — shown over the main view
+// ABOUTME: Save-and-restart model: selection writes audio_device to player.yaml
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Sendspin/sendspin-go/pkg/audio/output"
+)
+
+// pickerAction is what handlePickerKey tells the Model to do next. The
+// picker itself never writes to disk; the Model layer owns side effects so
+// the pure state machine here stays trivially testable.
+type pickerAction int
+
+const (
+	pickerNoop      pickerAction = iota // key was consumed, nothing further to do
+	pickerClose                         // close without saving
+	pickerSave                          // save the currently-selected device and close
+	pickerPropagate                     // key was not handled by the picker; caller may handle it
+)
+
+type devicePickerState struct {
+	devices     []output.PlaybackDevice
+	index       int    // currently-highlighted row
+	current     string // device name currently in effect (for the "(current)" annotation)
+	loadErr     error  // non-nil when ListPlaybackDevices failed
+	saveEnabled bool   // false when no config path is available — save is disabled, Esc still works
+}
+
+// newDevicePicker builds the state shown when the user first opens the
+// modal. listFn is the enumerator — parameterised so tests can stub it.
+func newDevicePicker(listFn func() ([]output.PlaybackDevice, error), current string, saveEnabled bool) devicePickerState {
+	devices, err := listFn()
+	s := devicePickerState{
+		current:     current,
+		loadErr:     err,
+		saveEnabled: saveEnabled,
+	}
+	if err != nil {
+		return s
+	}
+	s.devices = devices
+	// Seed selection: current device if matched; else default; else first.
+	for i, d := range devices {
+		if d.Name == current {
+			s.index = i
+			return s
+		}
+	}
+	for i, d := range devices {
+		if d.IsDefault {
+			s.index = i
+			return s
+		}
+	}
+	return s
+}
+
+// handlePickerKey is a pure state transition used by both production and
+// tests. It returns the next state and an action the caller performs (close,
+// save, etc.). The Model translates actions into side effects.
+func (s devicePickerState) handlePickerKey(key string) (devicePickerState, pickerAction) {
+	switch key {
+	case "up":
+		if len(s.devices) > 0 && s.index > 0 {
+			s.index--
+		}
+		return s, pickerNoop
+	case "down":
+		if s.index < len(s.devices)-1 {
+			s.index++
+		}
+		return s, pickerNoop
+	case "esc", "q":
+		return s, pickerClose
+	case "enter":
+		if !s.saveEnabled || len(s.devices) == 0 {
+			return s, pickerNoop
+		}
+		return s, pickerSave
+	}
+	return s, pickerPropagate
+}
+
+// selected returns the device the user would save if they pressed Enter
+// right now, or nil when the list is empty or failed to load.
+func (s devicePickerState) selected() *output.PlaybackDevice {
+	if s.loadErr != nil || len(s.devices) == 0 {
+		return nil
+	}
+	if s.index < 0 || s.index >= len(s.devices) {
+		return nil
+	}
+	return &s.devices[s.index]
+}
+
+// renderPicker draws the modal. width is the TUI width; the picker sizes
+// itself accordingly. If the list failed to load, the error is surfaced
+// inside the modal so the user knows why the picker is empty.
+func renderPicker(s devicePickerState, width int) string {
+	if width < 60 {
+		width = 60
+	}
+	inner := width - 4
+	var b strings.Builder
+
+	b.WriteString("\u250c\u2500 Select playback device " + repeatString("\u2500", width-26) + "\u2510\n")
+
+	if s.loadErr != nil {
+		line := fmt.Sprintf("  %s", truncateRunes(s.loadErr.Error(), inner-2))
+		b.WriteString(fmt.Sprintf("\u2502 %-*s \u2502\n", inner, line))
+	} else if len(s.devices) == 0 {
+		b.WriteString(fmt.Sprintf("\u2502 %-*s \u2502\n", inner, "  (no playback devices found)"))
+	} else {
+		for i, d := range s.devices {
+			marker := " "
+			if i == s.index {
+				marker = ">"
+			}
+			annotations := []string{}
+			if d.IsDefault {
+				annotations = append(annotations, "default")
+			}
+			if d.Name == s.current {
+				annotations = append(annotations, "current")
+			}
+			name := d.Name
+			if len(annotations) > 0 {
+				name = fmt.Sprintf("%s (%s)", d.Name, strings.Join(annotations, ", "))
+			}
+			line := fmt.Sprintf("%s %s", marker, truncateRunes(name, inner-2))
+			// Highlight the selected row with reverse video so it reads even
+			// when the user's terminal doesn't do dim/bright styling well.
+			if i == s.index {
+				line = ansiReverse + padRight(line, inner) + ansiReset
+				b.WriteString(fmt.Sprintf("\u2502 %s \u2502\n", line))
+			} else {
+				b.WriteString(fmt.Sprintf("\u2502 %-*s \u2502\n", inner, line))
+			}
+		}
+	}
+
+	// Blank row then the keybinding hints.
+	b.WriteString(fmt.Sprintf("\u2502 %-*s \u2502\n", inner, ""))
+	hints := "  " + hotkey(KeyUpDown, "move") + "   " + hotkey(KeyEnter, "save") + "   " + hotkey(KeyEsc, "cancel")
+	if !s.saveEnabled {
+		hints = "  " + hotkey(KeyUpDown, "move") + "   save unavailable (no writable config path)   " + hotkey(KeyEsc, "cancel")
+	}
+	// Padding accounts for the fact that hints contains ANSI escape codes
+	// that don't count toward display width.
+	displayLen := displayLen(hints)
+	pad := inner - displayLen
+	if pad < 0 {
+		pad = 0
+	}
+	b.WriteString(fmt.Sprintf("\u2502 %s%s \u2502\n", hints, strings.Repeat(" ", pad)))
+
+	b.WriteString("\u2514" + repeatString("\u2500", width-2) + "\u2518\n")
+	return b.String()
+}
+
+// displayLen approximates how many terminal columns a string takes, ignoring
+// ANSI escape sequences. Close enough for alignment padding; we're not
+// supporting combining characters or East Asian width here.
+func displayLen(s string) int {
+	count := 0
+	inEsc := false
+	for _, r := range s {
+		if r == '\x1b' {
+			inEsc = true
+			continue
+		}
+		if inEsc {
+			if r == 'm' {
+				inEsc = false
+			}
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+// truncateRunes returns s clipped to maxCols runes, appending an ellipsis
+// when truncation actually happens. Rune-safe variant of model.go's
+// byte-based truncate — device names may contain non-ASCII characters.
+func truncateRunes(s string, maxCols int) string {
+	if len([]rune(s)) <= maxCols {
+		return s
+	}
+	if maxCols <= 1 {
+		return "\u2026"
+	}
+	runes := []rune(s)
+	return string(runes[:maxCols-1]) + "\u2026"
+}
+
+// padRight pads s with spaces up to width display columns. Used for the
+// reverse-video row so the highlight extends across the full row.
+func padRight(s string, width int) string {
+	d := displayLen(s)
+	if d >= width {
+		return s
+	}
+	return s + strings.Repeat(" ", width-d)
+}

--- a/internal/ui/device_picker_test.go
+++ b/internal/ui/device_picker_test.go
@@ -1,0 +1,274 @@
+// ABOUTME: Tests for the device-picker state machine — pure functions, no TUI loop required
+package ui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Sendspin/sendspin-go/pkg/audio/output"
+)
+
+func fixtureDevices() []output.PlaybackDevice {
+	return []output.PlaybackDevice{
+		{Name: "USB Audio"},
+		{Name: "Built-in Analog", IsDefault: true},
+		{Name: "HDMI"},
+	}
+}
+
+func listOK() ([]output.PlaybackDevice, error) {
+	return fixtureDevices(), nil
+}
+
+func TestNewDevicePicker_SeedsIndexFromCurrent(t *testing.T) {
+	s := newDevicePicker(listOK, "HDMI", true)
+	if s.index != 2 {
+		t.Errorf("index = %d, want 2 (HDMI)", s.index)
+	}
+}
+
+func TestNewDevicePicker_SeedsIndexFromDefaultWhenCurrentMissing(t *testing.T) {
+	s := newDevicePicker(listOK, "No such device", true)
+	if s.index != 1 {
+		t.Errorf("index = %d, want 1 (the IsDefault entry)", s.index)
+	}
+}
+
+func TestNewDevicePicker_SeedsZeroWhenNoDefaultAndNoCurrent(t *testing.T) {
+	listNoDefault := func() ([]output.PlaybackDevice, error) {
+		return []output.PlaybackDevice{
+			{Name: "One"},
+			{Name: "Two"},
+		}, nil
+	}
+	s := newDevicePicker(listNoDefault, "", true)
+	if s.index != 0 {
+		t.Errorf("index = %d, want 0", s.index)
+	}
+}
+
+func TestNewDevicePicker_PropagatesLoadError(t *testing.T) {
+	listErr := func() ([]output.PlaybackDevice, error) {
+		return nil, errors.New("no audio stack")
+	}
+	s := newDevicePicker(listErr, "", true)
+	if s.loadErr == nil {
+		t.Error("loadErr should be set when enumerator fails")
+	}
+	if s.selected() != nil {
+		t.Error("selected() should be nil when load failed")
+	}
+}
+
+func TestHandlePickerKey_UpDownClamp(t *testing.T) {
+	s := newDevicePicker(listOK, "USB Audio", true) // index 0
+
+	// Up at the top clamps.
+	s, act := s.handlePickerKey("up")
+	if s.index != 0 || act != pickerNoop {
+		t.Errorf("up at top: index=%d act=%d", s.index, act)
+	}
+
+	// Two downs.
+	s, _ = s.handlePickerKey("down")
+	s, _ = s.handlePickerKey("down")
+	if s.index != 2 {
+		t.Fatalf("after 2 downs, index = %d, want 2", s.index)
+	}
+
+	// Down at the bottom clamps.
+	s, _ = s.handlePickerKey("down")
+	if s.index != 2 {
+		t.Errorf("down at bottom: index = %d, want 2", s.index)
+	}
+
+	// One up.
+	s, _ = s.handlePickerKey("up")
+	if s.index != 1 {
+		t.Errorf("up from 2: index = %d, want 1", s.index)
+	}
+}
+
+func TestHandlePickerKey_EnterSavesWhenEnabled(t *testing.T) {
+	s := newDevicePicker(listOK, "", true)
+	_, act := s.handlePickerKey("enter")
+	if act != pickerSave {
+		t.Errorf("enter action = %d, want pickerSave", act)
+	}
+}
+
+func TestHandlePickerKey_EnterNoopWhenSaveDisabled(t *testing.T) {
+	s := newDevicePicker(listOK, "", false)
+	_, act := s.handlePickerKey("enter")
+	if act != pickerNoop {
+		t.Errorf("enter with save disabled action = %d, want pickerNoop", act)
+	}
+}
+
+func TestHandlePickerKey_EnterNoopOnEmptyList(t *testing.T) {
+	s := newDevicePicker(func() ([]output.PlaybackDevice, error) { return nil, nil }, "", true)
+	_, act := s.handlePickerKey("enter")
+	if act != pickerNoop {
+		t.Errorf("enter on empty action = %d, want pickerNoop", act)
+	}
+}
+
+func TestHandlePickerKey_EscAndQClose(t *testing.T) {
+	for _, key := range []string{"esc", "q"} {
+		s := newDevicePicker(listOK, "", true)
+		_, act := s.handlePickerKey(key)
+		if act != pickerClose {
+			t.Errorf("%q action = %d, want pickerClose", key, act)
+		}
+	}
+}
+
+func TestHandlePickerKey_UnknownPropagates(t *testing.T) {
+	s := newDevicePicker(listOK, "", true)
+	_, act := s.handlePickerKey("x")
+	if act != pickerPropagate {
+		t.Errorf("unknown key action = %d, want pickerPropagate", act)
+	}
+}
+
+func TestSelected_ReturnsCurrentRow(t *testing.T) {
+	s := newDevicePicker(listOK, "HDMI", true)
+	got := s.selected()
+	if got == nil {
+		t.Fatal("selected() = nil")
+	}
+	if got.Name != "HDMI" {
+		t.Errorf("selected().Name = %q, want HDMI", got.Name)
+	}
+}
+
+func TestRenderPicker_ShowsDefaultAndCurrentAnnotations(t *testing.T) {
+	s := newDevicePicker(listOK, "HDMI", true)
+	out := renderPicker(s, 80)
+	// Built-in Analog carries (default), HDMI carries (current).
+	if !strings.Contains(out, "Built-in Analog (default)") {
+		t.Errorf("expected '(default)' annotation; got:\n%s", out)
+	}
+	if !strings.Contains(out, "HDMI (current)") {
+		t.Errorf("expected '(current)' annotation on HDMI; got:\n%s", out)
+	}
+}
+
+func TestRenderPicker_AnnotatesBothWhenCurrentIsDefault(t *testing.T) {
+	s := newDevicePicker(listOK, "Built-in Analog", true)
+	out := renderPicker(s, 80)
+	if !strings.Contains(out, "Built-in Analog (default, current)") {
+		t.Errorf("expected combined annotation; got:\n%s", out)
+	}
+}
+
+func TestRenderPicker_EmptyAndErrorStates(t *testing.T) {
+	empty := newDevicePicker(func() ([]output.PlaybackDevice, error) { return nil, nil }, "", true)
+	emptyOut := renderPicker(empty, 80)
+	if !strings.Contains(emptyOut, "no playback devices found") {
+		t.Errorf("empty state did not render expected message; got:\n%s", emptyOut)
+	}
+
+	errState := newDevicePicker(func() ([]output.PlaybackDevice, error) {
+		return nil, errors.New("enumeration boom")
+	}, "", true)
+	errOut := renderPicker(errState, 80)
+	if !strings.Contains(errOut, "enumeration boom") {
+		t.Errorf("error state did not render error; got:\n%s", errOut)
+	}
+}
+
+func TestRenderPicker_SaveUnavailableHint(t *testing.T) {
+	s := newDevicePicker(listOK, "", false)
+	out := renderPicker(s, 80)
+	if !strings.Contains(out, "save unavailable") {
+		t.Errorf("expected 'save unavailable' hint when saveEnabled=false; got:\n%s", out)
+	}
+}
+
+// The two tests below integrate picker state with the Model's key dispatch
+// to verify the end-to-end "press o → navigate → save" flow without
+// standing up a full bubbletea runtime.
+
+func TestModel_OKeyOpensPicker(t *testing.T) {
+	m := NewModel(Config{ConfigPath: "/tmp/test-player.yaml"})
+	m.listPlaybackDevices = listOK
+	m.width = 80
+
+	next, _ := m.handleKey(fakeKeyMsg("o"))
+	nm := next.(Model)
+	if nm.mode != modeDevicePicker {
+		t.Errorf("mode = %v, want modeDevicePicker", nm.mode)
+	}
+	if len(nm.picker.devices) != 3 {
+		t.Errorf("picker.devices len = %d, want 3", len(nm.picker.devices))
+	}
+}
+
+func TestModel_EnterInPickerSavesAndClosesModal(t *testing.T) {
+	var savedPath, savedKey, savedValue string
+	writer := func(path, key, value string) error {
+		savedPath, savedKey, savedValue = path, key, value
+		return nil
+	}
+
+	// Seed the current device so the picker opens highlighted on "USB Audio"
+	// (index 0). One "down" then lands on the IsDefault entry at index 1.
+	m := NewModel(Config{ConfigPath: "/tmp/test-player.yaml", AudioDevice: "USB Audio"})
+	m.listPlaybackDevices = listOK
+	m.writeConfigKey = writer
+	m.width = 80
+
+	// Open picker.
+	next, _ := m.handleKey(fakeKeyMsg("o"))
+	m = next.(Model)
+
+	// Navigate down to Built-in Analog (index 1).
+	next, _ = m.handleKey(fakeKeyMsg("down"))
+	m = next.(Model)
+
+	// Enter saves. Returns a Cmd (the 3s expire tick); we don't invoke it.
+	next, cmd := m.handleKey(fakeKeyMsg("enter"))
+	m = next.(Model)
+
+	if m.mode != modeNormal {
+		t.Errorf("mode after save = %v, want modeNormal", m.mode)
+	}
+	if savedPath != "/tmp/test-player.yaml" || savedKey != "audio_device" || savedValue != "Built-in Analog" {
+		t.Errorf("write recorded (%q, %q, %q); want (/tmp/test-player.yaml, audio_device, Built-in Analog)",
+			savedPath, savedKey, savedValue)
+	}
+	if m.transientMsg == "" {
+		t.Error("transient banner should be set after save")
+	}
+	if cmd == nil {
+		t.Error("save should schedule a transient-expire tick")
+	}
+}
+
+func TestModel_EnterWhenSelectionMatchesSkipsWrite(t *testing.T) {
+	writeCalled := false
+	writer := func(path, key, value string) error {
+		writeCalled = true
+		return nil
+	}
+
+	// Current is the HDMI entry; picker seeds selection there.
+	m := NewModel(Config{ConfigPath: "/tmp/test.yaml", AudioDevice: "HDMI"})
+	m.listPlaybackDevices = listOK
+	m.writeConfigKey = writer
+	m.width = 80
+
+	next, _ := m.handleKey(fakeKeyMsg("o"))
+	m = next.(Model)
+	next, _ = m.handleKey(fakeKeyMsg("enter"))
+	m = next.(Model)
+
+	if writeCalled {
+		t.Error("writeConfigKey should not be called when selection matches current")
+	}
+	if m.mode != modeNormal {
+		t.Errorf("mode = %v, want modeNormal", m.mode)
+	}
+}

--- a/internal/ui/hotkey.go
+++ b/internal/ui/hotkey.go
@@ -1,0 +1,115 @@
+// ABOUTME: Hotkey label rendering helper — marks the trigger character with reverse video
+// ABOUTME: Used by all TUI labels that advertise a keybinding so the cue is uniform
+package ui
+
+import (
+	"strings"
+	"unicode"
+)
+
+// ANSI escape sequences for SGR reverse-video. Kept here rather than in a
+// styling library because we only need two codes — pulling in lipgloss for
+// this would be overkill.
+const (
+	ansiReverse = "\x1b[7m"
+	ansiReset   = "\x1b[0m"
+)
+
+// hotkey renders a human-readable label with its trigger key reverse-
+// highlighted. The visual cue — a single inverted character embedded in the
+// label — is uniform across every keybinding in the TUI so users learn the
+// pattern once.
+//
+// Resolution rules:
+//   - Printable letter trigger with a case-insensitive match in the label:
+//     highlight the first occurrence in place.
+//     hotkey('o', "Output") -> "\x1b[7mO\x1b[0mutput"
+//   - Printable letter trigger NOT present in the label:
+//     fall back to a bracket prefix.
+//     hotkey('q', "Bye") -> "[\x1b[7mQ\x1b[0m] Bye"
+//   - Non-letter triggers (space, arrow sentinels, etc.) always use the
+//     bracket form with a friendly name for the key.
+//     hotkey(KeySpace, "Play/Pause") -> "[\x1b[7mSpace\x1b[0m] Play/Pause"
+//
+// Empty labels still render the bracket prefix so the binding is visible.
+func hotkey(trigger rune, label string) string {
+	if name, ok := specialKeyName(trigger); ok {
+		return bracketPrefix(name, label)
+	}
+	if !unicode.IsLetter(trigger) && !unicode.IsDigit(trigger) {
+		// Punctuation or symbols — use bracket form with the literal rune.
+		return bracketPrefix(string(trigger), label)
+	}
+	if idx := firstCaseFoldIndex(label, trigger); idx >= 0 {
+		r, width := runeAt(label, idx)
+		return label[:idx] + ansiReverse + string(r) + ansiReset + label[idx+width:]
+	}
+	return bracketPrefix(strings.ToUpper(string(trigger)), label)
+}
+
+// Special-key sentinels. These aren't valid Unicode code points that could
+// appear in a label, so overloading a rune-sized value is safe. Any value
+// outside the printable range works; using specific private-use-area code
+// points keeps them self-documenting in stack traces.
+const (
+	KeySpace rune = '\uE000' // "Space"
+	KeyUp    rune = '\uE001' // "↑"
+	KeyDown  rune = '\uE002' // "↓"
+	KeyUpDown rune = '\uE003' // "↑↓"
+	KeyEnter rune = '\uE004' // "Enter"
+	KeyEsc   rune = '\uE005' // "Esc"
+)
+
+func specialKeyName(r rune) (string, bool) {
+	switch r {
+	case KeySpace:
+		return "Space", true
+	case KeyUp:
+		return "\u2191", true
+	case KeyDown:
+		return "\u2193", true
+	case KeyUpDown:
+		return "\u2191\u2193", true
+	case KeyEnter:
+		return "Enter", true
+	case KeyEsc:
+		return "Esc", true
+	}
+	return "", false
+}
+
+// bracketPrefix renders "[<highlighted keyName>] label" with the key name
+// reverse-highlighted. When label is empty, emits just the bracket (still
+// useful so the binding is visible in compact hint rows).
+func bracketPrefix(keyName, label string) string {
+	prefix := "[" + ansiReverse + keyName + ansiReset + "]"
+	if label == "" {
+		return prefix
+	}
+	return prefix + " " + label
+}
+
+// firstCaseFoldIndex returns the byte index of the first rune in s that
+// case-folds equal to needle, or -1 if not found. Works for any letter —
+// multi-byte ones included, though this codebase only uses ASCII triggers.
+func firstCaseFoldIndex(s string, needle rune) int {
+	target := unicode.ToLower(needle)
+	for i, r := range s {
+		if unicode.ToLower(r) == target {
+			return i
+		}
+	}
+	return -1
+}
+
+// runeAt returns the rune at byte index i and its encoded byte width. Only
+// called after firstCaseFoldIndex has confirmed a match, so the index is
+// guaranteed to be on a rune boundary.
+func runeAt(s string, i int) (rune, int) {
+	for j, r := range s {
+		if j == i {
+			return r, len(string(r))
+		}
+	}
+	return 0, 0
+}

--- a/internal/ui/hotkey.go
+++ b/internal/ui/hotkey.go
@@ -52,12 +52,12 @@ func hotkey(trigger rune, label string) string {
 // outside the printable range works; using specific private-use-area code
 // points keeps them self-documenting in stack traces.
 const (
-	KeySpace rune = '\uE000' // "Space"
-	KeyUp    rune = '\uE001' // "↑"
-	KeyDown  rune = '\uE002' // "↓"
+	KeySpace  rune = '\uE000' // "Space"
+	KeyUp     rune = '\uE001' // "↑"
+	KeyDown   rune = '\uE002' // "↓"
 	KeyUpDown rune = '\uE003' // "↑↓"
-	KeyEnter rune = '\uE004' // "Enter"
-	KeyEsc   rune = '\uE005' // "Esc"
+	KeyEnter  rune = '\uE004' // "Enter"
+	KeyEsc    rune = '\uE005' // "Esc"
 )
 
 func specialKeyName(r rune) (string, bool) {

--- a/internal/ui/hotkey_test.go
+++ b/internal/ui/hotkey_test.go
@@ -1,0 +1,123 @@
+// ABOUTME: Tests for the hotkey label helper — in-place reverse highlighting
+package ui
+
+import "testing"
+
+func TestHotkey_LetterInLabel(t *testing.T) {
+	tests := []struct {
+		name    string
+		trigger rune
+		label   string
+		want    string
+	}{
+		{
+			name:    "first letter match",
+			trigger: 'o',
+			label:   "Output",
+			want:    ansiReverse + "O" + ansiReset + "utput",
+		},
+		{
+			name:    "case-insensitive — lowercase trigger, uppercase in label",
+			trigger: 'q',
+			label:   "Quit",
+			want:    ansiReverse + "Q" + ansiReset + "uit",
+		},
+		{
+			name:    "case-insensitive — uppercase trigger, lowercase in label",
+			trigger: 'E',
+			label:   "enter",
+			want:    ansiReverse + "e" + ansiReset + "nter",
+		},
+		{
+			name:    "trigger matches a non-initial letter",
+			trigger: 'u',
+			label:   "Quit",
+			want:    "Q" + ansiReverse + "u" + ansiReset + "it",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hotkey(tt.trigger, tt.label)
+			if got != tt.want {
+				t.Errorf("hotkey(%q, %q) =\n  %q\nwant\n  %q", tt.trigger, tt.label, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHotkey_LetterNotInLabel(t *testing.T) {
+	got := hotkey('x', "Bye")
+	want := "[" + ansiReverse + "X" + ansiReset + "] Bye"
+	if got != want {
+		t.Errorf("missing-letter fallback =\n  %q\nwant\n  %q", got, want)
+	}
+}
+
+func TestHotkey_SpecialKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		trigger rune
+		label   string
+		want    string
+	}{
+		{
+			name:    "space",
+			trigger: KeySpace,
+			label:   "Play/Pause",
+			want:    "[" + ansiReverse + "Space" + ansiReset + "] Play/Pause",
+		},
+		{
+			name:    "up-down combined",
+			trigger: KeyUpDown,
+			label:   "Volume",
+			want:    "[" + ansiReverse + "\u2191\u2193" + ansiReset + "] Volume",
+		},
+		{
+			name:    "enter",
+			trigger: KeyEnter,
+			label:   "Save",
+			want:    "[" + ansiReverse + "Enter" + ansiReset + "] Save",
+		},
+		{
+			name:    "esc",
+			trigger: KeyEsc,
+			label:   "Cancel",
+			want:    "[" + ansiReverse + "Esc" + ansiReset + "] Cancel",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hotkey(tt.trigger, tt.label)
+			if got != tt.want {
+				t.Errorf("hotkey(%q) =\n  %q\nwant\n  %q", tt.trigger, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHotkey_EmptyLabel(t *testing.T) {
+	// Letter with empty label uses the bracket fallback since nothing to match.
+	got := hotkey('q', "")
+	want := "[" + ansiReverse + "Q" + ansiReset + "]"
+	if got != want {
+		t.Errorf("empty label with letter =\n  %q\nwant\n  %q", got, want)
+	}
+
+	// Special key with empty label uses bracket without trailing space.
+	got = hotkey(KeyEsc, "")
+	want = "[" + ansiReverse + "Esc" + ansiReset + "]"
+	if got != want {
+		t.Errorf("empty label with special =\n  %q\nwant\n  %q", got, want)
+	}
+}
+
+func TestHotkey_Symbol(t *testing.T) {
+	// Symbols aren't letters; they use the bracket prefix with the literal rune.
+	got := hotkey('/', "Slash")
+	want := "[" + ansiReverse + "/" + ansiReset + "] Slash"
+	if got != want {
+		t.Errorf("symbol trigger =\n  %q\nwant\n  %q", got, want)
+	}
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -5,10 +5,24 @@ package ui
 import (
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/Sendspin/sendspin-go/pkg/audio/output"
+	"github.com/Sendspin/sendspin-go/pkg/sendspin"
 	"github.com/Sendspin/sendspin-go/pkg/sync"
 	tea "github.com/charmbracelet/bubbletea"
 )
+
+type uiMode int
+
+const (
+	modeNormal uiMode = iota
+	modeDevicePicker
+)
+
+// transientExpireMsg is fired after a transient banner's lifetime to clear
+// it. Bubbletea's scheduler guarantees at-most-once delivery.
+type transientExpireMsg struct{ nonce uint64 }
 
 // Model represents the TUI state
 type Model struct {
@@ -55,6 +69,23 @@ type Model struct {
 	// Controls
 	volumeCtrl    *VolumeControl
 	transportCtrl *TransportControl
+
+	// Audio device selection
+	audioDevice string // current device driving playback; shown in status row
+	configPath  string // where picker saves audio_device; empty disables save
+
+	// Modal state
+	mode   uiMode
+	picker devicePickerState
+
+	// Transient banner shown in the controls area (e.g. "Saved. Restart to apply.")
+	transientMsg   string
+	transientNonce uint64 // incremented per banner so stale expire ticks are ignored
+
+	// listPlaybackDevices is indirected so tests can stub it.
+	listPlaybackDevices func() ([]output.PlaybackDevice, error)
+	// writeConfigKey persists a key to the config file. Indirected for tests.
+	writeConfigKey func(path, key, value string) error
 }
 
 func (m Model) Init() tea.Cmd {
@@ -70,6 +101,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = msg.Height
 	case StatusMsg:
 		m.applyStatus(msg)
+	case transientExpireMsg:
+		if msg.nonce == m.transientNonce {
+			m.transientMsg = ""
+		}
 	}
 
 	return m, nil
@@ -78,6 +113,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m Model) View() string {
 	if m.width == 0 {
 		return "Loading..."
+	}
+
+	if m.mode == modeDevicePicker {
+		// Modal takes over the viewport; the normal view is suspended. A
+		// minimal header keeps context ("which player am I configuring?").
+		return m.renderHeader() + renderPicker(m.picker, m.width)
 	}
 
 	s := ""
@@ -186,7 +227,32 @@ func (m Model) renderControls() string {
 	bufferStr := fmt.Sprintf("Buffer: %dms", m.bufferDepth)
 	s += fmt.Sprintf("\u2502 %-*s \u2502\n", innerWidth, bufferStr)
 
+	// Output device status row. Uses the hotkey helper so the 'O' rendering
+	// stays in sync with the help line that advertises the trigger.
+	outputName := m.audioDevice
+	if outputName == "" {
+		outputName = "(miniaudio default)"
+	}
+	outputLine := hotkey('o', "Output: "+truncate(outputName, innerWidth-10))
+	s += renderLineWithANSI(innerWidth, outputLine)
+
+	if m.transientMsg != "" {
+		s += renderLineWithANSI(innerWidth, "  "+m.transientMsg)
+	}
+
 	return s
+}
+
+// renderLineWithANSI emits a bordered row whose contents contain ANSI
+// escape sequences. fmt's padding verbs count those escape bytes toward
+// width, leading to short rows; this helper pads using visible-column
+// count instead so every border stays aligned.
+func renderLineWithANSI(innerWidth int, content string) string {
+	pad := innerWidth - displayLen(content)
+	if pad < 0 {
+		pad = 0
+	}
+	return fmt.Sprintf("\u2502 %s%s \u2502\n", content, strings.Repeat(" ", pad))
 }
 
 func (m Model) renderStats() string {
@@ -211,8 +277,21 @@ func (m Model) renderHelp() string {
 	}
 	innerWidth := width - 4
 
-	helpStr := "Space:Play/Pause  n:Next  p:Prev  \u2191/\u2193:Vol  m:Mute  q:Quit"
-	helpLine := fmt.Sprintf("\u2502 %-*s \u2502\n", innerWidth, helpStr)
+	// Uniform hotkey rendering — every trigger character is reverse-
+	// highlighted inline via hotkey(). Separators are two spaces; we rely
+	// on renderLineWithANSI for correct padding because hotkey() emits
+	// escape codes that fmt would miscount.
+	parts := []string{
+		hotkey(KeySpace, "Play/Pause"),
+		hotkey('n', "Next"),
+		hotkey('p', "Prev"),
+		hotkey(KeyUpDown, "Volume"),
+		hotkey('m', "Mute"),
+		hotkey('o', "Output"),
+		hotkey('q', "Quit"),
+	}
+	helpStr := strings.Join(parts, "  ")
+	helpLine := renderLineWithANSI(innerWidth, helpStr)
 	bottom := "\u2514" + repeatString("\u2500", width-2) + "\u2518\n"
 
 	return helpLine + bottom
@@ -237,7 +316,12 @@ func (m Model) renderDebug() string {
 }
 
 func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.mode == modeDevicePicker {
+		return m.handlePickerMode(msg)
+	}
 	switch msg.String() {
+	case "o":
+		return m.openDevicePicker()
 	case "q", "ctrl+c":
 		if m.volumeCtrl != nil {
 			select {
@@ -473,4 +557,69 @@ func formatCodecDisplay(codec string, sampleRate, bitDepth int) string {
 	default:
 		return fmt.Sprintf("%s %s/%dbit", upper, rate, bitDepth)
 	}
+}
+
+// openDevicePicker transitions the Model into modeDevicePicker, enumerating
+// available devices via the injected lister (defaulting to the real
+// output.ListPlaybackDevices). The picker's own state tracks enumeration
+// errors, so we never fail to enter the modal — the user always gets to
+// see *something*, even if it's "couldn't enumerate devices".
+func (m Model) openDevicePicker() (tea.Model, tea.Cmd) {
+	lister := m.listPlaybackDevices
+	if lister == nil {
+		lister = output.ListPlaybackDevices
+	}
+	saveEnabled := m.configPath != ""
+	m.picker = newDevicePicker(lister, m.audioDevice, saveEnabled)
+	m.mode = modeDevicePicker
+	return m, nil
+}
+
+// handlePickerMode dispatches a key to the picker's pure state machine and
+// executes the requested action. Save writes audio_device to the config
+// file and shows a transient "Saved. Restart to apply." banner for 3s.
+func (m Model) handlePickerMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	next, action := m.picker.handlePickerKey(msg.String())
+	m.picker = next
+	switch action {
+	case pickerNoop:
+		return m, nil
+	case pickerClose, pickerPropagate:
+		m.mode = modeNormal
+		return m, nil
+	case pickerSave:
+		chosen := m.picker.selected()
+		if chosen == nil {
+			m.mode = modeNormal
+			return m, nil
+		}
+		writer := m.writeConfigKey
+		if writer == nil {
+			writer = sendspin.WriteStringKey
+		}
+		if chosen.Name != m.audioDevice {
+			// No-op when the chosen value already matches what's saved —
+			// matches the client_id write-back behavior and avoids
+			// churning user-edited config files for no reason.
+			if err := writer(m.configPath, "audio_device", chosen.Name); err != nil {
+				m.mode = modeNormal
+				return m.withTransient(fmt.Sprintf("Save failed: %v", err))
+			}
+		}
+		m.mode = modeNormal
+		return m.withTransient(fmt.Sprintf("Saved audio_device=%q. Restart to apply.", chosen.Name))
+	}
+	return m, nil
+}
+
+// withTransient schedules msg to be shown in the status row for ~3 seconds.
+// The nonce guards against a later expire firing for a previously-shown
+// banner that was already overwritten by a newer one.
+func (m Model) withTransient(msg string) (tea.Model, tea.Cmd) {
+	m.transientNonce++
+	m.transientMsg = msg
+	nonce := m.transientNonce
+	return m, tea.Tick(3*time.Second, func(time.Time) tea.Msg {
+		return transientExpireMsg{nonce: nonce}
+	})
 }

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNewModel(t *testing.T) {
-	model := NewModel(nil, nil) // VolumeControl and TransportControl are optional for testing
+	model := NewModel(Config{}) // VolumeControl and TransportControl are optional for testing
 
 	// Check initial state
 	if model.connected {
@@ -35,7 +35,7 @@ func TestNewModel(t *testing.T) {
 }
 
 func TestStatusMsgConnected(t *testing.T) {
-	model := NewModel(nil, nil)
+	model := NewModel(Config{})
 
 	connected := true
 	msg := StatusMsg{
@@ -55,7 +55,7 @@ func TestStatusMsgConnected(t *testing.T) {
 }
 
 func TestStatusMsgDisconnected(t *testing.T) {
-	model := NewModel(nil, nil)
+	model := NewModel(Config{})
 
 	// First connect
 	connected := true
@@ -71,7 +71,7 @@ func TestStatusMsgDisconnected(t *testing.T) {
 }
 
 func TestStatusMsgSyncStats(t *testing.T) {
-	model := NewModel(nil, nil)
+	model := NewModel(Config{})
 
 	msg := StatusMsg{
 		SyncRTT:     5000,
@@ -90,7 +90,7 @@ func TestStatusMsgSyncStats(t *testing.T) {
 }
 
 func TestStatusMsgStreamInfo(t *testing.T) {
-	model := NewModel(nil, nil)
+	model := NewModel(Config{})
 
 	msg := StatusMsg{
 		Codec:      "opus",
@@ -119,7 +119,7 @@ func TestStatusMsgStreamInfo(t *testing.T) {
 }
 
 func TestStatusMsgMetadata(t *testing.T) {
-	model := NewModel(nil, nil)
+	model := NewModel(Config{})
 
 	msg := StatusMsg{
 		Title:  "Test Song",
@@ -143,7 +143,7 @@ func TestStatusMsgMetadata(t *testing.T) {
 }
 
 func TestStatusMsgArtworkPath(t *testing.T) {
-	model := NewModel(nil, nil)
+	model := NewModel(Config{})
 
 	msg := StatusMsg{
 		ArtworkPath: "/tmp/artwork.jpg",
@@ -157,7 +157,7 @@ func TestStatusMsgArtworkPath(t *testing.T) {
 }
 
 func TestStatusMsgVolume(t *testing.T) {
-	model := NewModel(nil, nil)
+	model := NewModel(Config{})
 
 	msg := StatusMsg{
 		Volume: 75,
@@ -171,7 +171,7 @@ func TestStatusMsgVolume(t *testing.T) {
 }
 
 func TestStatusMsgStats(t *testing.T) {
-	model := NewModel(nil, nil)
+	model := NewModel(Config{})
 
 	msg := StatusMsg{
 		Received:    1000,
@@ -200,7 +200,7 @@ func TestStatusMsgStats(t *testing.T) {
 }
 
 func TestStatusMsgRuntimeStats(t *testing.T) {
-	model := NewModel(nil, nil)
+	model := NewModel(Config{})
 
 	msg := StatusMsg{
 		Goroutines: 42,
@@ -214,7 +214,7 @@ func TestStatusMsgRuntimeStats(t *testing.T) {
 }
 
 func TestMultipleStatusUpdates(t *testing.T) {
-	model := NewModel(nil, nil)
+	model := NewModel(Config{})
 
 	// First update
 	connected := true
@@ -244,7 +244,7 @@ func TestMultipleStatusUpdates(t *testing.T) {
 }
 
 func TestStatusMsgZeroValues(t *testing.T) {
-	model := NewModel(nil, nil)
+	model := NewModel(Config{})
 
 	// Set some non-zero values first
 	model.applyStatus(StatusMsg{
@@ -317,7 +317,7 @@ func TestChannelNameFunction(t *testing.T) {
 }
 
 func TestSyncQualityDisplay(t *testing.T) {
-	model := NewModel(nil, nil)
+	model := NewModel(Config{})
 
 	// Test different quality levels
 	// Note: quality is only applied when SyncRTT is non-zero
@@ -340,7 +340,7 @@ func TestSyncQualityDisplay(t *testing.T) {
 }
 
 func TestMetadataClearing(t *testing.T) {
-	model := NewModel(nil, nil)
+	model := NewModel(Config{})
 
 	// Set metadata
 	model.applyStatus(StatusMsg{
@@ -363,7 +363,7 @@ func TestMetadataClearing(t *testing.T) {
 }
 
 func TestPlaybackStateApplication(t *testing.T) {
-	model := NewModel(nil, nil)
+	model := NewModel(Config{})
 
 	// Initial state should be idle
 	if model.playbackState != "idle" {
@@ -391,7 +391,7 @@ func TestPlaybackStateApplication(t *testing.T) {
 
 func TestTransportKeyToggle(t *testing.T) {
 	tc := NewTransportControl()
-	model := NewModel(nil, tc)
+	model := NewModel(Config{TransportCtrl: tc})
 	model.width = 80
 	model.height = 24
 
@@ -411,7 +411,7 @@ func TestTransportKeyToggle(t *testing.T) {
 
 func TestTransportKeyNext(t *testing.T) {
 	tc := NewTransportControl()
-	model := NewModel(nil, tc)
+	model := NewModel(Config{TransportCtrl: tc})
 	model.width = 80
 	model.height = 24
 
@@ -430,7 +430,7 @@ func TestTransportKeyNext(t *testing.T) {
 
 func TestTransportKeyPrevious(t *testing.T) {
 	tc := NewTransportControl()
-	model := NewModel(nil, tc)
+	model := NewModel(Config{TransportCtrl: tc})
 	model.width = 80
 	model.height = 24
 
@@ -449,7 +449,7 @@ func TestTransportKeyPrevious(t *testing.T) {
 
 func TestTransportKeyReconnect(t *testing.T) {
 	tc := NewTransportControl()
-	model := NewModel(nil, tc)
+	model := NewModel(Config{TransportCtrl: tc})
 	model.width = 80
 	model.height = 24
 
@@ -468,7 +468,7 @@ func TestTransportKeyReconnect(t *testing.T) {
 
 func TestTransportNilSafe(t *testing.T) {
 	// Transport keys should not panic when transportCtrl is nil
-	model := NewModel(nil, nil)
+	model := NewModel(Config{})
 	model.width = 80
 	model.height = 24
 

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -32,17 +32,34 @@ func NewTransportControl() *TransportControl {
 	}
 }
 
-func NewModel(volCtrl *VolumeControl, transportCtrl *TransportControl) Model {
+// Config bundles everything the TUI needs from main.go at construction.
+// Extending by adding fields is intentionally cheap — the alternative was
+// growing the Run() / NewModel() positional argument list every time a new
+// TUI feature needs a dependency.
+type Config struct {
+	VolumeCtrl    *VolumeControl
+	TransportCtrl *TransportControl
+	// ConfigPath is where WriteStringKey persists settings like audio_device.
+	// Empty disables the Save action in modals that would write to disk.
+	ConfigPath string
+	// AudioDevice is the device currently driving playback, shown in the
+	// status line and used to seed the picker's highlighted row.
+	AudioDevice string
+}
+
+func NewModel(cfg Config) Model {
 	return Model{
 		volume:        100,
 		state:         "idle",
 		playbackState: "idle",
-		volumeCtrl:    volCtrl,
-		transportCtrl: transportCtrl,
+		volumeCtrl:    cfg.VolumeCtrl,
+		transportCtrl: cfg.TransportCtrl,
+		configPath:    cfg.ConfigPath,
+		audioDevice:   cfg.AudioDevice,
 	}
 }
 
-func Run(volCtrl *VolumeControl, transportCtrl *TransportControl) (*tea.Program, error) {
-	p := tea.NewProgram(NewModel(volCtrl, transportCtrl), tea.WithAltScreen())
+func Run(cfg Config) (*tea.Program, error) {
+	p := tea.NewProgram(NewModel(cfg), tea.WithAltScreen())
 	return p, nil
 }

--- a/main.go
+++ b/main.go
@@ -119,7 +119,21 @@ func main() {
 		volumeCtrl = ui.NewVolumeControl()
 		transportCtrl = ui.NewTransportControl()
 		var err error
-		tuiProg, err = ui.Run(volumeCtrl, transportCtrl)
+		// Hand the picker a writable config path — fall back to the OS
+		// default location if nothing was loaded, so selections still persist
+		// on first-ever launch.
+		uiConfigPath := loadedConfigPath
+		if uiConfigPath == "" {
+			if p, perr := sendspin.DefaultPlayerConfigPath(); perr == nil {
+				uiConfigPath = p
+			}
+		}
+		tuiProg, err = ui.Run(ui.Config{
+			VolumeCtrl:    volumeCtrl,
+			TransportCtrl: transportCtrl,
+			ConfigPath:    uiConfigPath,
+			AudioDevice:   *audioDevice,
+		})
 		if err != nil {
 			log.Fatalf("Failed to start TUI: %v", err)
 		}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Sendspin/sendspin-go/internal/discovery"
 	"github.com/Sendspin/sendspin-go/internal/ui"
 	"github.com/Sendspin/sendspin-go/internal/version"
+	"github.com/Sendspin/sendspin-go/pkg/audio/output"
 	"github.com/Sendspin/sendspin-go/pkg/sendspin"
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -38,15 +39,26 @@ var (
 	bufferCapacity = flag.Int("buffer-capacity", 1048576, "Buffer capacity in bytes advertised to server (default: 1MB)")
 	clientID       = flag.String("client-id", "", "Override the persisted client_id. When set, the value is written to the config file and reused on subsequent launches.")
 	configPath     = flag.String("config", "", "Path to player.yaml config file. Default search: $SENDSPIN_PLAYER_CONFIG, ~/.config/sendspin/player.yaml, /etc/sendspin/player.yaml.")
+	audioDevice    = flag.String("audio-device", "", "Playback device name (see --list-audio-devices). Empty = miniaudio default.")
+	listAudio      = flag.Bool("list-audio-devices", false, "List available playback devices and exit.")
 )
 
 func main() {
 	flag.Parse()
 
+	if *listAudio {
+		if err := printPlaybackDevices(os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to list audio devices: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	// Overlay YAML file and SENDSPIN_PLAYER_* env vars onto flag vars for
 	// anything the user didn't set on the CLI. client_id is handled
 	// separately below because it has its own resolver and persistence.
-	setByUser := map[string]bool{"client-id": true, "config": true}
+	// list-audio-devices is already handled above and exits early.
+	setByUser := map[string]bool{"client-id": true, "config": true, "list-audio-devices": true}
 	flag.Visit(func(f *flag.Flag) { setByUser[f.Name] = true })
 
 	cfg, loadedConfigPath, err := sendspin.LoadPlayerConfig(*configPath)
@@ -167,6 +179,7 @@ func main() {
 		PreferredCodec: *preferredCodec,
 		BufferCapacity: *bufferCapacity,
 		ClientID:       resolvedClientID,
+		AudioDevice:    *audioDevice,
 		DeviceInfo: sendspin.DeviceInfo{
 			ProductName:     deviceProduct,
 			Manufacturer:    deviceManufacturer,
@@ -308,6 +321,32 @@ func handleTransportControl(player *sendspin.Player, ctrl *ui.TransportControl) 
 			log.Printf("Transport command %q failed: %v", cmd.Command, err)
 		}
 	}
+}
+
+// printPlaybackDevices enumerates every playback device miniaudio can see
+// and prints them in a format a user can copy/paste into --audio-device or
+// the audio_device: key in player.yaml. The '[*]' marker identifies the
+// device miniaudio considers its current default.
+func printPlaybackDevices(w io.Writer) error {
+	devices, err := output.ListPlaybackDevices()
+	if err != nil {
+		return err
+	}
+	if len(devices) == 0 {
+		fmt.Fprintln(w, "No playback devices found.")
+		return nil
+	}
+	fmt.Fprintln(w, "Playback devices:")
+	for _, d := range devices {
+		marker := "[ ]"
+		if d.IsDefault {
+			marker = "[*]"
+		}
+		fmt.Fprintf(w, "  %s %s\n", marker, d.Name)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "[*] = current default. Use --audio-device \"<name>\" or set audio_device: in player.yaml.")
+	return nil
 }
 
 // resolveClientID chooses the player's client_id and arranges for it to be

--- a/pkg/audio/output/malgo.go
+++ b/pkg/audio/output/malgo.go
@@ -6,18 +6,31 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sort"
+	"strings"
 	"sync"
 	"time"
+	"unsafe"
 
 	"github.com/Sendspin/sendspin-go/pkg/audio"
 	"github.com/gen2brain/malgo"
 )
+
+// PlaybackDevice describes a playback endpoint discoverable via miniaudio.
+// Returned by ListPlaybackDevices and used to select a specific device when
+// constructing a Malgo output.
+type PlaybackDevice struct {
+	Name      string
+	IsDefault bool
+	ID        malgo.DeviceID
+}
 
 type Malgo struct {
 	ctx        context.Context
 	cancel     context.CancelFunc
 	malgoCtx   *malgo.AllocatedContext
 	device     *malgo.Device
+	deviceName string // empty = use default
 	sampleRate int
 	channels   int
 	bitDepth   int
@@ -98,15 +111,86 @@ func (rb *RingBuffer) Free() int {
 	return rb.size - rb.count
 }
 
-func NewMalgo() Output {
+// NewMalgo constructs a new malgo-backed audio output. deviceName selects a
+// specific playback device by name (as reported by ListPlaybackDevices). An
+// empty deviceName lets miniaudio pick the platform default.
+func NewMalgo(deviceName string) Output {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return &Malgo{
-		ctx:    ctx,
-		cancel: cancel,
-		volume: 100,
-		muted:  false,
+		ctx:        ctx,
+		cancel:     cancel,
+		deviceName: deviceName,
+		volume:     100,
+		muted:      false,
 	}
+}
+
+// ListPlaybackDevices enumerates every playback device miniaudio can see.
+// It creates a fresh context and tears it down before returning, so it is
+// safe to call before any player/device has been initialized.
+func ListPlaybackDevices() ([]PlaybackDevice, error) {
+	ctx, err := malgo.InitContext(nil, malgo.ContextConfig{}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("init malgo context: %w", err)
+	}
+	defer func() {
+		_ = ctx.Uninit()
+		ctx.Free()
+	}()
+
+	infos, err := ctx.Devices(malgo.Playback)
+	if err != nil {
+		return nil, fmt.Errorf("enumerate playback devices: %w", err)
+	}
+
+	out := make([]PlaybackDevice, 0, len(infos))
+	for _, info := range infos {
+		out = append(out, PlaybackDevice{
+			Name:      info.Name(),
+			IsDefault: info.IsDefault != 0,
+			ID:        info.ID,
+		})
+	}
+	return out, nil
+}
+
+// matchDevice picks a PlaybackDevice from a list based on a requested name.
+//
+// Empty requested name -> the device with IsDefault set, else the first in
+// the list, else nil if the list is empty (caller falls back to whatever
+// miniaudio's default-config path does).
+//
+// Non-empty requested name -> exact match on Name. If no match: returns an
+// error whose message lists every available device name so the user can fix
+// the config. Fail-loud is intentional: silent fallback to default is the
+// behavior this feature exists to correct.
+func matchDevice(devices []PlaybackDevice, requested string) (*PlaybackDevice, error) {
+	if requested == "" {
+		if len(devices) == 0 {
+			return nil, nil
+		}
+		for i := range devices {
+			if devices[i].IsDefault {
+				return &devices[i], nil
+			}
+		}
+		return &devices[0], nil
+	}
+	for i := range devices {
+		if devices[i].Name == requested {
+			return &devices[i], nil
+		}
+	}
+	if len(devices) == 0 {
+		return nil, fmt.Errorf("audio device %q not found (no playback devices available)", requested)
+	}
+	names := make([]string, 0, len(devices))
+	for _, d := range devices {
+		names = append(names, d.Name)
+	}
+	sort.Strings(names)
+	return nil, fmt.Errorf("audio device %q not found; available: %s", requested, strings.Join(names, ", "))
 }
 
 func (m *Malgo) Open(sampleRate, channels, bitDepth int) error {
@@ -158,6 +242,36 @@ func (m *Malgo) Open(sampleRate, channels, bitDepth int) error {
 	deviceConfig.SampleRate = uint32(sampleRate)
 	deviceConfig.Alsa.NoMMap = 1
 
+	// Resolve the playback device. When m.deviceName is empty, miniaudio's
+	// enumerated default is picked (and logged so the operator knows what
+	// they're getting). When non-empty, the device must exist or Open fails
+	// loudly — silent fallback defeats the point of the knob.
+	infos, err := m.malgoCtx.Devices(malgo.Playback)
+	if err != nil {
+		return fmt.Errorf("enumerate playback devices: %w", err)
+	}
+	catalog := make([]PlaybackDevice, 0, len(infos))
+	for _, info := range infos {
+		catalog = append(catalog, PlaybackDevice{
+			Name:      info.Name(),
+			IsDefault: info.IsDefault != 0,
+			ID:        info.ID,
+		})
+	}
+	chosen, err := matchDevice(catalog, m.deviceName)
+	if err != nil {
+		return err
+	}
+	chosenLabel := "(miniaudio default)"
+	if chosen != nil {
+		deviceConfig.Playback.DeviceID = unsafe.Pointer(&chosen.ID[0])
+		if chosen.IsDefault {
+			chosenLabel = fmt.Sprintf("%q (default)", chosen.Name)
+		} else {
+			chosenLabel = fmt.Sprintf("%q", chosen.Name)
+		}
+	}
+
 	onSamples := func(pOutputSample, pInputSamples []byte, frameCount uint32) {
 		m.dataCallback(pOutputSample, frameCount)
 	}
@@ -182,8 +296,8 @@ func (m *Malgo) Open(sampleRate, channels, bitDepth int) error {
 	m.bitDepth = bitDepth
 	m.ready = true
 
-	log.Printf("Audio output initialized: %dHz, %d channels, %d-bit (malgo/%s)",
-		sampleRate, channels, bitDepth, formatName(format))
+	log.Printf("Audio output initialized: device=%s %dHz/%dch/%d-bit (malgo/%s)",
+		chosenLabel, sampleRate, channels, bitDepth, formatName(format))
 
 	return nil
 }

--- a/pkg/audio/output/malgo_test.go
+++ b/pkg/audio/output/malgo_test.go
@@ -1,0 +1,143 @@
+// ABOUTME: Tests for the pure matchDevice selection logic used by Open
+package output
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gen2brain/malgo"
+)
+
+// newDevice builds a PlaybackDevice with a unique sentinel ID so tests can
+// assert the correct entry was returned. The actual ID bytes are opaque to
+// miniaudio at this layer; we only check that matchDevice returns the right
+// slice element.
+func newDevice(name string, isDefault bool, marker byte) PlaybackDevice {
+	var id malgo.DeviceID
+	id[0] = marker
+	return PlaybackDevice{Name: name, IsDefault: isDefault, ID: id}
+}
+
+func TestMatchDevice_EmptyRequest(t *testing.T) {
+	tests := []struct {
+		name       string
+		devices    []PlaybackDevice
+		wantNil    bool
+		wantName   string
+		wantMarker byte
+	}{
+		{
+			name:    "empty catalog returns nil",
+			devices: nil,
+			wantNil: true,
+		},
+		{
+			name: "prefers the device flagged IsDefault",
+			devices: []PlaybackDevice{
+				newDevice("First", false, 0x01),
+				newDevice("DefaultSink", true, 0x02),
+				newDevice("Third", false, 0x03),
+			},
+			wantName:   "DefaultSink",
+			wantMarker: 0x02,
+		},
+		{
+			name: "falls back to first device when none flagged default",
+			devices: []PlaybackDevice{
+				newDevice("Alpha", false, 0x0A),
+				newDevice("Beta", false, 0x0B),
+			},
+			wantName:   "Alpha",
+			wantMarker: 0x0A,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := matchDevice(tt.devices, "")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("expected nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected a device, got nil")
+			}
+			if got.Name != tt.wantName {
+				t.Errorf("name = %q, want %q", got.Name, tt.wantName)
+			}
+			if got.ID[0] != tt.wantMarker {
+				t.Errorf("id[0] = 0x%x, want 0x%x (wrong slice element returned)", got.ID[0], tt.wantMarker)
+			}
+		})
+	}
+}
+
+func TestMatchDevice_ExactNameMatch(t *testing.T) {
+	devices := []PlaybackDevice{
+		newDevice("HDA Intel PCH: ALC257 Analog", true, 0x10),
+		newDevice("HDMI 0", false, 0x11),
+		newDevice("USB Audio Device", false, 0x12),
+	}
+
+	got, err := matchDevice(devices, "USB Audio Device")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || got.Name != "USB Audio Device" {
+		t.Errorf("got %+v, want USB Audio Device", got)
+	}
+	if got.ID[0] != 0x12 {
+		t.Errorf("wrong device matched: id[0] = 0x%x, want 0x12", got.ID[0])
+	}
+}
+
+func TestMatchDevice_NoMatchListsAvailable(t *testing.T) {
+	devices := []PlaybackDevice{
+		newDevice("Charlie", false, 0x01),
+		newDevice("Alpha", true, 0x02),
+		newDevice("Bravo", false, 0x03),
+	}
+
+	got, err := matchDevice(devices, "DoesNotExist")
+	if got != nil {
+		t.Errorf("expected nil device, got %+v", got)
+	}
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `"DoesNotExist"`) {
+		t.Errorf("error should name the missing device: %q", msg)
+	}
+	// Available names must be listed, sorted, so users can copy/paste the right one.
+	for _, want := range []string{"Alpha", "Bravo", "Charlie"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error should list %q; got %q", want, msg)
+		}
+	}
+	alphaIdx := strings.Index(msg, "Alpha")
+	bravoIdx := strings.Index(msg, "Bravo")
+	charlieIdx := strings.Index(msg, "Charlie")
+	if !(alphaIdx < bravoIdx && bravoIdx < charlieIdx) {
+		t.Errorf("available names should be sorted alphabetically; got %q", msg)
+	}
+}
+
+func TestMatchDevice_NoMatchEmptyCatalogGivesDistinctError(t *testing.T) {
+	got, err := matchDevice(nil, "Anything")
+	if got != nil {
+		t.Errorf("expected nil device, got %+v", got)
+	}
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "no playback devices available") {
+		t.Errorf("error should distinguish empty-catalog case: %q", msg)
+	}
+}

--- a/pkg/sendspin/config.go
+++ b/pkg/sendspin/config.go
@@ -38,6 +38,7 @@ type PlayerConfigFile struct {
 	PreferredCodec string `yaml:"preferred_codec,omitempty"`
 	BufferCapacity *int   `yaml:"buffer_capacity,omitempty"`
 	ClientID       string `yaml:"client_id,omitempty"`
+	AudioDevice    string `yaml:"audio_device,omitempty"`
 }
 
 // LoadPlayerConfig searches for a player.yaml and returns its parsed contents
@@ -177,6 +178,9 @@ func (c *PlayerConfigFile) asStringMap() map[string]string {
 	}
 	if c.ClientID != "" {
 		m["client_id"] = c.ClientID
+	}
+	if c.AudioDevice != "" {
+		m["audio_device"] = c.AudioDevice
 	}
 	return m
 }

--- a/pkg/sendspin/config_test.go
+++ b/pkg/sendspin/config_test.go
@@ -27,6 +27,7 @@ daemon: false
 preferred_codec: "flac"
 buffer_capacity: 2097152
 client_id: "aa:bb:cc:dd:ee:ff"
+audio_device: "USB Audio Device"
 `
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		t.Fatalf("seed: %v", err)
@@ -56,6 +57,9 @@ client_id: "aa:bb:cc:dd:ee:ff"
 	}
 	if cfg.ClientID != "aa:bb:cc:dd:ee:ff" {
 		t.Errorf("client_id = %q", cfg.ClientID)
+	}
+	if cfg.AudioDevice != "USB Audio Device" {
+		t.Errorf("audio_device = %q", cfg.AudioDevice)
 	}
 }
 

--- a/pkg/sendspin/player.go
+++ b/pkg/sendspin/player.go
@@ -67,6 +67,11 @@ type PlayerConfig struct {
 	// ResolveClientID) and reuse the same value across reconnects.
 	ClientID string
 
+	// AudioDevice selects a specific playback device by name (as reported by
+	// output.ListPlaybackDevices). Empty = let miniaudio pick the default.
+	// Open fails loudly if a non-empty name doesn't match an available device.
+	AudioDevice string
+
 	DeviceInfo DeviceInfo
 
 	OnMetadata func(Metadata)
@@ -309,7 +314,7 @@ func jitter(d time.Duration, frac float64) time.Duration {
 
 func (p *Player) onStreamStart(format audio.Format) {
 	if p.output == nil {
-		p.output = output.NewMalgo()
+		p.output = output.NewMalgo(p.config.AudioDevice)
 	}
 
 	if err := p.output.Open(format.SampleRate, format.Channels, format.BitDepth); err != nil {


### PR DESCRIPTION
## Summary

Gives the player three ways to pick a playback device and one way to see what's available:

- **`--list-audio-devices`** — enumerate every playback device miniaudio can see, print with a `[*]` next to the current default, and exit.
- **`--audio-device <name>`** — open a specific device by exact name. Fail-loud if the name doesn't match.
- **`audio_device:` YAML key** — same value via `player.yaml`, threaded through the existing overlay.
- **`SENDSPIN_PLAYER_AUDIO_DEVICE` env** — automatic, no special casing.
- **Chosen device is logged on every `Open()`** so operators see exactly which sink got opened.

## Motivating case

A Pi user reports their soundcard works with sendspin-cpp but not sendspin-go. Root cause hypothesis: miniaudio's default backend (PulseAudio/PipeWire on most modern Pi installs) routes to a different sink than ALSA's `default`, which is what sendspin-cpp hits. Previously we had no way to tell the user what miniaudio saw or override it. Now both are one flag away.

## Design calls

- **Fail-loud on device-not-found.** The error lists every available device name, sorted alphabetically, so the user can copy-paste. Silent fallback to default would defeat the point — we'd be re-creating the exact \"looks fine, nothing plays\" symptom this feature exists to fix.
- **Exact name match.** No substring or case-insensitive mode in this PR. Names on ALSA look like `\"HDA Intel PCH: ALC257 Analog (hw:0,0)\"`; we can loosen later if users find that painful.
- **Fresh malgo context for `ListPlaybackDevices`.** Same `InitContext(nil, ContextConfig{}, nil)` args as the player's `Open()`, so miniaudio picks the same backend for enumeration as for opening — guaranteeing a name shown by `--list` will match when passed to `--audio-device`.
- **Backend logging punted.** malgo's Go API doesn't expose `ctx.Backend()`, so \"PulseAudio vs ALSA\" isn't directly loggable. We log the chosen device name, which is what operators actually need to see. Explicit backend probing (try ALSA first, then PulseAudio, log which one worked) is a follow-up if device name alone doesn't solve the Pi user's case.

## Files

- `pkg/audio/output/malgo.go` — `PlaybackDevice` struct; `NewMalgo(deviceName string)` (breaking, single call site updated); `ListPlaybackDevices()`; `matchDevice()` pure lookup; `Open()` enumerates, matches, sets `DeviceConfig.Playback.DeviceID`, and logs the chosen device.
- `pkg/audio/output/malgo_test.go` *(new)* — table tests for `matchDevice` covering empty-request/IsDefault-preference, first-fallback, exact match, not-found-lists-available (with sort check), and empty-catalog distinct error. Uses a sentinel-byte on `DeviceID[0]` to prove the correct slice element is returned.
- `pkg/sendspin/player.go` — `PlayerConfig.AudioDevice`, passed to `output.NewMalgo(p.config.AudioDevice)` in `onStreamStart`. No `ReceiverConfig` plumbing needed because `onStreamStart` is a `Player` method with full access to `p.config`.
- `pkg/sendspin/config.go` — `PlayerConfigFile.AudioDevice` with yaml tag; matching entry in `asStringMap()` so the existing overlay handles env + file precedence.
- `pkg/sendspin/config_test.go` — extended the \"all keys\" fixture with `audio_device: \"USB Audio Device\"`.
- `main.go` — two new flags; `--list-audio-devices` early-exit handler that runs before overlay/client-id resolution; `printPlaybackDevices()` helper; `AudioDevice` passed into `PlayerConfig`.
- `dist/config/player.example.yaml` — commented-out `audio_device:` block with a pointer to `--list-audio-devices`.
- `README.md` — new \"Selecting a playback device\" subsection with a worked example of `--list-audio-devices` → pick name → set config; both flags added to the options list; `audio_device:` added to the sample YAML.

## Test plan

- [x] `go test ./...` clean (all packages green)
- [x] `go vet ./...` clean
- [x] `go build ./...` clean; `--help` shows `--audio-device` and `--list-audio-devices`
- [x] Ran `./sendspin-player --list-audio-devices` on dev machine — correctly enumerated two devices with `[*]` on the system default
- [ ] Pi user runs `sendspin-player --list-audio-devices`, identifies the name their soundcard surfaces under, and sets it via `audio_device:` in `/etc/sendspin/player.yaml` or passes `--audio-device \"<name>\"`. Startup log should read `Audio output initialized: device=\"<name>\" ...` and audio should come out of the expected card.
- [ ] Pi user sets a deliberately-bogus `audio_device:` value; player aborts with a sorted list of what *is* available (fail-loud behavior verified).
- [ ] Existing installs that don't set `audio_device` see no behavior change — log line now includes the device name but miniaudio's default-selection path is unchanged.

## What this PR does NOT do

- **No `--audio-backend` flag** yet. Adding one would let users force ALSA over PulseAudio (or vice versa) and would be the natural next step if device-name selection alone doesn't fix the Pi case.
- **No integration test of `ListPlaybackDevices`.** Requires a real audio stack; CI doesn't have one.
- **No migration of existing configs.** `audio_device` is an additive key; absence means \"default\", matching prior behavior.