### PR TITLE
fix(conformance): drop redundant symlink that breaks multi-worktree usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,6 @@ conformance:
 		echo "Cloning sendspin-cli (supplies the FLAC test fixture)..."; \
 		git clone --depth 1 https://github.com/Sendspin/sendspin-cli.git ../conformance/repos/sendspin-cli; \
 	fi
-	@ln -sfn "$(CURDIR)" ../conformance/repos/sendspin-go
 	@cd ../conformance && uv sync
 	@cd ../conformance && CONFORMANCE_REPO_SENDSPIN_GO="$(CURDIR)" uv run python scripts/run_all.py \
 		--from sendspin-go \


### PR DESCRIPTION
`make conformance` was failing from any worktree but the primary checkout because `ln -sfn "$(CURDIR)" ../conformance/repos/sendspin-go` collides on a stale junction.

The conformance harness (`paths.py:31-34`) checks the `CONFORMANCE_REPO_SENDSPIN_GO` env var **first**, then falls back to `repos/sendspin-go`. Since the Makefile already passes that env var on the next line, the `ln -sfn` is dead state. Verified 12/12 conformance from a fresh worktree without it.