### PR TITLE
fix(player/malgo): pin period to 20ms and bump malgo to v0.11.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,14 @@ go 1.24.1
 require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
-	github.com/gen2brain/malgo v0.11.21
+	github.com/gen2brain/malgo v0.11.24
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/hajimehoshi/go-mp3 v0.3.4
 	github.com/hashicorp/mdns v1.0.6
 	github.com/mewkiz/flac v1.0.13
 	gopkg.in/hraban/opus.v2 v2.0.0-20230925203106-0188a62cb302
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -40,5 +41,4 @@ require (
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQ
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
-github.com/gen2brain/malgo v0.11.21 h1:qsS4Dh6zhZgmvAW5CtKRxDjQzHbc2NJlBG9eE0tgS8w=
-github.com/gen2brain/malgo v0.11.21/go.mod h1:f9TtuN7DVrXMiV/yIceMeWpvanyVzJQMlBecJFVMxww=
+github.com/gen2brain/malgo v0.11.24 h1:hHcIJVfzWcEDHFdPl5Dl/CUSOjzOleY0zzAV8Kx+imE=
+github.com/gen2brain/malgo v0.11.24/go.mod h1:f9TtuN7DVrXMiV/yIceMeWpvanyVzJQMlBecJFVMxww=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -142,6 +142,7 @@ golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58
 golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d h1:vU5i/LfpvrRCpgM/VPfJLg5KjxD3E+hfT1SH+d9zLwg=
 golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/hraban/opus.v2 v2.0.0-20230925203106-0188a62cb302 h1:xeVptzkP8BuJhoIjNizd2bRHfq9KB9HfOLZu90T04XM=
 gopkg.in/hraban/opus.v2 v2.0.0-20230925203106-0188a62cb302/go.mod h1:/L5E7a21VWl8DeuCPKxQBdVG5cy+L0MRZ08B1wnqt7g=

--- a/pkg/audio/output/malgo.go
+++ b/pkg/audio/output/malgo.go
@@ -261,6 +261,18 @@ func (m *Malgo) Open(sampleRate, channels, bitDepth int) error {
 	deviceConfig.Playback.Channels = uint32(channels)
 	deviceConfig.SampleRate = uint32(sampleRate)
 	deviceConfig.Alsa.NoMMap = 1
+	// Pin the period to 20 ms instead of miniaudio's default low-latency
+	// 10 ms. Several backends (bcm2835 ALSA on Pi, PulseAudio/PipeWire on
+	// some Intel Smart Sound paths — see mackron/miniaudio#877) silently
+	// round the requested 10 ms period to a different internal value and
+	// then stall the audio callback after a few invocations. Asking for
+	// 20 ms lands inside the safer range used by miniaudio's own backend
+	// defaults (see CHANGES.md: PulseAudio default raised to 25 ms in
+	// v0.11.8 to work around PipeWire glitches) and gives the driver
+	// enough headroom that the negotiated period matches what we asked
+	// for. ~20 ms of added pipeline latency is invisible inside Sendspin's
+	// 200+ ms scheduler budget.
+	deviceConfig.PeriodSizeInMilliseconds = 20
 
 	// Resolve the playback device. When m.deviceName is empty, miniaudio's
 	// enumerated default is picked (and logged so the operator knows what
@@ -330,8 +342,8 @@ func (m *Malgo) Open(sampleRate, channels, bitDepth int) error {
 	m.bitDepth = bitDepth
 	m.ready = true
 
-	log.Printf("Audio output initialized: device=%s %dHz/%dch/%d-bit (malgo/%s)",
-		chosenLabel, sampleRate, channels, bitDepth, formatName(format))
+	log.Printf("Audio output initialized: device=%s %dHz/%dch/%d-bit period=%dms (malgo/%s)",
+		chosenLabel, sampleRate, channels, bitDepth, deviceConfig.PeriodSizeInMilliseconds, formatName(format))
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Addresses the bcm2835/Pi3 callback-starvation pattern from #96 at the configuration layer instead of with a runtime watchdog.

## Root cause

[mackron/miniaudio#877](https://github.com/mackron/miniaudio/issues/877) is a near-verbatim match for pantherale0's reproduction in #96: the audio data callback fires a small number of times (1–3 in #877, 4–5 in pantherale0's runs), then ceases entirely while `ma_device_is_started()` continues to report true. The producer keeps writing, the ring fills, the existing stall detector drops samples, and no audio reaches the speaker. A manual `ma_device_stop()`/`ma_device_start()` cycle re-arms callback delivery — which both confirms the failure mode is recoverable at the device layer and rules out application-side bugs.

The root cause in #877 was period-size negotiation. The user explicitly requested `periodSizeInFrames=256`, the backend internally rounded to 768 (`256*3`), and the mismatch wedged the callback. The same class of bug shows up on bcm2835 ALSA where `snd_pcm_hw_params_set_buffer_size_near` can return a fixed value (commonly 32768 frames) regardless of what miniaudio asked for ([Pi forum thread](https://forums.raspberrypi.com/viewtopic.php?t=350524)).

## Why not a watchdog + `Stop()/Start()` recycle

That was the plan I'd been considering — automate the manual recycle pantherale0 demonstrated works. Three reasons against:

1. **It addresses the wrong layer.** The bug lives in period-size negotiation. A recycle masks the symptom but leaves the same negotiation in place — likely to wedge again at the next stop/start.
2. **It risks [mackron/miniaudio#355](https://github.com/mackron/miniaudio/issues/355).** ALSA `ma_device_stop()` is documented to hang under repeated cycles ("main thread waits in `pthread_cond_wait`, audio thread stuck in poll, frequency every 10–100 iterations"). A watchdog firing repeatedly is the exact load pattern that tickles it. The recycle path turns one bug into a worse one.
3. **It's ~150 lines of state-machine code vs ~1 line of config**, with proportionally more test surface and regression risk.

## What this PR does

1. **Pin `deviceConfig.PeriodSizeInMilliseconds = 20`** in `pkg/audio/output/malgo.go`'s `Open()`. miniaudio's default low-latency period is 10 ms — the value reported to misbehave on bcm2835 ALSA, PulseAudio on certain Intel Smart Sound paths, and PipeWire. 20 ms lands inside the safer range miniaudio's own backend defaults use: v0.11.8 raised its PulseAudio default buffer to 25 ms "to work around PipeWire glitches" (per [CHANGES.md](https://github.com/mackron/miniaudio/blob/master/CHANGES.md)). 20 ms of added pipeline latency is invisible inside Sendspin's 200+ ms scheduler buffer.

2. **Bump `gen2brain/malgo` from `v0.11.21` to `v0.11.24`.** v0.11.24 vendors `miniaudio.h v0.11.23`, which carries v0.11.22's ALSA-backend fix: *"Fix a bug where a playback device can fail to start"* (CHANGES.md, 2025-02-24). Distinct from the period-size class of bug but plausibly related; bringing the upstream stack to current is cheap and shrinks the surface area for future "could be fixed upstream" hypotheses.

3. **Log the requested period in `Audio output initialized`.** The line now shows e.g. `48000Hz/2ch/16-bit period=20ms`, so the next bug report shows whether the fix code path was reached. malgo doesn't expose the negotiated period back to Go post-init, so the log shows intent, not the result — sufficient for triage.

## Test plan

- [x] `go build ./...` and `go test -race ./...` — clean across all 12 packages with the bumped malgo on Windows host
- [x] `go vet ./...` — silent
- [ ] CI Lint, Test, four Builds, and Conformance — relying on this PR's CI to validate
- [ ] **On-device confirmation by @pantherale0** on the original #96 reproduction (DietPi/Trixie on Pi3 with bcm2835 onboard headphones). The Windows host can't repro the symptom; #877's evidence is what supports the diagnosis.

## Sources

- [mackron/miniaudio#877](https://github.com/mackron/miniaudio/issues/877) — verbatim symptom match (callback fires N times then stops; period-size config is the fix)
- [mackron/miniaudio#366](https://github.com/mackron/miniaudio/issues/366) — same symptom on ALSA backend
- [mackron/miniaudio#355](https://github.com/mackron/miniaudio/issues/355) — `ma_device_stop()` hang risk that argues against the recycle approach
- [miniaudio CHANGES.md](https://github.com/mackron/miniaudio/blob/master/CHANGES.md) — v0.11.8 default-period tuning and v0.11.22 ALSA fix
- [Raspberry Pi Forums — bcm2835 buffer-size quirks](https://forums.raspberrypi.com/viewtopic.php?t=350524)