### PR TITLE
fix(pre-commit): build sendspin-server, drop deleted cmd/test-sync

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
 
       - id: go-build-all
         name: go build all binaries
-        entry: bash -c 'go build -v -o sendspin-player . && go build -v ./cmd/test-sync'
+        entry: bash -c 'go build -v -o sendspin-player . && go build -v -o sendspin-server ./cmd/sendspin-server'
         language: system
         files: \.go$
         pass_filenames: false


### PR DESCRIPTION
`cmd/test-sync` was deleted in commit 577dd0c (v1.2 rip-legacy-cli sweep) but the pre-commit `go-build-all` hook still references it, failing on every commit. Replaces it with `cmd/sendspin-server` (which exists, has no tests, and would otherwise compile-rot silently). Now matches the Makefile's `make` target.