### PR TITLE
docs(sync): drop misleading (0,1] hint from MaxErrorScale comment

### DIFF
--- a/pkg/sync/timefilter.go
+++ b/pkg/sync/timefilter.go
@@ -48,7 +48,8 @@ type TimeFilterConfig struct {
 	MinSamples uint8
 	// DriftSignificanceThreshold is the SNR threshold for applying drift compensation.
 	DriftSignificanceThreshold float64
-	// MaxErrorScale (0,1] scales max_error before use as the measurement std dev. Spec recommends 0.5.
+	// MaxErrorScale scales max_error before use as the measurement std dev.
+	// Spec recommends 0.5; values <1 indicate max_error overestimates noise.
 	MaxErrorScale float64
 }
 


### PR DESCRIPTION
Field comment said `(0,1]` but `NewTimeFilter` only enforces `<=0` (clamped to 1.0); values `>1` are silently accepted. Upstream C++ also has no upper clamp ([`sendspin_time_filter.h`](https://github.com/Sendspin/time-filter/blob/main/cpp/sendspin_time_filter.h)). Drops the misleading range hint and matches upstream phrasing.