### PR TITLE
docs(server): document timestamp invariants in generateAndSendChunk

### DIFF
--- a/pkg/sendspin/server_stream.go
+++ b/pkg/sendspin/server_stream.go
@@ -28,6 +28,16 @@ func (s *Server) streamAudio() {
 }
 
 func (s *Server) generateAndSendChunk() {
+	// Timestamp invariants — do not weaken without re-analysis:
+	//   1. playbackTime is sampled fresh from the monotonic clock on every
+	//      tick. It is NOT a running counter like `pending += chunkDurationUs`.
+	//   2. ChunkDurationMs × sampleRate must divide evenly by 1000 at every
+	//      supported rate. At 20ms this holds: 44.1k→882, 48k→960, 88.2k→1764,
+	//      96k→1920. At 25ms, 44.1k→1102.5 (fractional) — do NOT change the
+	//      constant without also re-working the chunk-size/sample math.
+	// Weakening either invariant re-introduces the drift class described in
+	// aiosendspin#217 (500ms cliff after ~17 minutes at 44.1k/25ms). See also
+	// issue #91 for converting the linear resampler to integer-rational math.
 	currentTime := s.getClockMicros()
 	playbackTime := currentTime + (BufferAheadMs * 1000)
 


### PR DESCRIPTION
Comment-only change. Motivated by review of [aiosendspin#217](https://github.com/Sendspin/aiosendspin/pull/217) (17-minute audio-drift cliff caused by accumulated integer-truncated timestamp math in their server-side transformer pipeline).

## What

Captures the two load-bearing invariants in \`generateAndSendChunk\` that make our server immune to that drift class:

1. \`playbackTime\` is sampled fresh from the monotonic clock every tick — **not** accumulated as \`pending += chunkDurationUs\`. If anyone later 'optimizes' this to a running counter, they re-introduce the bug.
2. At \`ChunkDurationMs = 20\`, samples-per-chunk is integer at every supported rate (44.1k→882, 48k→960, 88.2k→1764, 96k→1920). At 25ms, 44.1k→1102.5 (fractional) — changing the constant without re-working the math surfaces the drift.

Also points at #91 for the longer-term defense-in-depth task of converting the linear resampler to integer-rational position math.

## Why

Comparison against #217 concluded we don't have their bug — but the reason is non-obvious (wall-clock timestamping saving us) and trivially easy to break with an innocent-looking refactor. The comment makes the invariants explicit so the next person touching this loop doesn't have to re-derive the analysis.

## What this is NOT

- No behavior change.
- Not the resampler fix itself — that's #91 and remains deferred because current behavior is provably correct under all supported sample-rate × chunk-size combinations.