### PR TITLE
fix(player): resolve HiFiBerry/ALSA --audio-device selection

### DIFF
--- a/main.go
+++ b/main.go
@@ -356,10 +356,11 @@ func printPlaybackDevices(w io.Writer) error {
 		if d.IsDefault {
 			marker = "[*]"
 		}
-		fmt.Fprintf(w, "  %s %s\n", marker, d.Name)
+		fmt.Fprintf(w, "  %s %q\n", marker, d.Name)
 	}
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "[*] = current default. Use --audio-device \"<name>\" or set audio_device: in player.yaml.")
+	fmt.Fprintln(w, "On Linux, miniaudio names look like \"<short>, <description>\"; either the full name or just the short part before the comma will match.")
 	return nil
 }
 

--- a/pkg/audio/output/malgo.go
+++ b/pkg/audio/output/malgo.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -281,9 +282,23 @@ func (m *Malgo) Open(sampleRate, channels, bitDepth int) error {
 	if err != nil {
 		return err
 	}
+	// Hand miniaudio a pointer to the selected device ID, pinned across the
+	// cgo call so Go 1.21+'s pointer check accepts it.
+	//
+	// Pinning &chosen.ID[0] directly would fail: chosen is an element inside
+	// a []PlaybackDevice, and the containing heap object also holds the Go
+	// string Name — whose backing bytes are another Go pointer that cgo's
+	// recursive scan would find unpinned and reject. Copying the ID bytes
+	// into a standalone []byte isolates the pointer target: a byte slice's
+	// backing array contains only bytes (no further Go pointers), so the
+	// scan finds nothing to complain about.
+	var pinner runtime.Pinner
+	defer pinner.Unpin()
 	chosenLabel := "(miniaudio default)"
 	if chosen != nil {
-		deviceConfig.Playback.DeviceID = unsafe.Pointer(&chosen.ID[0])
+		idBuf := append([]byte(nil), chosen.ID[:]...)
+		pinner.Pin(&idBuf[0])
+		deviceConfig.Playback.DeviceID = unsafe.Pointer(&idBuf[0])
 		if chosen.IsDefault {
 			chosenLabel = fmt.Sprintf("%q (default)", chosen.Name)
 		} else {

--- a/pkg/audio/output/malgo.go
+++ b/pkg/audio/output/malgo.go
@@ -161,10 +161,17 @@ func ListPlaybackDevices() ([]PlaybackDevice, error) {
 // the list, else nil if the list is empty (caller falls back to whatever
 // miniaudio's default-config path does).
 //
-// Non-empty requested name -> exact match on Name. If no match: returns an
-// error whose message lists every available device name so the user can fix
-// the config. Fail-loud is intentional: silent fallback to default is the
-// behavior this feature exists to correct.
+// Non-empty requested name -> exact Name match first, then short-name match
+// (the text before the first ", "). Miniaudio's Linux/ALSA backend builds
+// device names from snd_device_name_hint's DESC field, which follows a
+// "<card-short>, <stream-description>" convention, so users naturally try
+// just the short part. If the short-name match is ambiguous, we error out
+// instead of picking one silently.
+//
+// Fail-loud on no-match: the error lists every available device name, each
+// quoted with %q so embedded commas are distinguishable from the list
+// separator. Silent fallback to default is the behavior this feature
+// exists to correct.
 func matchDevice(devices []PlaybackDevice, requested string) (*PlaybackDevice, error) {
 	if requested == "" {
 		if len(devices) == 0 {
@@ -182,15 +189,27 @@ func matchDevice(devices []PlaybackDevice, requested string) (*PlaybackDevice, e
 			return &devices[i], nil
 		}
 	}
+	var shortMatches []int
+	for i, d := range devices {
+		if idx := strings.Index(d.Name, ", "); idx > 0 && d.Name[:idx] == requested {
+			shortMatches = append(shortMatches, i)
+		}
+	}
+	if len(shortMatches) == 1 {
+		return &devices[shortMatches[0]], nil
+	}
 	if len(devices) == 0 {
 		return nil, fmt.Errorf("audio device %q not found (no playback devices available)", requested)
 	}
-	names := make([]string, 0, len(devices))
-	for _, d := range devices {
-		names = append(names, d.Name)
+	quoted := make([]string, len(devices))
+	for i, d := range devices {
+		quoted[i] = fmt.Sprintf("%q", d.Name)
 	}
-	sort.Strings(names)
-	return nil, fmt.Errorf("audio device %q not found; available: %s", requested, strings.Join(names, ", "))
+	sort.Strings(quoted)
+	if len(shortMatches) > 1 {
+		return nil, fmt.Errorf("audio device %q is ambiguous (matches %d devices by short name); use the full quoted name. Available: %s", requested, len(shortMatches), strings.Join(quoted, ", "))
+	}
+	return nil, fmt.Errorf("audio device %q not found; available: %s", requested, strings.Join(quoted, ", "))
 }
 
 func (m *Malgo) Open(sampleRate, channels, bitDepth int) error {

--- a/pkg/audio/output/malgo_test.go
+++ b/pkg/audio/output/malgo_test.go
@@ -141,3 +141,92 @@ func TestMatchDevice_NoMatchEmptyCatalogGivesDistinctError(t *testing.T) {
 		t.Errorf("error should distinguish empty-catalog case: %q", msg)
 	}
 }
+
+// TestMatchDevice_ShortNameMatch covers miniaudio's Linux/ALSA naming where
+// device.name is "<card-short>, <stream-description>" — users typing just
+// the short prefix should match unambiguously when only one device has that
+// prefix. Reproduces the HiFiBerry case from the field bug.
+func TestMatchDevice_ShortNameMatch(t *testing.T) {
+	devices := []PlaybackDevice{
+		newDevice("Default Audio Device", true, 0x01),
+		newDevice("vc4-hdmi-0, MAI PCM i2s-hifi-0", false, 0x02),
+		newDevice("vc4-hdmi-1, MAI PCM i2s-hifi-0", false, 0x03),
+		newDevice("PDP Audio Device, USB Audio", false, 0x04),
+	}
+
+	got, err := matchDevice(devices, "vc4-hdmi-0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || got.ID[0] != 0x02 {
+		t.Errorf("short-name %q should resolve to id 0x02; got %+v", "vc4-hdmi-0", got)
+	}
+
+	got, err = matchDevice(devices, "PDP Audio Device")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || got.ID[0] != 0x04 {
+		t.Errorf("short-name %q should resolve to id 0x04; got %+v", "PDP Audio Device", got)
+	}
+}
+
+// TestMatchDevice_ExactNameWinsOverShortName guards the precedence: if a
+// device's full name happens to equal someone else's short prefix, the
+// exact match takes priority over the short-name search.
+func TestMatchDevice_ExactNameWinsOverShortName(t *testing.T) {
+	devices := []PlaybackDevice{
+		newDevice("Foo, long description", false, 0x01),
+		newDevice("Foo", false, 0x02),
+	}
+
+	got, err := matchDevice(devices, "Foo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || got.ID[0] != 0x02 {
+		t.Errorf("exact match should win: expected id 0x02; got %+v", got)
+	}
+}
+
+// TestMatchDevice_ShortNameAmbiguousReturnsError covers the two-HiFiBerry
+// case: the same short prefix matches multiple devices. We must not silently
+// pick one.
+func TestMatchDevice_ShortNameAmbiguousReturnsError(t *testing.T) {
+	devices := []PlaybackDevice{
+		newDevice("HiFiBerry, card 0", false, 0x01),
+		newDevice("HiFiBerry, card 1", false, 0x02),
+	}
+
+	got, err := matchDevice(devices, "HiFiBerry")
+	if got != nil {
+		t.Errorf("expected nil on ambiguous short-name match, got %+v", got)
+	}
+	if err == nil {
+		t.Fatal("expected an error on ambiguous short-name match")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "ambiguous") {
+		t.Errorf("error should mention ambiguity: %q", msg)
+	}
+	if !strings.Contains(msg, `"HiFiBerry, card 0"`) || !strings.Contains(msg, `"HiFiBerry, card 1"`) {
+		t.Errorf("ambiguity error should list both candidates quoted with %%q: %q", msg)
+	}
+}
+
+// TestMatchDevice_NoMatchQuotesNames ensures names with embedded commas are
+// distinguishable from the list separator in the error output.
+func TestMatchDevice_NoMatchQuotesNames(t *testing.T) {
+	devices := []PlaybackDevice{
+		newDevice("vc4-hdmi-0, MAI PCM i2s-hifi-0", false, 0x01),
+	}
+
+	_, err := matchDevice(devices, "nonexistent")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `"vc4-hdmi-0, MAI PCM i2s-hifi-0"`) {
+		t.Errorf("name should appear quoted in error so embedded comma is unambiguous: %q", msg)
+	}
+}


### PR DESCRIPTION
## Summary

Two bugs that together prevented `--audio-device` from working on Linux. Reported against a Pi with a HiFiBerry Digi+ Pro HAT but affects every ALSA device whose name contains a comma.

### Bug 1 — exact-match against the wrong name

Miniaudio's Linux/ALSA backend builds `device.name` from `snd_device_name_hint`'s `DESC` field, which by convention is `"<card-short>, <stream-description>"`. A HiFiBerry Digi+ Pro reports as:

```
"snd_rpi_hifiberry_digi, HiFiBerry Digi+ Pro HiFi wm8804-spdif-0"
```

Users seeing the short name (from `/proc/asound/cards`, `aplay -l`, or the pre-fix `--list-audio-devices` output where the embedded comma was indistinguishable from the list separator) naturally put just the short prefix in `audio_device`, and the exact-match lookup failed with:

```
audio device "snd_rpi_hifiberry_digi" not found; available: ..., bcm2835 Headphones, bcm2835 Headphones, snd_rpi_hifiberry_digi, HiFiBerry Digi+ Pro HiFi wm8804-spdif-0, vc4-hdmi, ...
```

(That list looks like nine devices — it's actually seven, two of which contain commas.)

**Fix:** after the exact-name check, try matching the text before the first `", "`. If exactly one device matches, use it; if multiple, error explicitly with an ambiguity message. Exact match still wins when both apply. Error output and `--list-audio-devices` now quote every name with `%q` so embedded commas are unambiguous.

### Bug 2 — cgo pointer panic once the match succeeds

Pre-existing since 1.5.0's `--audio-device` feature but masked by Bug 1 — the exact-name lookup rarely succeeded, so the code path never actually reached miniaudio's C side with a selected device. Once matchDevice starts returning non-nil, `InitDevice` panics:

```
panic: runtime error: cgo argument has Go pointer to unpinned Go pointer
```

`deviceConfig.Playback.DeviceID = unsafe.Pointer(&chosen.ID[0])` hands cgo a pointer into Go memory. Go 1.21+'s stricter cgo check rejects that unless the pointer target is pinned — and pinning `&chosen.ID[0]` directly isn't enough because the containing `PlaybackDevice` also holds a `Name string` whose backing bytes are another unpinned Go pointer.

**Fix:** copy the device ID into a fresh `[]byte` and pin that. A byte slice's backing array contains only bytes (no further Go pointers), so the cgo recursive scan finds nothing to reject. `runtime.Pinner.Unpin` at function exit releases the pin once InitDevice has copied the ID into its own C-side state.

## Verified on hardware

End-to-end on a Pi (aarch64, Debian 12, Go 1.24.0, libasound2-dev 1.2.14) with a USB DAC whose ALSA DESC contains a comma:

- `--audio-device "PDP Audio Device"` (short) → opens the USB DAC.
- `--audio-device "PDP Audio Device, USB Audio"` (full) → opens the USB DAC.
- no flag → opens the `Default Audio Device` (current default).
- `--audio-device "nope"` → fail-loud error listing every device with `%q` quoting.

## Commits

1. `fix(player): accept short device name, quote names in diagnostics` — matchDevice change + quoted output.
2. `fix(player): pin isolated device ID buffer across cgo InitDevice` — runtime.Pinner on a standalone byte slice.

## Test plan

- [x] `go test ./pkg/audio/output/ -run TestMatchDevice -v` — 4 new tests + 4 existing pass.
- [x] `go test ./... -short` — full suite passes.
- [x] Pi end-to-end smoke (all four scenarios above).
- [ ] **Reviewer:** verify against the original HiFiBerry Pi if available — the user's existing `audio_device: snd_rpi_hifiberry_digi` config should now Just Work without edits.