### PR TITLE
feat(player): cap advertised SupportedFormats by output device probe

### DIFF
--- a/dist/config/player.example.yaml
+++ b/dist/config/player.example.yaml
@@ -91,3 +91,25 @@
 # start and lists every available device — silent fallback would defeat the
 # point of setting this key.
 # audio_device: "USB Audio Device"
+
+# ---------------------------------------------------------------------------
+# Output capability override
+# ---------------------------------------------------------------------------
+
+# Cap the highest sample rate / bit depth advertised to the server. Both
+# default to 0, which means "auto-probe the audio device for its native
+# ceiling at startup". Setting either key disables auto-probe entirely
+# (the explicit value wins, even if it's higher than the probe would have
+# returned).
+#
+# When to set these explicitly:
+#  - Pi3 / Pi Zero with onboard headphone output: ALSA reports the bcm2835
+#    driver accepts 192k/24, but the actual hardware can't drain that fast.
+#    Cap at 48000 / 16 to match what the device can really do.
+#  - USB DAC that advertises higher rates than its analog stage handles
+#    cleanly — pin to the rate that sounds best.
+#  - Bandwidth-constrained networks where you'd rather force lossy/low-rate
+#    even though the device could play hi-res.
+#
+# max_sample_rate: 48000
+# max_bit_depth: 16

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,9 +1,14 @@
 // ABOUTME: Version information for the player
-// ABOUTME: Used in device_info sent during handshake
+// ABOUTME: Used in device_info sent during handshake; patched at link time via -X
 package version
 
-const (
-	Version      = "1.6.0"
+// Version is the player version. Declared as var (not const) so the release
+// workflow can inject the tag string with -ldflags "-X .../version.Version=v1.6.3".
+// Linker -X only patches package-level string vars; constants are inlined and
+// silently ignored. Pre-1.6.3 this was a const, which is why every release
+// binary reported the hardcoded default regardless of the tag it shipped under.
+var (
+	Version      = "1.6.3"
 	Product      = "Sendspin Go Player"
 	Manufacturer = "sendspin-go"
 )

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,10 +3,9 @@
 package version
 
 // Version is the player version. Declared as var (not const) so the release
-// workflow can inject the tag string with -ldflags "-X .../version.Version=v1.6.3".
-// Linker -X only patches package-level string vars; constants are inlined and
-// silently ignored. Pre-1.6.3 this was a const, which is why every release
-// binary reported the hardcoded default regardless of the tag it shipped under.
+// workflow can inject the tag string with -ldflags "-X .../version.Version=...".
+// Go's linker -X flag only patches package-level string vars; constants are
+// inlined at every callsite and silently ignored.
 var (
 	Version      = "1.6.3"
 	Product      = "Sendspin Go Player"

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -60,9 +60,9 @@ func TestManufacturerFormat(t *testing.T) {
 
 func TestVersionLdflagsPatchable(t *testing.T) {
 	// Version, Product, and Manufacturer are package-level string vars so the
-	// release workflow can patch Version via -ldflags "-X .../version.Version=v1.6.3".
-	// This test just verifies the symbols are accessible. We deliberately don't
-	// assert immutability — that's exactly what we gave up to make ldflags work.
+	// release workflow can patch Version via -ldflags -X. Verify the symbols
+	// are accessible; immutability is intentionally not asserted, since
+	// patchability requires var declarations.
 	if Version == "" {
 		t.Error("Version is empty")
 	}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,5 +1,5 @@
-// ABOUTME: Tests for version constants
-// ABOUTME: Ensures version information is properly defined
+// ABOUTME: Tests for version package symbols
+// ABOUTME: Ensures version information is properly defined and ldflags-patchable
 package version
 
 import (
@@ -58,24 +58,19 @@ func TestManufacturerFormat(t *testing.T) {
 	}
 }
 
-func TestVersionImmutability(t *testing.T) {
-	// Store original values
-	originalVersion := Version
-	originalProduct := Product
-	originalManufacturer := Manufacturer
-
-	// These are const, so they can't actually be modified,
-	// but let's verify they're still accessible
-	if Version != originalVersion {
-		t.Error("Version changed unexpectedly")
+func TestVersionLdflagsPatchable(t *testing.T) {
+	// Version, Product, and Manufacturer are package-level string vars so the
+	// release workflow can patch Version via -ldflags "-X .../version.Version=v1.6.3".
+	// This test just verifies the symbols are accessible. We deliberately don't
+	// assert immutability — that's exactly what we gave up to make ldflags work.
+	if Version == "" {
+		t.Error("Version is empty")
 	}
-
-	if Product != originalProduct {
-		t.Error("Product changed unexpectedly")
+	if Product == "" {
+		t.Error("Product is empty")
 	}
-
-	if Manufacturer != originalManufacturer {
-		t.Error("Manufacturer changed unexpectedly")
+	if Manufacturer == "" {
+		t.Error("Manufacturer is empty")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -41,6 +41,8 @@ var (
 	configPath     = flag.String("config", "", "Path to player.yaml config file. Default search: $SENDSPIN_PLAYER_CONFIG, ~/.config/sendspin/player.yaml, /etc/sendspin/player.yaml.")
 	audioDevice    = flag.String("audio-device", "", "Playback device name (see --list-audio-devices). Empty = miniaudio default.")
 	listAudio      = flag.Bool("list-audio-devices", false, "List available playback devices and exit.")
+	maxSampleRate  = flag.Int("max-sample-rate", 0, "Cap the highest sample rate advertised to the server. 0 = auto-probe the audio device. Set explicitly when the auto-probe is wrong (e.g. Pi3 onboard headphones report 192k but can't actually drain it).")
+	maxBitDepth    = flag.Int("max-bit-depth", 0, "Cap the highest bit depth advertised to the server. 0 = auto-probe. Setting either --max-sample-rate or --max-bit-depth disables auto-probe entirely.")
 )
 
 func main() {
@@ -194,6 +196,8 @@ func main() {
 		BufferCapacity: *bufferCapacity,
 		ClientID:       resolvedClientID,
 		AudioDevice:    *audioDevice,
+		MaxSampleRate:  *maxSampleRate,
+		MaxBitDepth:    *maxBitDepth,
 		DeviceInfo: sendspin.DeviceInfo{
 			ProductName:     deviceProduct,
 			Manufacturer:    deviceManufacturer,

--- a/pkg/audio/output/query.go
+++ b/pkg/audio/output/query.go
@@ -1,0 +1,110 @@
+// ABOUTME: Capability probe for malgo playback devices (rate/bit-depth ceilings)
+// ABOUTME: Used by Player to filter advertised SupportedFormats before handshake
+package output
+
+import (
+	"fmt"
+
+	"github.com/gen2brain/malgo"
+)
+
+// QueryDeviceCapabilities returns the highest sample rate and bit depth the
+// named playback device's malgo (miniaudio) backend reports as natively
+// supported. deviceName matches the same way ListPlaybackDevices and Open
+// accept it; an empty string selects the platform default.
+//
+// Best-effort. When the backend reports zero native formats — some devices
+// don't, especially on cold-start Windows / Pulse — this returns (0, 0, nil)
+// so the caller can fall back to "no cap". On Linux/ALSA the answer can also
+// be optimistic, because miniaudio reports what the driver claims to accept,
+// and ALSA layers software resampling under formats the underlying hardware
+// (e.g. bcm2835 onboard headphones) can't actually sustain. The user-facing
+// override knob exists exactly for that case.
+//
+// Does NOT InitDevice. Cheaper than opening the device, but the trade-off is
+// that the answer is a best-guess from miniaudio rather than ground truth.
+func QueryDeviceCapabilities(deviceName string) (maxSampleRate, maxBitDepth int, err error) {
+	ctx, err := malgo.InitContext(nil, malgo.ContextConfig{}, nil)
+	if err != nil {
+		return 0, 0, fmt.Errorf("init malgo context: %w", err)
+	}
+	defer func() {
+		_ = ctx.Uninit()
+		ctx.Free()
+	}()
+
+	infos, err := ctx.Devices(malgo.Playback)
+	if err != nil {
+		return 0, 0, fmt.Errorf("enumerate playback devices: %w", err)
+	}
+
+	catalog := make([]PlaybackDevice, 0, len(infos))
+	for _, info := range infos {
+		catalog = append(catalog, PlaybackDevice{
+			Name:      info.Name(),
+			IsDefault: info.IsDefault != 0,
+			ID:        info.ID,
+		})
+	}
+
+	chosen, err := matchDevice(catalog, deviceName)
+	if err != nil {
+		return 0, 0, err
+	}
+	if chosen == nil {
+		// No devices at all. Treat as "no cap" — no audio output is going to
+		// happen anyway, so the caller's handshake will fail for unrelated
+		// reasons.
+		return 0, 0, nil
+	}
+
+	detail, err := ctx.DeviceInfo(malgo.Playback, chosen.ID, malgo.Shared)
+	if err != nil {
+		return 0, 0, fmt.Errorf("query device info for %q: %w", chosen.Name, err)
+	}
+
+	maxRate, maxDepth := capsFromFormats(detail.Formats)
+	return maxRate, maxDepth, nil
+}
+
+// capsFromFormats walks a DeviceInfo's native-format list and returns the
+// highest sample rate and bit depth observed. Formats with unknown bit
+// representations (FormatU8, FormatUnknown) are ignored — we'd rather report
+// a lower cap than advertise rates only achievable in unsupported formats.
+//
+// Pure helper so the cgo-bound QueryDeviceCapabilities doesn't need test
+// coverage of its own — capsFromFormats covers the interesting logic.
+func capsFromFormats(formats []malgo.DataFormat) (maxSampleRate, maxBitDepth int) {
+	for _, f := range formats {
+		bits := formatBits(f.Format)
+		if bits == 0 {
+			continue
+		}
+		if int(f.SampleRate) > maxSampleRate {
+			maxSampleRate = int(f.SampleRate)
+		}
+		if bits > maxBitDepth {
+			maxBitDepth = bits
+		}
+	}
+	return maxSampleRate, maxBitDepth
+}
+
+// formatBits returns the linear bit count for a malgo FormatType.
+// 0 means unknown/unsupported and the caller should ignore the entry.
+func formatBits(f malgo.FormatType) int {
+	switch f {
+	case malgo.FormatS16:
+		return 16
+	case malgo.FormatS24:
+		return 24
+	case malgo.FormatS32:
+		return 32
+	case malgo.FormatF32:
+		// 32-bit float carries the same dynamic range as S32 for our
+		// purposes — both clear our 24-bit advertised ceiling.
+		return 32
+	default:
+		return 0
+	}
+}

--- a/pkg/audio/output/query_test.go
+++ b/pkg/audio/output/query_test.go
@@ -1,4 +1,5 @@
 // ABOUTME: Tests for the pure capsFromFormats / formatBits helpers
+// ABOUTME: cgo-bound QueryDeviceCapabilities is not exercised here
 package output
 
 import (

--- a/pkg/audio/output/query_test.go
+++ b/pkg/audio/output/query_test.go
@@ -1,0 +1,89 @@
+// ABOUTME: Tests for the pure capsFromFormats / formatBits helpers
+package output
+
+import (
+	"testing"
+
+	"github.com/gen2brain/malgo"
+)
+
+func TestFormatBits(t *testing.T) {
+	tests := []struct {
+		format malgo.FormatType
+		want   int
+	}{
+		{malgo.FormatS16, 16},
+		{malgo.FormatS24, 24},
+		{malgo.FormatS32, 32},
+		{malgo.FormatF32, 32},
+		{malgo.FormatUnknown, 0},
+		{malgo.FormatU8, 0}, // we don't currently advertise 8-bit formats
+	}
+
+	for _, tt := range tests {
+		if got := formatBits(tt.format); got != tt.want {
+			t.Errorf("formatBits(%v) = %d, want %d", tt.format, got, tt.want)
+		}
+	}
+}
+
+func TestCapsFromFormats_Empty(t *testing.T) {
+	rate, depth := capsFromFormats(nil)
+	if rate != 0 || depth != 0 {
+		t.Errorf("expected (0, 0) for empty input, got (%d, %d)", rate, depth)
+	}
+}
+
+func TestCapsFromFormats_TakesMaxAcrossEntries(t *testing.T) {
+	// Mixed-rate / mixed-depth list. Rate and depth caps come from
+	// different entries — neither field's max needs to come from the same row.
+	formats := []malgo.DataFormat{
+		{Format: malgo.FormatS16, Channels: 2, SampleRate: 192000},
+		{Format: malgo.FormatS24, Channels: 2, SampleRate: 48000},
+	}
+	rate, depth := capsFromFormats(formats)
+	if rate != 192000 {
+		t.Errorf("expected max rate 192000, got %d", rate)
+	}
+	if depth != 24 {
+		t.Errorf("expected max depth 24, got %d", depth)
+	}
+}
+
+func TestCapsFromFormats_IgnoresUnknownFormat(t *testing.T) {
+	// An entry with an unknown FormatType must not contribute to either cap,
+	// even if its SampleRate is huge — we'd be advertising a rate we couldn't
+	// actually drive in any of our supported formats.
+	formats := []malgo.DataFormat{
+		{Format: malgo.FormatUnknown, Channels: 2, SampleRate: 384000},
+		{Format: malgo.FormatS16, Channels: 2, SampleRate: 48000},
+	}
+	rate, depth := capsFromFormats(formats)
+	if rate != 48000 {
+		t.Errorf("expected unknown-format entry to be ignored; got rate %d", rate)
+	}
+	if depth != 16 {
+		t.Errorf("expected depth 16, got %d", depth)
+	}
+}
+
+func TestCapsFromFormats_AllUnknownReturnsZero(t *testing.T) {
+	formats := []malgo.DataFormat{
+		{Format: malgo.FormatUnknown, Channels: 2, SampleRate: 192000},
+		{Format: malgo.FormatU8, Channels: 2, SampleRate: 48000},
+	}
+	rate, depth := capsFromFormats(formats)
+	if rate != 0 || depth != 0 {
+		t.Errorf("expected (0, 0) when no entry has a known bit depth, got (%d, %d)", rate, depth)
+	}
+}
+
+func TestCapsFromFormats_F32MapsToThirtyTwo(t *testing.T) {
+	formats := []malgo.DataFormat{
+		{Format: malgo.FormatF32, Channels: 2, SampleRate: 96000},
+	}
+	_, depth := capsFromFormats(formats)
+	if depth != 32 {
+		t.Errorf("FormatF32 should map to 32 bits; got %d", depth)
+	}
+}

--- a/pkg/sendspin/config.go
+++ b/pkg/sendspin/config.go
@@ -39,6 +39,8 @@ type PlayerConfigFile struct {
 	BufferCapacity *int   `yaml:"buffer_capacity,omitempty"`
 	ClientID       string `yaml:"client_id,omitempty"`
 	AudioDevice    string `yaml:"audio_device,omitempty"`
+	MaxSampleRate  *int   `yaml:"max_sample_rate,omitempty"`
+	MaxBitDepth    *int   `yaml:"max_bit_depth,omitempty"`
 }
 
 // loadYAMLConfig walks searchPaths, and for the first one that exists opens
@@ -206,6 +208,12 @@ func (c *PlayerConfigFile) AsStringMap() map[string]string {
 	}
 	if c.AudioDevice != "" {
 		m["audio_device"] = c.AudioDevice
+	}
+	if c.MaxSampleRate != nil {
+		m["max_sample_rate"] = strconv.Itoa(*c.MaxSampleRate)
+	}
+	if c.MaxBitDepth != nil {
+		m["max_bit_depth"] = strconv.Itoa(*c.MaxBitDepth)
 	}
 	return m
 }

--- a/pkg/sendspin/config_test.go
+++ b/pkg/sendspin/config_test.go
@@ -227,11 +227,11 @@ func TestApplyEnvAndFile_InvalidEnvReturnsError(t *testing.T) {
 	}
 }
 
-// TestApplyEnvAndFile_MaxSampleRateAndBitDepth covers the new output-capability
-// override keys end-to-end: file value flows through, env beats file, CLI beats
-// env. Same precedence as every other key — but worth a dedicated test because
-// these are the user's escape hatch when the auto-probe is wrong, and a silent
-// bug here means users can't override.
+// TestApplyEnvAndFile_MaxSampleRateAndBitDepth covers the output-capability
+// override keys end-to-end: file value flows through, env beats file, CLI
+// beats env. Same precedence as every other key, but worth a dedicated test:
+// these are the operator's escape hatch when the auto-probe is wrong, and a
+// silent bug here means users can't override.
 func TestApplyEnvAndFile_MaxSampleRateAndBitDepth(t *testing.T) {
 	t.Run("file fills both", func(t *testing.T) {
 		fs, _, ints, _ := newTestFlagSet()

--- a/pkg/sendspin/config_test.go
+++ b/pkg/sendspin/config_test.go
@@ -118,12 +118,12 @@ func newTestFlagSet() (*flag.FlagSet, map[string]*string, map[string]*int, map[s
 		"client-id":       fs.String("client-id", "", "client id"),
 	}
 	ints := map[string]*int{
-		"port":             fs.Int("port", 8927, "port"),
-		"buffer-ms":        fs.Int("buffer-ms", 150, "buffer ms"),
-		"static-delay-ms":  fs.Int("static-delay-ms", 0, "static delay"),
-		"buffer-capacity":  fs.Int("buffer-capacity", 1048576, "buffer cap"),
-		"max-sample-rate":  fs.Int("max-sample-rate", 0, "max sample rate"),
-		"max-bit-depth":    fs.Int("max-bit-depth", 0, "max bit depth"),
+		"port":            fs.Int("port", 8927, "port"),
+		"buffer-ms":       fs.Int("buffer-ms", 150, "buffer ms"),
+		"static-delay-ms": fs.Int("static-delay-ms", 0, "static delay"),
+		"buffer-capacity": fs.Int("buffer-capacity", 1048576, "buffer cap"),
+		"max-sample-rate": fs.Int("max-sample-rate", 0, "max sample rate"),
+		"max-bit-depth":   fs.Int("max-bit-depth", 0, "max bit depth"),
 	}
 	bools := map[string]*bool{
 		"no-tui":       fs.Bool("no-tui", false, "no tui"),

--- a/pkg/sendspin/config_test.go
+++ b/pkg/sendspin/config_test.go
@@ -118,10 +118,12 @@ func newTestFlagSet() (*flag.FlagSet, map[string]*string, map[string]*int, map[s
 		"client-id":       fs.String("client-id", "", "client id"),
 	}
 	ints := map[string]*int{
-		"port":            fs.Int("port", 8927, "port"),
-		"buffer-ms":       fs.Int("buffer-ms", 150, "buffer ms"),
-		"static-delay-ms": fs.Int("static-delay-ms", 0, "static delay"),
-		"buffer-capacity": fs.Int("buffer-capacity", 1048576, "buffer cap"),
+		"port":             fs.Int("port", 8927, "port"),
+		"buffer-ms":        fs.Int("buffer-ms", 150, "buffer ms"),
+		"static-delay-ms":  fs.Int("static-delay-ms", 0, "static delay"),
+		"buffer-capacity":  fs.Int("buffer-capacity", 1048576, "buffer cap"),
+		"max-sample-rate":  fs.Int("max-sample-rate", 0, "max sample rate"),
+		"max-bit-depth":    fs.Int("max-bit-depth", 0, "max bit depth"),
 	}
 	bools := map[string]*bool{
 		"no-tui":       fs.Bool("no-tui", false, "no tui"),
@@ -222,6 +224,93 @@ func TestApplyEnvAndFile_InvalidEnvReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "port") {
 		t.Errorf("error should mention the offending flag: %v", err)
+	}
+}
+
+// TestApplyEnvAndFile_MaxSampleRateAndBitDepth covers the new output-capability
+// override keys end-to-end: file value flows through, env beats file, CLI beats
+// env. Same precedence as every other key — but worth a dedicated test because
+// these are the user's escape hatch when the auto-probe is wrong, and a silent
+// bug here means users can't override.
+func TestApplyEnvAndFile_MaxSampleRateAndBitDepth(t *testing.T) {
+	t.Run("file fills both", func(t *testing.T) {
+		fs, _, ints, _ := newTestFlagSet()
+		if err := fs.Parse(nil); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		rate, depth := 48000, 16
+		cfg := &PlayerConfigFile{MaxSampleRate: &rate, MaxBitDepth: &depth}
+		if err := ApplyEnvAndFile(fs, map[string]bool{}, PlayerEnvPrefix, cfg.AsStringMap()); err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		if *ints["max-sample-rate"] != 48000 {
+			t.Errorf("max-sample-rate = %d, want 48000", *ints["max-sample-rate"])
+		}
+		if *ints["max-bit-depth"] != 16 {
+			t.Errorf("max-bit-depth = %d, want 16", *ints["max-bit-depth"])
+		}
+	})
+
+	t.Run("env beats file", func(t *testing.T) {
+		fs, _, ints, _ := newTestFlagSet()
+		if err := fs.Parse(nil); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		t.Setenv("SENDSPIN_PLAYER_MAX_SAMPLE_RATE", "96000")
+		rate := 48000
+		cfg := &PlayerConfigFile{MaxSampleRate: &rate}
+		if err := ApplyEnvAndFile(fs, map[string]bool{}, PlayerEnvPrefix, cfg.AsStringMap()); err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		if *ints["max-sample-rate"] != 96000 {
+			t.Errorf("env should beat file: max-sample-rate = %d", *ints["max-sample-rate"])
+		}
+	})
+
+	t.Run("CLI beats env and file", func(t *testing.T) {
+		fs, _, ints, _ := newTestFlagSet()
+		if err := fs.Parse([]string{"-max-sample-rate", "192000"}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		setByUser := map[string]bool{"max-sample-rate": true}
+		t.Setenv("SENDSPIN_PLAYER_MAX_SAMPLE_RATE", "96000")
+		rate := 48000
+		cfg := &PlayerConfigFile{MaxSampleRate: &rate}
+		if err := ApplyEnvAndFile(fs, setByUser, PlayerEnvPrefix, cfg.AsStringMap()); err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		if *ints["max-sample-rate"] != 192000 {
+			t.Errorf("CLI should win: max-sample-rate = %d", *ints["max-sample-rate"])
+		}
+	})
+}
+
+// TestPlayerConfigFile_AsStringMap_OmitsUnsetCaps guards a subtle precedence
+// bug: if AsStringMap emitted "0" for an unset *int field, that "0" would
+// flow through ApplyEnvAndFile as an explicit value and clobber any flag
+// default, env override, or CLI flag the user actually set. The pointer-vs-
+// nil distinction in the YAML field is the only thing keeping the precedence
+// chain honest, and AsStringMap must respect it.
+func TestPlayerConfigFile_AsStringMap_OmitsUnsetCaps(t *testing.T) {
+	cfg := &PlayerConfigFile{} // all fields nil/empty
+	m := cfg.AsStringMap()
+	if _, ok := m["max_sample_rate"]; ok {
+		t.Error("max_sample_rate should be absent when not set in YAML")
+	}
+	if _, ok := m["max_bit_depth"]; ok {
+		t.Error("max_bit_depth should be absent when not set in YAML")
+	}
+
+	// Set explicitly to zero — the user genuinely wants 0, which means
+	// "no cap, auto-probe". Pointer is non-nil so the key DOES appear.
+	zero := 0
+	cfg = &PlayerConfigFile{MaxSampleRate: &zero, MaxBitDepth: &zero}
+	m = cfg.AsStringMap()
+	if got := m["max_sample_rate"]; got != "0" {
+		t.Errorf("explicit zero should round-trip; got %q", got)
+	}
+	if got := m["max_bit_depth"]; got != "0" {
+		t.Errorf("explicit zero should round-trip; got %q", got)
 	}
 }
 

--- a/pkg/sendspin/player.go
+++ b/pkg/sendspin/player.go
@@ -72,6 +72,19 @@ type PlayerConfig struct {
 	// Open fails loudly if a non-empty name doesn't match an available device.
 	AudioDevice string
 
+	// MaxSampleRate caps the highest SampleRate advertised to the server.
+	// 0 = auto-probe the AudioDevice for its native ceiling on first Connect.
+	// Setting either MaxSampleRate or MaxBitDepth to a non-zero value disables
+	// auto-probe entirely (replace semantics — explicit user choice wins, even
+	// if it raises the cap above what the probe would have found). Use the
+	// override when the auto-probe is wrong, as on Pi3 where ALSA reports the
+	// bcm2835 onboard headphones accept 192k/24 but the hardware can't
+	// actually drain it.
+	MaxSampleRate int
+	// MaxBitDepth caps the highest BitDepth advertised to the server.
+	// 0 = auto-probe. See MaxSampleRate for override semantics.
+	MaxBitDepth int
+
 	DeviceInfo DeviceInfo
 
 	OnMetadata func(Metadata)
@@ -137,12 +150,13 @@ type PlayerStats struct {
 // Player provides high-level audio playback from Sendspin servers.
 // It composes a Receiver (connect/sync/decode/schedule) with an audio output backend.
 type Player struct {
-	config   PlayerConfig
-	receiver *Receiver
-	output   output.Output
-	state    PlayerState
-	ctx      context.Context
-	cancel   context.CancelFunc
+	config       PlayerConfig
+	receiver     *Receiver
+	output       output.Output
+	state        PlayerState
+	ctx          context.Context
+	cancel       context.CancelFunc
+	capsResolved bool // probe runs once at first Connect; reconnects reuse the cached caps
 }
 
 func NewPlayer(config PlayerConfig) (*Player, error) {
@@ -203,6 +217,7 @@ func (p *Player) Connect() error {
 }
 
 func (p *Player) buildReceiver(addr string) (*Receiver, error) {
+	p.ensureCapsResolved()
 	return NewReceiver(ReceiverConfig{
 		ServerAddr:     addr,
 		PlayerName:     p.config.PlayerName,
@@ -210,6 +225,8 @@ func (p *Player) buildReceiver(addr string) (*Receiver, error) {
 		StaticDelayMs:  p.config.StaticDelayMs,
 		PreferredCodec: p.config.PreferredCodec,
 		BufferCapacity: p.config.BufferCapacity,
+		MaxSampleRate:  p.config.MaxSampleRate,
+		MaxBitDepth:    p.config.MaxBitDepth,
 		ClientID:       p.config.ClientID,
 		DeviceInfo:     p.config.DeviceInfo,
 		DecoderFactory: p.config.DecoderFactory,
@@ -218,6 +235,48 @@ func (p *Player) buildReceiver(addr string) (*Receiver, error) {
 		OnStreamEnd:    p.onStreamEnd,
 		OnError:        p.config.OnError,
 	})
+}
+
+// ensureCapsResolved decides MaxSampleRate / MaxBitDepth on first call and
+// caches the decision so subsequent reconnects reuse the same caps without
+// re-probing miniaudio.
+//
+// Replace semantics: any explicit non-zero override on either field skips
+// the probe entirely, so users who want to raise the cap above the device's
+// reported ceiling can. Probe failures are logged and treated as "no cap" —
+// we'd rather advertise too much (and let the device-stall path complain)
+// than refuse to start when the malgo backend is unavailable (e.g. CI).
+//
+// When config.Output is non-nil, the caller has substituted their own output
+// (test doubles, custom backends), and probing the malgo default device
+// wouldn't tell us anything useful — skip in that case too.
+func (p *Player) ensureCapsResolved() {
+	if p.capsResolved {
+		return
+	}
+	p.capsResolved = true
+
+	if p.config.MaxSampleRate != 0 || p.config.MaxBitDepth != 0 {
+		log.Printf("Output capability cap: %d Hz / %d-bit (source: config)",
+			p.config.MaxSampleRate, p.config.MaxBitDepth)
+		return
+	}
+	if p.config.Output != nil {
+		return
+	}
+
+	rate, depth, err := output.QueryDeviceCapabilities(p.config.AudioDevice)
+	if err != nil {
+		log.Printf("Output capability probe failed (%v); advertising full format list", err)
+		return
+	}
+	if rate == 0 && depth == 0 {
+		log.Printf("Output capability probe returned no native formats; advertising full format list")
+		return
+	}
+	p.config.MaxSampleRate = rate
+	p.config.MaxBitDepth = depth
+	log.Printf("Output capability cap: %d Hz / %d-bit (source: probe)", rate, depth)
 }
 
 // runReconnectLoop supervises the active receiver and rebuilds it with

--- a/pkg/sendspin/player_test.go
+++ b/pkg/sendspin/player_test.go
@@ -196,11 +196,11 @@ func TestPlayer_StatusBeforeConnect(t *testing.T) {
 	}
 }
 
-// TestPlayer_EnsureCapsResolved_ExplicitOverrideSkipsProbe asserts the
-// "replace" semantics from the design discussion: if the user has set either
-// MaxSampleRate or MaxBitDepth, ensureCapsResolved must NOT overwrite the
-// other field via probe — explicit user choice wins entirely, even when
-// only one of the two fields is non-zero.
+// TestPlayer_EnsureCapsResolved_ExplicitOverrideSkipsProbe asserts replace
+// semantics: if the user has set either MaxSampleRate or MaxBitDepth,
+// ensureCapsResolved must NOT overwrite the other field via probe.
+// Explicit user choice wins entirely, even when only one of the two
+// fields is non-zero.
 func TestPlayer_EnsureCapsResolved_ExplicitOverrideSkipsProbe(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/sendspin/player_test.go
+++ b/pkg/sendspin/player_test.go
@@ -195,3 +195,65 @@ func TestPlayer_StatusBeforeConnect(t *testing.T) {
 		t.Errorf("expected state idle, got %s", status.State)
 	}
 }
+
+// TestPlayer_EnsureCapsResolved_ExplicitOverrideSkipsProbe asserts the
+// "replace" semantics from the design discussion: if the user has set either
+// MaxSampleRate or MaxBitDepth, ensureCapsResolved must NOT overwrite the
+// other field via probe — explicit user choice wins entirely, even when
+// only one of the two fields is non-zero.
+func TestPlayer_EnsureCapsResolved_ExplicitOverrideSkipsProbe(t *testing.T) {
+	tests := []struct {
+		name      string
+		rate      int
+		depth     int
+		wantRate  int
+		wantDepth int
+	}{
+		{"both set", 48000, 16, 48000, 16},
+		{"rate only", 96000, 0, 96000, 0},
+		{"depth only", 0, 16, 0, 16},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			player, _ := NewPlayer(PlayerConfig{
+				ServerAddr:    "localhost:8927",
+				PlayerName:    "Test",
+				MaxSampleRate: tt.rate,
+				MaxBitDepth:   tt.depth,
+			})
+			player.ensureCapsResolved()
+			if player.config.MaxSampleRate != tt.wantRate {
+				t.Errorf("MaxSampleRate = %d, want %d (probe must not run)",
+					player.config.MaxSampleRate, tt.wantRate)
+			}
+			if player.config.MaxBitDepth != tt.wantDepth {
+				t.Errorf("MaxBitDepth = %d, want %d (probe must not run)",
+					player.config.MaxBitDepth, tt.wantDepth)
+			}
+		})
+	}
+}
+
+// TestPlayer_EnsureCapsResolved_RunsOnce guards reconnect behavior: the
+// caps are probed at most once. The cached flag is set even on probe-skip
+// paths so subsequent reconnects don't re-probe miniaudio either.
+func TestPlayer_EnsureCapsResolved_RunsOnce(t *testing.T) {
+	player, _ := NewPlayer(PlayerConfig{
+		ServerAddr:    "localhost:8927",
+		PlayerName:    "Test",
+		MaxSampleRate: 48000, // user-set, so no probe
+	})
+	player.ensureCapsResolved()
+	if !player.capsResolved {
+		t.Error("capsResolved should be true after first call")
+	}
+	// Mutating MaxSampleRate after first call must not be re-resolved by a
+	// second invocation — proves the early return on capsResolved fires.
+	player.config.MaxSampleRate = 99999
+	player.ensureCapsResolved()
+	if player.config.MaxSampleRate != 99999 {
+		t.Errorf("second call should be no-op; got MaxSampleRate=%d",
+			player.config.MaxSampleRate)
+	}
+}

--- a/pkg/sendspin/receiver.go
+++ b/pkg/sendspin/receiver.go
@@ -530,13 +530,14 @@ func buildSupportedFormats(preferredCodec string, maxSampleRate, maxBitDepth int
 }
 
 // logAdvertisedFormats writes one summary line describing what the player
-// is about to send in client/hello. Future bug reports include this line so
-// "what did the player say it could do?" stops being a question we have to
-// reverse-engineer from server logs.
+// is about to send in client/hello — codec set, max rate, max depth, and
+// the cap that produced the list. Operators reading the log can answer
+// "what did this player say it could do?" without having to inspect server
+// traces.
 //
-// Empty list is logged loudly as a warning because the resulting handshake
-// will produce only a generic negotiation failure — surfacing the cause at
-// the player keeps the user out of the wrong rabbit hole.
+// Empty list goes out as a WARNING: the resulting handshake produces only
+// a generic negotiation failure, so surfacing the cause player-side saves
+// users from chasing the same symptom on the server.
 func logAdvertisedFormats(formats []protocol.AudioFormat, maxSampleRate, maxBitDepth int) {
 	capDesc := "no cap"
 	if maxSampleRate > 0 || maxBitDepth > 0 {

--- a/pkg/sendspin/receiver.go
+++ b/pkg/sendspin/receiver.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/Sendspin/sendspin-go/pkg/audio"
@@ -22,6 +23,14 @@ type ReceiverConfig struct {
 	StaticDelayMs  int    // optional static latency compensation (ms) applied to every scheduled play time
 	PreferredCodec string // "pcm", "opus", or "flac" — reorders the advertised format list so the server picks this codec first
 	BufferCapacity int    // buffer_capacity in bytes advertised to the server (default: 1048576 = 1MB)
+	// MaxSampleRate caps the highest SampleRate advertised to the server.
+	// 0 = no cap. Set this when the eventual audio output device cannot
+	// sustain higher rates (e.g. Pi3 onboard bcm2835 headphones can't
+	// actually drain 192k even though ALSA reports it accepts the format).
+	MaxSampleRate int
+	// MaxBitDepth caps the highest BitDepth advertised to the server.
+	// 0 = no cap. See MaxSampleRate for the motivating case.
+	MaxBitDepth int
 	// ClientID is the already-resolved client_id to advertise in client/hello.
 	// Required — callers should compute this once at startup (typically via
 	// ResolveClientID) and thread the same value through reconnects.
@@ -145,6 +154,9 @@ func (r *Receiver) Connect() error {
 		return fmt.Errorf("ReceiverConfig.ClientID is required (resolve via sendspin.ResolveClientID)")
 	}
 
+	supportedFormats := buildSupportedFormats(r.config.PreferredCodec, r.config.MaxSampleRate, r.config.MaxBitDepth)
+	logAdvertisedFormats(supportedFormats, r.config.MaxSampleRate, r.config.MaxBitDepth)
+
 	clientConfig := protocol.Config{
 		ServerAddr: r.serverAddr,
 		ClientID:   r.config.ClientID,
@@ -156,7 +168,7 @@ func (r *Receiver) Connect() error {
 			SoftwareVersion: r.config.DeviceInfo.SoftwareVersion,
 		},
 		PlayerV1Support: protocol.PlayerV1Support{
-			SupportedFormats:  buildSupportedFormats(r.config.PreferredCodec),
+			SupportedFormats:  supportedFormats,
 			BufferCapacity:    r.config.BufferCapacity,
 			SupportedCommands: []string{"volume", "mute"},
 		},
@@ -463,10 +475,17 @@ func (r *Receiver) clockSyncLoop() {
 	}
 }
 
-// buildSupportedFormats returns the player's advertised format list.
-// If preferredCodec is set, formats matching that codec are moved to
-// the front so the server is more likely to select them.
-func buildSupportedFormats(preferredCodec string) []protocol.AudioFormat {
+// buildSupportedFormats returns the player's advertised format list,
+// optionally filtered by maxSampleRate / maxBitDepth (0 = no cap) and
+// reordered so preferredCodec entries come first when set.
+//
+// Filter happens before reorder, so the surviving preferred-codec entries
+// stay grouped at the head. Returns an empty slice when the caps exclude
+// every format — callers can detect that and fail loudly. We do NOT
+// fabricate a fallback entry: if the user asks for caps no format can
+// satisfy, the honest response is empty, and the resulting handshake
+// failure is the right user-visible signal.
+func buildSupportedFormats(preferredCodec string, maxSampleRate, maxBitDepth int) []protocol.AudioFormat {
 	allFormats := []protocol.AudioFormat{
 		{Codec: "pcm", Channels: 2, SampleRate: 192000, BitDepth: 24},
 		{Codec: "pcm", Channels: 2, SampleRate: 176400, BitDepth: 24},
@@ -481,14 +500,26 @@ func buildSupportedFormats(preferredCodec string) []protocol.AudioFormat {
 		{Codec: "opus", Channels: 2, SampleRate: 48000, BitDepth: 16},
 	}
 
-	if preferredCodec == "" {
-		return allFormats
+	filtered := make([]protocol.AudioFormat, 0, len(allFormats))
+	for _, f := range allFormats {
+		if maxSampleRate > 0 && f.SampleRate > maxSampleRate {
+			continue
+		}
+		if maxBitDepth > 0 && f.BitDepth > maxBitDepth {
+			continue
+		}
+		filtered = append(filtered, f)
 	}
 
-	// Move preferred codec formats to the front.
-	preferred := make([]protocol.AudioFormat, 0, len(allFormats))
-	rest := make([]protocol.AudioFormat, 0, len(allFormats))
-	for _, f := range allFormats {
+	if preferredCodec == "" {
+		return filtered
+	}
+
+	// Move preferred codec formats to the front while preserving original
+	// order within each group.
+	preferred := make([]protocol.AudioFormat, 0, len(filtered))
+	rest := make([]protocol.AudioFormat, 0, len(filtered))
+	for _, f := range filtered {
 		if f.Codec == preferredCodec {
 			preferred = append(preferred, f)
 		} else {
@@ -496,6 +527,42 @@ func buildSupportedFormats(preferredCodec string) []protocol.AudioFormat {
 		}
 	}
 	return append(preferred, rest...)
+}
+
+// logAdvertisedFormats writes one summary line describing what the player
+// is about to send in client/hello. Future bug reports include this line so
+// "what did the player say it could do?" stops being a question we have to
+// reverse-engineer from server logs.
+//
+// Empty list is logged loudly as a warning because the resulting handshake
+// will produce only a generic negotiation failure — surfacing the cause at
+// the player keeps the user out of the wrong rabbit hole.
+func logAdvertisedFormats(formats []protocol.AudioFormat, maxSampleRate, maxBitDepth int) {
+	capDesc := "no cap"
+	if maxSampleRate > 0 || maxBitDepth > 0 {
+		capDesc = fmt.Sprintf("cap %dHz/%d-bit", maxSampleRate, maxBitDepth)
+	}
+	if len(formats) == 0 {
+		log.Printf("WARNING: advertising 0 supported formats (%s) — handshake will fail; relax the caps", capDesc)
+		return
+	}
+	codecsSeen := make(map[string]struct{}, 3)
+	codecsOrdered := make([]string, 0, 3)
+	var maxRate, maxDepth int
+	for _, f := range formats {
+		if _, ok := codecsSeen[f.Codec]; !ok {
+			codecsSeen[f.Codec] = struct{}{}
+			codecsOrdered = append(codecsOrdered, f.Codec)
+		}
+		if f.SampleRate > maxRate {
+			maxRate = f.SampleRate
+		}
+		if f.BitDepth > maxDepth {
+			maxDepth = f.BitDepth
+		}
+	}
+	log.Printf("Advertising %d supported formats: codecs=[%s] max=%dHz/%d-bit (%s)",
+		len(formats), strings.Join(codecsOrdered, ","), maxRate, maxDepth, capDesc)
 }
 
 func (r *Receiver) notifyError(err error) {

--- a/pkg/sendspin/receiver_test.go
+++ b/pkg/sendspin/receiver_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Sendspin/sendspin-go/pkg/audio"
 	"github.com/Sendspin/sendspin-go/pkg/audio/decode"
+	"github.com/Sendspin/sendspin-go/pkg/protocol"
 )
 
 func TestNewReceiver_Defaults(t *testing.T) {
@@ -168,5 +169,114 @@ func TestReceiver_CustomDecoderFactory(t *testing.T) {
 	}
 	if factoryCalled {
 		t.Error("factory should not be called before connect")
+	}
+}
+
+// maxRateAndDepth scans formats and returns the largest sample rate and bit
+// depth present. Test helper: lets assertions describe the cap by intent
+// ("nothing above 48k/16") rather than counting list entries.
+func maxRateAndDepth(formats []protocol.AudioFormat) (int, int) {
+	var maxRate, maxDepth int
+	for _, f := range formats {
+		if f.SampleRate > maxRate {
+			maxRate = f.SampleRate
+		}
+		if f.BitDepth > maxDepth {
+			maxDepth = f.BitDepth
+		}
+	}
+	return maxRate, maxDepth
+}
+
+func TestBuildSupportedFormats_NoCaps(t *testing.T) {
+	got := buildSupportedFormats("", 0, 0)
+	if len(got) == 0 {
+		t.Fatal("expected non-empty format list with no caps")
+	}
+	maxRate, maxDepth := maxRateAndDepth(got)
+	if maxRate != 192000 {
+		t.Errorf("expected max rate 192000 with no caps, got %d", maxRate)
+	}
+	if maxDepth != 24 {
+		t.Errorf("expected max depth 24 with no caps, got %d", maxDepth)
+	}
+}
+
+func TestBuildSupportedFormats_RateCap(t *testing.T) {
+	got := buildSupportedFormats("", 48000, 0)
+	if len(got) == 0 {
+		t.Fatal("expected non-empty list with 48000Hz cap")
+	}
+	for _, f := range got {
+		if f.SampleRate > 48000 {
+			t.Errorf("expected no rate > 48000, got %s @ %dHz", f.Codec, f.SampleRate)
+		}
+	}
+	// Boundary: 48000Hz formats must survive.
+	hasFortyEight := false
+	for _, f := range got {
+		if f.SampleRate == 48000 {
+			hasFortyEight = true
+			break
+		}
+	}
+	if !hasFortyEight {
+		t.Error("expected at least one 48000Hz format to survive the cap")
+	}
+}
+
+func TestBuildSupportedFormats_BitDepthCap(t *testing.T) {
+	got := buildSupportedFormats("", 0, 16)
+	if len(got) == 0 {
+		t.Fatal("expected non-empty list with 16-bit cap")
+	}
+	for _, f := range got {
+		if f.BitDepth > 16 {
+			t.Errorf("expected no depth > 16, got %s @ %d-bit", f.Codec, f.BitDepth)
+		}
+	}
+}
+
+func TestBuildSupportedFormats_BothCaps(t *testing.T) {
+	got := buildSupportedFormats("", 48000, 16)
+	if len(got) == 0 {
+		t.Fatal("expected non-empty list with 48k/16 caps")
+	}
+	for _, f := range got {
+		if f.SampleRate > 48000 || f.BitDepth > 16 {
+			t.Errorf("expected no entries beyond 48000Hz/16-bit, got %s @ %dHz/%d-bit",
+				f.Codec, f.SampleRate, f.BitDepth)
+		}
+	}
+}
+
+func TestBuildSupportedFormats_PreferredCodecAfterFilter(t *testing.T) {
+	// Filter eliminates high-res FLAC; the survivor should still be ordered
+	// with FLAC at the front when preferredCodec="flac".
+	got := buildSupportedFormats("flac", 48000, 24)
+	if len(got) == 0 {
+		t.Fatal("expected non-empty list")
+	}
+	if got[0].Codec != "flac" {
+		t.Errorf("expected preferred codec at front, got %s", got[0].Codec)
+	}
+}
+
+func TestBuildSupportedFormats_CapsAtExactBoundary(t *testing.T) {
+	// maxSampleRate=192000, maxBitDepth=24 should keep everything.
+	full := buildSupportedFormats("", 0, 0)
+	bounded := buildSupportedFormats("", 192000, 24)
+	if len(bounded) != len(full) {
+		t.Errorf("boundary cap should keep all formats: full=%d bounded=%d", len(full), len(bounded))
+	}
+}
+
+func TestBuildSupportedFormats_AggressiveCapEmpty(t *testing.T) {
+	// User asks for ≤ 8000Hz / ≤ 8-bit. Nothing in our list matches; we
+	// honestly return empty rather than fabricating a fallback. The handshake
+	// will fail, which is the right user-visible signal that the cap is wrong.
+	got := buildSupportedFormats("", 8000, 8)
+	if len(got) != 0 {
+		t.Errorf("expected empty list for impossible caps, got %d entries", len(got))
 	}
 }


### PR DESCRIPTION
## Summary

- **Closes #96.** Player now caps the codec/rate/depth list it advertises in `client/hello` based on what the local output device can actually do, instead of unconditionally offering `pcm/192k/24` to every server. Auto-probes via miniaudio on first connect; replaceable via `--max-sample-rate` / `--max-bit-depth` (CLI), `max_sample_rate` / `max_bit_depth` (YAML), or `SENDSPIN_PLAYER_MAX_*` (env).
- **Fixes silent version stamping.** `internal/version.Version` is now a `var`, so the release workflow's `-ldflags -X` actually patches it. Pre-1.6.3 every release binary reported the hardcoded default — which is what made #96 confusing in the first place (pantherale0's v1.6.2 archive contained a binary that reported `1.6.0`).
- **Adds a handshake diagnostic.** Receiver logs one summary line at handshake time — `Advertising N supported formats: codecs=[...] max=XHz/Y-bit (cap …)` — so the next bug report doesn't require reverse-engineering the offer from server traces.

## Architecture

- `pkg/sendspin.Receiver.Config` gains `MaxSampleRate` / `MaxBitDepth` (`0` = no cap). `buildSupportedFormats` filters its static 11-entry list by them; preferred-codec reordering still applies after the filter. Empty result is emitted honestly with a `WARNING:` log — no fabricated fallback.
- `pkg/audio/output.QueryDeviceCapabilities(deviceName)` opens a malgo context, looks up the named device via the existing `matchDevice` resolver, and reads `ctx.DeviceInfo`'s `nativeDataFormats[]` without `InitDevice`. The pure `capsFromFormats` helper is split out so the interesting logic gets unit tests without an audio backend in CI.
- `pkg/sendspin.Player.buildReceiver` lazily probes once on first connect and caches via `capsResolved`; reconnects reuse the cached cap. **Replace semantics**: any explicit non-zero override on either field skips the probe entirely so operators who want to raise the cap above the device's reported ceiling can. Probe failures degrade to "no cap" with a log line — better to advertise too much than refuse to start when malgo is unavailable (CI, custom `Output` overrides).

## Why the override is non-negotiable

`QueryDeviceCapabilities` reports what miniaudio's backend claims. On Linux/ALSA that can be optimistic — bcm2835 will accept `192k/24` at the ALSA layer through software resampling, then fail to drain it at the hardware layer (the original #96 symptom: `ring buffer stalled, no drain progress`). The auto-probe handles the easy 95% (USB DACs that report honest ceilings) and the explicit override is the escape hatch for the rest.

For the Pi3 case specifically, the workaround once this lands is one config line:

```yaml
# ~/.config/sendspin/player.yaml
max_sample_rate: 48000
max_bit_depth: 16
```

## Test plan

- [x] `go test -race ./...` — green across all 14 packages
- [x] `go vet ./...` — silent
- [x] Manual smoke on Windows: probe found `48000 Hz / 32-bit`, advertised 5/11 formats with correct cap line
- [x] Manual smoke: CLI override (`-max-sample-rate 48000 -max-bit-depth 16`) → `(source: config)`, 4/11 formats
- [x] Manual smoke: env override (`SENDSPIN_PLAYER_MAX_SAMPLE_RATE=96000`) → `(source: config)`, 8/11 formats
- [x] Manual smoke: ldflags injection produced `version v1.6.3-test`
- [x] CI lint + conformance suite (couldn't run locally on Windows host — relying on CI to verify wire format unchanged)
- [x] On-device verification on a Pi3 / DietPi against a Music Assistant 192k/24 source: confirm the auto-probe still allows playback at degraded rate, and that explicit `max_sample_rate: 48000` resolves the `ring buffer stalled` loop. **This is the canonical reproduction from #96 — would appreciate @pantherale0 retesting once the v1.6.3 artifact lands.**

## Test coverage added (15 tests)

- 7 `TestBuildSupportedFormats_*` — filter behavior + preferred-codec interaction + boundary + impossible-cap-empty
- 6 `TestCapsFromFormats_*` / `TestFormatBits` — pure probe helpers
- 2 `TestPlayer_EnsureCapsResolved_*` — replace semantics + probe-runs-once
- 2 `TestApplyEnvAndFile_MaxSampleRate*` / `TestPlayerConfigFile_AsStringMap_OmitsUnsetCaps` — config overlay round-trip + pointer-vs-nil precedence guard

## Out of scope (follow-up tickets if interesting)

- Auto-recovery on observed runtime stall (renegotiate at lower rate after N consecutive `ring buffer stalled` errors). Filed mentally as "option (b)" during design — punted in favor of shipping the override now. Worth it only if the override knob turns out to be insufficient in practice.
- The `Co-Authored-By: Claude Opus 4.7` trailer on `eeb8bad` (in v1.6.2) — separate issue, not addressed here.