### PR TITLE
fix(player/malgo): write in passes; absorb oversized buffers

### DIFF
--- a/pkg/audio/output/malgo.go
+++ b/pkg/audio/output/malgo.go
@@ -337,11 +337,12 @@ func (m *Malgo) Open(sampleRate, channels, bitDepth int) error {
 }
 
 // Write queues audio samples for playback.
-// Blocks briefly if the ring buffer is full, waiting for the audio callback
-// to drain space. If insufficient space is available within the timeout,
-// the entire buffer is dropped — partial writes split a buffer mid-stream
-// and produce an audible click at the cut, while a whole-buffer drop yields
-// a brief, clean silence the audio callback fills with zeros.
+// Writes in passes if the ring is too small to absorb the whole buffer
+// at once, waiting for the audio callback to drain space between passes.
+// Buffers larger than the ring (e.g. Music Assistant's ~85 ms PCM chunks
+// against a 80 ms ring) succeed as long as the callback keeps draining.
+// Returns an error only if no drain progress occurs for maxStallTime,
+// which indicates the audio callback itself has stalled.
 func (m *Malgo) Write(samples []int32) error {
 	if !m.ready {
 		return fmt.Errorf("output not initialized")
@@ -349,35 +350,33 @@ func (m *Malgo) Write(samples []int32) error {
 
 	const (
 		retryInterval = 1 * time.Millisecond
-		maxWait       = 50 * time.Millisecond
+		maxStallTime  = 50 * time.Millisecond
 	)
 
 	volumedSamples := applyVolume(samples, m.volume, m.muted)
 
-	if len(volumedSamples) > m.ringBuffer.size {
-		// The buffer is larger than the ring can ever hold. Surfacing
-		// this loudly is more useful than silently truncating — it
-		// indicates upstream produced an oversized buffer (e.g. a
-		// decoder concatenated multiple frames).
-		return fmt.Errorf("buffer of %d samples exceeds ring capacity %d (likely upstream framing bug)",
-			len(volumedSamples), m.ringBuffer.size)
-	}
+	written := 0
+	lastProgress := time.Now()
+	for written < len(volumedSamples) {
+		n := m.ringBuffer.Write(volumedSamples[written:])
+		if n > 0 {
+			written += n
+			lastProgress = time.Now()
+			continue
+		}
 
-	// Wait for enough free space to fit the entire buffer atomically.
-	// Free() is a lower bound on actual free space at Write time (the
-	// audio callback only ever drains, never fills), so once Free()
-	// reports enough, the subsequent Write call is guaranteed to fit.
-	waited := time.Duration(0)
-	for m.ringBuffer.Free() < len(volumedSamples) {
-		if waited >= maxWait {
-			return fmt.Errorf("ring buffer full, dropped %d samples after %v",
-				len(volumedSamples), maxWait)
+		// Ring is full this pass. Wait for the audio callback to
+		// drain. If we go too long with zero progress, the callback
+		// has likely stalled — drop the remainder rather than block
+		// the producer indefinitely.
+		if time.Since(lastProgress) > maxStallTime {
+			dropped := len(volumedSamples) - written
+			return fmt.Errorf("ring buffer stalled, dropped %d of %d samples after %v with no drain progress",
+				dropped, len(volumedSamples), maxStallTime)
 		}
 		time.Sleep(retryInterval)
-		waited += retryInterval
 	}
 
-	m.ringBuffer.Write(volumedSamples)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Refines the malgo `Write` behavior introduced in #98 / `eeb8bad`. The strict version errors on any buffer larger than the ring capacity, which breaks callers that legitimately produce oversized buffers — Music Assistant sends ~85 ms PCM chunks (32768 samples at 192k/24-bit stereo) against the 80 ms ring (30720 samples), so the strict path errors on every chunk.

The new behavior writes in passes, advancing as the audio callback drains the ring, and returns an error only if **no drain progress** occurs for 50 ms (i.e. the callback itself has stalled — the actual failure mode worth surfacing).

The ring buffer's `Write` already returned the count of samples written; the previous code discarded that return value. The new code uses it.

## Behavior delta vs v1.6.0

| Scenario | Before (`eeb8bad`) | After |
|---|---|---|
| Buffer fits, ring has space | write succeeds | write succeeds |
| Buffer fits, ring momentarily full | wait up to 50 ms, drop whole buffer on timeout | write in passes, succeeds while callback drains |
| Buffer > ring capacity | error: "buffer exceeds ring capacity" | write in passes, succeeds |
| Audio callback stalled | (same) drop after 50 ms | error: "ring buffer stalled, dropped N of M samples after 50 ms with no drain progress" |

## Test plan

- [x] `go build ./pkg/audio/output/...`
- [x] `go test ./pkg/audio/output/...` — pass
- [x] `make test`
- [x] `make conformance`
- [x] Live: Music Assistant → `sendspin-player` at 192k/24-bit no longer logs `ring buffer full, dropped N samples after 50ms`
- [x] Live: standard Sendspin-encoded FLAC playback still smooth (the 1:1 chunk→frame guarantee from `eeb8bad` keeps decoded buffers ≤ ring capacity, so this path is unchanged for native server output)