### PR TITLE
fix(sync): correct stale default value in test error message

### DIFF
--- a/pkg/sync/clock_test.go
+++ b/pkg/sync/clock_test.go
@@ -160,7 +160,7 @@ func TestNewClockSyncWithConfig(t *testing.T) {
 	errDefault := csDefault.filter.GetError()
 	errScaled := csScaled.filter.GetError()
 	if !(errScaled < errDefault) {
-		t.Errorf("expected scaled (0.25) error < default (1.0); got scaled=%d default=%d",
+		t.Errorf("expected scaled (0.25) error < default (0.5); got scaled=%d default=%d",
 			errScaled, errDefault)
 	}
 }


### PR DESCRIPTION
Cosmetic: `TestNewClockSyncWithConfig`'s error message still said `default (1.0)` after Phase B flipped the default to `0.5`. One-character intent fix; no behavior change.