### PR TITLE
fix(sendspin): merge metadata updates with tristate semantics

### DIFF
--- a/pkg/protocol/messages.go
+++ b/pkg/protocol/messages.go
@@ -2,6 +2,8 @@
 // ABOUTME: Defines structs for all message types per the Sendspin spec
 package protocol
 
+import "encoding/json"
+
 // Message is the top-level wrapper for all protocol messages
 type Message struct {
 	Type    string      `json:"type"`
@@ -142,7 +144,12 @@ type ServerStateMessage struct {
 	Controller *ControllerState `json:"controller,omitempty"`
 }
 
-// MetadataState contains track metadata per spec (for metadata role)
+// MetadataState contains track metadata per spec (for metadata role).
+//
+// The wire encoding is tristate: an omitted key means "unchanged, preserve
+// prior value", a JSON null means "explicitly clear", and a value means
+// "set". Receivers must distinguish all three to merge a diff_update onto a
+// running snapshot — see HasField.
 type MetadataState struct {
 	Timestamp   int64          `json:"timestamp"`              // Server clock µs when valid
 	Title       *string        `json:"title,omitempty"`        // Track title
@@ -155,6 +162,56 @@ type MetadataState struct {
 	Progress    *ProgressState `json:"progress,omitempty"`     // Playback progress
 	Repeat      *string        `json:"repeat,omitempty"`       // "off", "one", "all"
 	Shuffle     *bool          `json:"shuffle,omitempty"`      // Shuffle enabled
+
+	// presentKeys records which JSON keys appeared in the incoming message,
+	// so callers can distinguish "field omitted" (preserve prior value)
+	// from "field set to null" (clear prior value). Populated by
+	// UnmarshalJSON; nil for messages constructed in Go directly.
+	presentKeys map[string]struct{}
+}
+
+// HasField reports whether the named JSON key was present in the incoming
+// server/state message. The check is case-sensitive against the wire name
+// (e.g. "artwork_url", not "ArtworkURL"). Returns true for messages
+// constructed in-process via field assignment (not through UnmarshalJSON),
+// so backwards-compatible callers that build a MetadataState directly are
+// treated as if every assigned field were "present".
+func (m *MetadataState) HasField(jsonKey string) bool {
+	if m.presentKeys == nil {
+		return true
+	}
+	_, ok := m.presentKeys[jsonKey]
+	return ok
+}
+
+// UnmarshalJSON decodes a MetadataState while tracking which JSON keys
+// were present. Required to distinguish "omitted" (preserve prior value)
+// from "null" (clear prior value) per the Sendspin metadata diff-update
+// protocol — both decode to a nil pointer otherwise, which loses the
+// signal.
+func (m *MetadataState) UnmarshalJSON(data []byte) error {
+	// First pass: capture key presence.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	// Second pass: decode known fields. The `type alias` indirection is the
+	// standard Go trick to avoid infinite recursion: json.Unmarshal on the
+	// alias bypasses our custom UnmarshalJSON because the alias type does
+	// not inherit methods.
+	type alias MetadataState
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+
+	*m = MetadataState(a)
+	m.presentKeys = make(map[string]struct{}, len(raw))
+	for k := range raw {
+		m.presentKeys[k] = struct{}{}
+	}
+	return nil
 }
 
 // ProgressState contains playback progress info per spec

--- a/pkg/protocol/messages_test.go
+++ b/pkg/protocol/messages_test.go
@@ -168,3 +168,169 @@ func TestStreamStart_PlayerOnlyUnchanged(t *testing.T) {
 		t.Errorf("marshal output = %s, want %s", data, want)
 	}
 }
+
+// TestMetadataState_TristateUnmarshal verifies the wire-protocol contract:
+// an omitted JSON key, an explicit null, and a value must each produce a
+// distinguishable receiver-side signal. The merge layer in
+// pkg/sendspin.Receiver depends on this.
+func TestMetadataState_TristateUnmarshal(t *testing.T) {
+	cases := []struct {
+		name         string
+		json         string
+		wantPtrSet   bool   // is Title pointer non-nil?
+		wantTitle    string // value if non-nil
+		wantHasField bool   // HasField("title")?
+	}{
+		{"omitted", `{"timestamp": 1}`, false, "", false},
+		{"null", `{"timestamp": 1, "title": null}`, false, "", true},
+		{"value", `{"timestamp": 1, "title": "Hello"}`, true, "Hello", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var m MetadataState
+			if err := json.Unmarshal([]byte(tc.json), &m); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if (m.Title != nil) != tc.wantPtrSet {
+				t.Errorf("Title pointer non-nil = %v, want %v", m.Title != nil, tc.wantPtrSet)
+			}
+			if m.Title != nil && *m.Title != tc.wantTitle {
+				t.Errorf("Title value = %q, want %q", *m.Title, tc.wantTitle)
+			}
+			if got := m.HasField("title"); got != tc.wantHasField {
+				t.Errorf("HasField(\"title\") = %v, want %v", got, tc.wantHasField)
+			}
+			// Timestamp must always decode.
+			if m.Timestamp != 1 {
+				t.Errorf("Timestamp = %d, want 1", m.Timestamp)
+			}
+			// HasField("timestamp") should be true in every case
+			// because the wire JSON always carries it here.
+			if !m.HasField("timestamp") {
+				t.Error("HasField(\"timestamp\") = false, want true")
+			}
+		})
+	}
+}
+
+// TestMetadataState_HasFieldInGoConstruction confirms that messages built
+// in process via field assignment (the conformance adapter and any
+// server-side helpers do this) report HasField == true for every field.
+// This is the backwards-compat guarantee callers can rely on.
+func TestMetadataState_HasFieldInGoConstruction(t *testing.T) {
+	title := "T"
+	m := MetadataState{Timestamp: 42, Title: &title}
+	for _, key := range []string{"title", "artist", "album", "progress", "shuffle", "anything"} {
+		if !m.HasField(key) {
+			t.Errorf("HasField(%q) = false on Go-constructed value, want true", key)
+		}
+	}
+}
+
+// TestMetadataState_TristateAcrossAllFields exercises every tristate field
+// at once to make sure the alias-based decoder did not accidentally drop a
+// field type (pointer-to-int, pointer-to-bool, pointer-to-struct).
+func TestMetadataState_TristateAcrossAllFields(t *testing.T) {
+	raw := `{
+		"timestamp": 100,
+		"title": "T",
+		"artist": null,
+		"album": "A",
+		"album_artist": null,
+		"artwork_url": "http://x",
+		"year": 2020,
+		"track": null,
+		"progress": {"track_progress": 1000, "track_duration": 5000, "playback_speed": 1000},
+		"shuffle": true
+	}`
+	var m MetadataState
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Set fields decode to non-nil pointers.
+	if m.Title == nil || *m.Title != "T" {
+		t.Errorf("Title = %v, want pointer to \"T\"", m.Title)
+	}
+	if m.Album == nil || *m.Album != "A" {
+		t.Errorf("Album = %v, want pointer to \"A\"", m.Album)
+	}
+	if m.ArtworkURL == nil || *m.ArtworkURL != "http://x" {
+		t.Errorf("ArtworkURL = %v", m.ArtworkURL)
+	}
+	if m.Year == nil || *m.Year != 2020 {
+		t.Errorf("Year = %v, want pointer to 2020", m.Year)
+	}
+	if m.Shuffle == nil || *m.Shuffle != true {
+		t.Errorf("Shuffle = %v, want pointer to true", m.Shuffle)
+	}
+	if m.Progress == nil {
+		t.Error("Progress = nil, want non-nil")
+	} else if m.Progress.TrackDuration != 5000 {
+		t.Errorf("Progress.TrackDuration = %d, want 5000", m.Progress.TrackDuration)
+	}
+	// Null fields decode to nil pointers but HasField is true.
+	for _, key := range []string{"artist", "album_artist", "track"} {
+		if !m.HasField(key) {
+			t.Errorf("HasField(%q) = false, want true (null is present)", key)
+		}
+	}
+	if m.Artist != nil {
+		t.Errorf("Artist = %v, want nil (null on wire)", m.Artist)
+	}
+	if m.AlbumArtist != nil {
+		t.Errorf("AlbumArtist = %v, want nil (null on wire)", m.AlbumArtist)
+	}
+	if m.Track != nil {
+		t.Errorf("Track = %v, want nil (null on wire)", m.Track)
+	}
+	// Omitted fields: HasField false.
+	if m.HasField("repeat") {
+		t.Error("HasField(\"repeat\") = true, want false (omitted)")
+	}
+	if m.Repeat != nil {
+		t.Errorf("Repeat = %v, want nil (omitted)", m.Repeat)
+	}
+}
+
+// TestMetadataState_RoundTripPreservesValues ensures encoding then
+// decoding a populated MetadataState preserves every value. The wire
+// shape must be unchanged by the new decoder.
+func TestMetadataState_RoundTripPreservesValues(t *testing.T) {
+	title := "Song"
+	artist := "Artist"
+	album := "Album"
+	original := MetadataState{
+		Timestamp: 12345,
+		Title:     &title,
+		Artist:    &artist,
+		Album:     &album,
+		Progress: &ProgressState{
+			TrackProgress: 1000, TrackDuration: 60000, PlaybackSpeed: 1000,
+		},
+	}
+	data, err := json.Marshal(&original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded MetadataState
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.Timestamp != original.Timestamp {
+		t.Errorf("Timestamp = %d, want %d", decoded.Timestamp, original.Timestamp)
+	}
+	if decoded.Title == nil || *decoded.Title != title {
+		t.Errorf("Title = %v", decoded.Title)
+	}
+	if decoded.Progress == nil || decoded.Progress.TrackDuration != 60000 {
+		t.Errorf("Progress = %+v", decoded.Progress)
+	}
+	// Round-trip preserves presence: the original was constructed in Go
+	// (presentKeys nil → HasField always true), then re-marshaled (omitempty
+	// drops nil pointers), then re-decoded (presentKeys captures only the
+	// fields that survived omitempty). HasField must report present for the
+	// fields we set.
+	if !decoded.HasField("title") || !decoded.HasField("progress") {
+		t.Error("decoded.HasField missed a set field after round-trip")
+	}
+}

--- a/pkg/sendspin/player.go
+++ b/pkg/sendspin/player.go
@@ -563,29 +563,6 @@ func (p *Player) notifyError(err error) {
 	}
 }
 
-// Helper functions used by both player.go and receiver.go
-
-func derefString(s *string) string {
-	if s == nil {
-		return ""
-	}
-	return *s
-}
-
-func derefInt(i *int) int {
-	if i == nil {
-		return 0
-	}
-	return *i
-}
-
-func getDurationSeconds(p *protocol.ProgressState) int {
-	if p == nil {
-		return 0
-	}
-	return p.TrackDuration / 1000
-}
-
 func containsRole(roles []string, role string) bool {
 	for _, r := range roles {
 		if r == role {

--- a/pkg/sendspin/receiver.go
+++ b/pkg/sendspin/receiver.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"sort"
 	"strings"
+	stdsync "sync"
 	"time"
 
 	"github.com/Sendspin/sendspin-go/pkg/audio"
@@ -26,6 +28,12 @@ const (
 	timeSyncBurstInterval   = 10 * time.Second
 	timeSyncResponseTimeout = 500 * time.Millisecond
 )
+
+// metadataApplyTickInterval is the cadence at which metadataApplyLoop wakes
+// to drain pending updates whose server timestamp has elapsed. 100 ms is
+// imperceptible for metadata display lag; do not shorten without a real
+// reason.
+const metadataApplyTickInterval = 100 * time.Millisecond
 
 type ReceiverConfig struct {
 	ServerAddr     string
@@ -48,10 +56,17 @@ type ReceiverConfig struct {
 	ClientID       string
 	DeviceInfo     DeviceInfo
 	DecoderFactory func(audio.Format) (decode.Decoder, error)
-	OnMetadata     func(Metadata)
-	OnStreamStart  func(audio.Format)
-	OnStreamEnd    func()
-	OnError        func(error)
+	// OnMetadata is invoked after each server metadata update is merged
+	// onto the running snapshot. It may be called from either the
+	// server-state reader goroutine (immediate updates) or the metadata
+	// apply-loop goroutine (timestamp-deferred updates), and is invoked
+	// while an internal mutex is held — callbacks must not block on
+	// other Receiver methods. Implementations should serialize their
+	// own state if needed.
+	OnMetadata    func(Metadata)
+	OnStreamStart func(audio.Format)
+	OnStreamEnd   func()
+	OnError       func(error)
 }
 
 type ReceiverStats struct {
@@ -79,6 +94,18 @@ type Receiver struct {
 	schedulerCancel context.CancelFunc
 	serverAddr      string
 	connected       bool
+
+	// Metadata merge state. mergedMetadata is the running snapshot fed to
+	// OnMetadata; pendingMetadata holds future-dated updates sorted by
+	// ascending Timestamp until clockNow() crosses each one.
+	metadataMu      stdsync.Mutex
+	mergedMetadata  Metadata
+	pendingMetadata []*protocol.MetadataState
+
+	// clockNow returns "current server time in microseconds". Indirected
+	// from r.clockSync.ServerMicrosNow so tests can drive the
+	// timestamp-deferral path with a fake clock.
+	clockNow func() int64
 }
 
 // NewReceiver creates a new Receiver with the given configuration.
@@ -116,6 +143,7 @@ func NewReceiver(config ReceiverConfig) (*Receiver, error) {
 		cancel:     cancel,
 		serverAddr: config.ServerAddr,
 	}
+	r.clockNow = r.clockSync.ServerMicrosNow
 
 	return r, nil
 }
@@ -214,6 +242,7 @@ func (r *Receiver) Connect() error {
 	go r.handleAudioChunks()
 	go r.handleServerState()
 	go r.handleGroupUpdates()
+	go r.metadataApplyLoop()
 
 	return nil
 }
@@ -374,26 +403,155 @@ func (r *Receiver) handleStreamEnd() {
 	}
 }
 
+// handleServerState reads server/state messages from the protocol client
+// and feeds metadata updates into the merge layer. Non-metadata fields
+// of ServerStateMessage are not used today; if/when they grow handlers
+// they should branch off here.
 func (r *Receiver) handleServerState() {
 	for {
 		select {
 		case state := <-r.client.ServerState:
-			if state.Metadata != nil && r.config.OnMetadata != nil {
-				meta := state.Metadata
-				r.config.OnMetadata(Metadata{
-					Title:       derefString(meta.Title),
-					Artist:      derefString(meta.Artist),
-					Album:       derefString(meta.Album),
-					AlbumArtist: derefString(meta.AlbumArtist),
-					ArtworkURL:  derefString(meta.ArtworkURL),
-					Track:       derefInt(meta.Track),
-					Year:        derefInt(meta.Year),
-					Duration:    getDurationSeconds(meta.Progress),
-				})
+			if state.Metadata != nil {
+				r.enqueueMetadata(state.Metadata)
 			}
 		case <-r.ctx.Done():
 			return
 		}
+	}
+}
+
+// enqueueMetadata accepts a server metadata update and either applies it
+// immediately (timestamp <= current server time, or zero timestamp) or
+// queues it for future application sorted by ascending timestamp.
+//
+// Zero / negative timestamps apply immediately. Per spec, MetadataState
+// always carries a timestamp, but defending against malformed servers
+// costs nothing and keeps existing snapshot-style emitters working.
+func (r *Receiver) enqueueMetadata(m *protocol.MetadataState) {
+	r.metadataMu.Lock()
+	defer r.metadataMu.Unlock()
+
+	serverNow := r.clockNow()
+
+	if m.Timestamp <= 0 || m.Timestamp <= serverNow {
+		r.applyMetadataLocked(m)
+		return
+	}
+
+	// Insertion-sort into pendingMetadata by ascending Timestamp.
+	idx := sort.Search(len(r.pendingMetadata), func(i int) bool {
+		return r.pendingMetadata[i].Timestamp >= m.Timestamp
+	})
+	r.pendingMetadata = append(r.pendingMetadata, nil)
+	copy(r.pendingMetadata[idx+1:], r.pendingMetadata[idx:])
+	r.pendingMetadata[idx] = m
+}
+
+// applyMetadataLocked merges the update onto mergedMetadata per tristate
+// rules and fires OnMetadata. Caller must hold r.metadataMu.
+//
+// For each field: if the wire key was absent, preserve the prior value;
+// if present and null (pointer is nil after decode), reset to zero; if
+// present with a value, replace. The progress field is atomic per spec —
+// a non-null progress always carries all three fields, so we either take
+// TrackDuration or zero Duration.
+func (r *Receiver) applyMetadataLocked(m *protocol.MetadataState) {
+	if m.HasField("title") {
+		if m.Title != nil {
+			r.mergedMetadata.Title = *m.Title
+		} else {
+			r.mergedMetadata.Title = ""
+		}
+	}
+	if m.HasField("artist") {
+		if m.Artist != nil {
+			r.mergedMetadata.Artist = *m.Artist
+		} else {
+			r.mergedMetadata.Artist = ""
+		}
+	}
+	if m.HasField("album") {
+		if m.Album != nil {
+			r.mergedMetadata.Album = *m.Album
+		} else {
+			r.mergedMetadata.Album = ""
+		}
+	}
+	if m.HasField("album_artist") {
+		if m.AlbumArtist != nil {
+			r.mergedMetadata.AlbumArtist = *m.AlbumArtist
+		} else {
+			r.mergedMetadata.AlbumArtist = ""
+		}
+	}
+	if m.HasField("artwork_url") {
+		if m.ArtworkURL != nil {
+			r.mergedMetadata.ArtworkURL = *m.ArtworkURL
+		} else {
+			r.mergedMetadata.ArtworkURL = ""
+		}
+	}
+	if m.HasField("track") {
+		if m.Track != nil {
+			r.mergedMetadata.Track = *m.Track
+		} else {
+			r.mergedMetadata.Track = 0
+		}
+	}
+	if m.HasField("year") {
+		if m.Year != nil {
+			r.mergedMetadata.Year = *m.Year
+		} else {
+			r.mergedMetadata.Year = 0
+		}
+	}
+	if m.HasField("progress") {
+		if m.Progress != nil {
+			r.mergedMetadata.Duration = m.Progress.TrackDuration / 1000
+		} else {
+			r.mergedMetadata.Duration = 0
+		}
+	}
+
+	snapshot := r.mergedMetadata
+	if r.config.OnMetadata != nil {
+		r.config.OnMetadata(snapshot)
+	}
+}
+
+// metadataApplyLoop drains pendingMetadata as server time crosses each
+// queued update's timestamp. Started as a goroutine in Connect.
+func (r *Receiver) metadataApplyLoop() {
+	ticker := time.NewTicker(metadataApplyTickInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			r.drainPendingMetadata()
+		case <-r.ctx.Done():
+			return
+		}
+	}
+}
+
+// drainPendingMetadata applies every pending update whose timestamp has
+// elapsed, in ascending timestamp order. Pending is kept sorted by
+// enqueueMetadata, so we can stop at the first future-dated entry.
+func (r *Receiver) drainPendingMetadata() {
+	r.metadataMu.Lock()
+	defer r.metadataMu.Unlock()
+
+	serverNow := r.clockNow()
+	applied := 0
+	for _, m := range r.pendingMetadata {
+		if m.Timestamp > serverNow {
+			break
+		}
+		r.applyMetadataLocked(m)
+		applied++
+	}
+	if applied > 0 {
+		r.pendingMetadata = r.pendingMetadata[applied:]
 	}
 }
 

--- a/pkg/sendspin/receiver_test.go
+++ b/pkg/sendspin/receiver_test.go
@@ -2,7 +2,9 @@
 package sendspin
 
 import (
+	"encoding/json"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/Sendspin/sendspin-go/pkg/audio"
@@ -278,5 +280,316 @@ func TestBuildSupportedFormats_AggressiveCapEmpty(t *testing.T) {
 	got := buildSupportedFormats("", 8000, 8)
 	if len(got) != 0 {
 		t.Errorf("expected empty list for impossible caps, got %d entries", len(got))
+	}
+}
+
+// metadataStateWithKeys builds a MetadataState by JSON-marshaling the input
+// map and decoding through the real wire path so presentKeys is populated
+// correctly. This is the only way to construct a MetadataState whose
+// HasField returns false for unspecified keys, since presentKeys is
+// unexported. Tests that rely on tristate semantics must use this helper.
+func metadataStateWithKeys(t *testing.T, fields map[string]any) *protocol.MetadataState {
+	t.Helper()
+	data, err := json.Marshal(fields)
+	if err != nil {
+		t.Fatalf("metadataStateWithKeys: marshal: %v", err)
+	}
+	var m protocol.MetadataState
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("metadataStateWithKeys: unmarshal: %v", err)
+	}
+	return &m
+}
+
+// receiverForMetadataTests builds a Receiver with a fixed fake clock and an
+// OnMetadata callback that captures every snapshot. The captured slice is
+// guarded by its own mutex because OnMetadata may be invoked from either
+// the channel reader goroutine or the apply-loop goroutine.
+type metadataCapture struct {
+	mu       sync.Mutex
+	captured []Metadata
+}
+
+func (mc *metadataCapture) record(m Metadata) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	mc.captured = append(mc.captured, m)
+}
+
+func (mc *metadataCapture) latest() (Metadata, bool) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	if len(mc.captured) == 0 {
+		return Metadata{}, false
+	}
+	return mc.captured[len(mc.captured)-1], true
+}
+
+func (mc *metadataCapture) count() int {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	return len(mc.captured)
+}
+
+// newMetadataReceiver returns a Receiver wired up for direct enqueue/apply
+// testing — no Connect, no protocol client, no scheduler. clockNow is
+// overridden to a fixed value so timestamp-deferral tests are deterministic.
+func newMetadataReceiver(t *testing.T, fakeNow int64, mc *metadataCapture) *Receiver {
+	t.Helper()
+	r, err := NewReceiver(ReceiverConfig{
+		ServerAddr: "localhost:8927",
+		PlayerName: "Metadata Test",
+		OnMetadata: mc.record,
+	})
+	if err != nil {
+		t.Fatalf("NewReceiver: %v", err)
+	}
+	r.clockNow = func() int64 { return fakeNow }
+	t.Cleanup(func() { _ = r.Close() })
+	return r
+}
+
+// TestReceiver_MetadataMergePreservesUnchangedFields is the headline
+// regression: a track A snapshot followed by a track B diff_update that
+// only carries `title` must not blank out artist/album. Pre-fix, the
+// receiver dereffed nil pointers and dispatched empty strings for both.
+func TestReceiver_MetadataMergePreservesUnchangedFields(t *testing.T) {
+	mc := &metadataCapture{}
+	r := newMetadataReceiver(t, 0, mc)
+
+	// Snapshot: title + artist + album set.
+	r.enqueueMetadata(metadataStateWithKeys(t, map[string]any{
+		"timestamp": 0,
+		"title":     "Song A",
+		"artist":    "Artist X",
+		"album":     "Album Y",
+	}))
+
+	// Diff: only title changes. Artist + album omitted → must preserve.
+	r.enqueueMetadata(metadataStateWithKeys(t, map[string]any{
+		"timestamp": 0,
+		"title":     "Song B",
+	}))
+
+	got, ok := mc.latest()
+	if !ok {
+		t.Fatal("OnMetadata was not invoked")
+	}
+	t.Logf("merged snapshot after diff: %+v", got)
+	if got.Title != "Song B" {
+		t.Errorf("Title = %q, want %q", got.Title, "Song B")
+	}
+	if got.Artist != "Artist X" {
+		t.Errorf("Artist = %q, want %q (must be preserved across diff)", got.Artist, "Artist X")
+	}
+	if got.Album != "Album Y" {
+		t.Errorf("Album = %q, want %q (must be preserved across diff)", got.Album, "Album Y")
+	}
+	if mc.count() != 2 {
+		t.Errorf("OnMetadata invocation count = %d, want 2", mc.count())
+	}
+}
+
+// TestReceiver_MetadataNullClearsField verifies the "null" leg of the
+// tristate contract: a wire-explicit null must reset the prior value.
+func TestReceiver_MetadataNullClearsField(t *testing.T) {
+	mc := &metadataCapture{}
+	r := newMetadataReceiver(t, 0, mc)
+
+	r.enqueueMetadata(metadataStateWithKeys(t, map[string]any{
+		"timestamp":   0,
+		"title":       "Song A",
+		"artist":      "Artist X",
+		"artwork_url": "http://example/a.jpg",
+	}))
+
+	// Explicit null on artwork_url and artist: must clear both.
+	r.enqueueMetadata(metadataStateWithKeys(t, map[string]any{
+		"timestamp":   0,
+		"artist":      nil,
+		"artwork_url": nil,
+	}))
+
+	got, ok := mc.latest()
+	if !ok {
+		t.Fatal("OnMetadata was not invoked")
+	}
+	t.Logf("merged snapshot after null-clear: %+v", got)
+	if got.Title != "Song A" {
+		t.Errorf("Title = %q, want %q (omitted, should be preserved)", got.Title, "Song A")
+	}
+	if got.Artist != "" {
+		t.Errorf("Artist = %q, want empty (null on wire clears it)", got.Artist)
+	}
+	if got.ArtworkURL != "" {
+		t.Errorf("ArtworkURL = %q, want empty (null on wire clears it)", got.ArtworkURL)
+	}
+}
+
+// TestReceiver_MetadataFutureTimestampDeferred verifies a future-dated
+// update is held in pendingMetadata until the fake clock advances past
+// the timestamp, then drainPendingMetadata flushes it.
+func TestReceiver_MetadataFutureTimestampDeferred(t *testing.T) {
+	mc := &metadataCapture{}
+	// Fake clock starts at server-time = 1000 µs.
+	r, err := NewReceiver(ReceiverConfig{
+		ServerAddr: "localhost:8927",
+		PlayerName: "Defer Test",
+		OnMetadata: mc.record,
+	})
+	if err != nil {
+		t.Fatalf("NewReceiver: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+
+	var now int64 = 1000
+	r.clockNow = func() int64 { return now }
+
+	// Apply-now snapshot to set baseline.
+	r.enqueueMetadata(metadataStateWithKeys(t, map[string]any{
+		"timestamp": 0,
+		"title":     "Now Playing",
+		"artist":    "Current Artist",
+	}))
+	if mc.count() != 1 {
+		t.Fatalf("expected 1 immediate apply, got %d", mc.count())
+	}
+
+	// Future-dated update at server-time = 5000 µs. Should NOT apply yet.
+	r.enqueueMetadata(metadataStateWithKeys(t, map[string]any{
+		"timestamp": 5000,
+		"title":     "Up Next",
+	}))
+	if mc.count() != 1 {
+		t.Errorf("future-dated update applied early; OnMetadata count = %d, want 1", mc.count())
+	}
+
+	r.metadataMu.Lock()
+	pendingLen := len(r.pendingMetadata)
+	r.metadataMu.Unlock()
+	if pendingLen != 1 {
+		t.Errorf("pendingMetadata length = %d, want 1", pendingLen)
+	}
+
+	// Drain at clock = 4000 µs (still before timestamp): nothing applies.
+	now = 4000
+	r.drainPendingMetadata()
+	if mc.count() != 1 {
+		t.Errorf("drain at clock<timestamp applied prematurely; count = %d, want 1", mc.count())
+	}
+
+	// Advance clock past the timestamp; drain should flush the queued update.
+	now = 5500
+	r.drainPendingMetadata()
+	if mc.count() != 2 {
+		t.Fatalf("expected drain to apply 1 deferred update; count = %d, want 2", mc.count())
+	}
+
+	got, _ := mc.latest()
+	t.Logf("post-defer-flush snapshot: %+v", got)
+	if got.Title != "Up Next" {
+		t.Errorf("Title = %q, want %q", got.Title, "Up Next")
+	}
+	// Artist was omitted in the future-dated diff → must still be the
+	// baseline value from the first update.
+	if got.Artist != "Current Artist" {
+		t.Errorf("Artist = %q, want %q (omitted in diff, preserved)", got.Artist, "Current Artist")
+	}
+
+	// Pending must be empty after drain.
+	r.metadataMu.Lock()
+	pendingLen = len(r.pendingMetadata)
+	r.metadataMu.Unlock()
+	if pendingLen != 0 {
+		t.Errorf("pendingMetadata length after drain = %d, want 0", pendingLen)
+	}
+}
+
+// TestReceiver_MetadataPendingSortedByTimestamp confirms enqueue maintains
+// ascending-timestamp order even when callers send out-of-order updates.
+// drainPendingMetadata depends on this to short-circuit at the first
+// future-dated entry.
+func TestReceiver_MetadataPendingSortedByTimestamp(t *testing.T) {
+	mc := &metadataCapture{}
+	r, err := NewReceiver(ReceiverConfig{
+		ServerAddr: "localhost:8927",
+		PlayerName: "Sort Test",
+		OnMetadata: mc.record,
+	})
+	if err != nil {
+		t.Fatalf("NewReceiver: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+	r.clockNow = func() int64 { return 0 }
+
+	// Enqueue three future-dated updates out of order.
+	for _, ts := range []int64{500, 100, 300} {
+		r.enqueueMetadata(metadataStateWithKeys(t, map[string]any{
+			"timestamp": ts,
+			"title":     fmt.Sprintf("ts-%d", ts),
+		}))
+	}
+
+	r.metadataMu.Lock()
+	got := make([]int64, len(r.pendingMetadata))
+	for i, m := range r.pendingMetadata {
+		got[i] = m.Timestamp
+	}
+	r.metadataMu.Unlock()
+	t.Logf("pending timestamps after out-of-order enqueue: %v", got)
+
+	want := []int64{100, 300, 500}
+	if len(got) != len(want) {
+		t.Fatalf("pending length = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("pending[%d].Timestamp = %d, want %d", i, got[i], want[i])
+		}
+	}
+}
+
+// TestReceiver_MetadataProgressTristate exercises the progress field
+// across set / null / omitted, since it's the only nested struct in the
+// merge path. Per spec, progress is atomic — a non-null value always
+// carries TrackDuration; a null clears Duration; an omitted progress
+// preserves the prior Duration.
+func TestReceiver_MetadataProgressTristate(t *testing.T) {
+	mc := &metadataCapture{}
+	r := newMetadataReceiver(t, 0, mc)
+
+	// Set progress with track_duration = 60_000 ms (= 60s).
+	r.enqueueMetadata(metadataStateWithKeys(t, map[string]any{
+		"timestamp": 0,
+		"progress": map[string]any{
+			"track_progress": 0,
+			"track_duration": 60000,
+			"playback_speed": 1000,
+		},
+	}))
+	got, _ := mc.latest()
+	if got.Duration != 60 {
+		t.Errorf("Duration = %d, want 60 (60000ms / 1000)", got.Duration)
+	}
+
+	// Diff with progress omitted → Duration preserved.
+	r.enqueueMetadata(metadataStateWithKeys(t, map[string]any{
+		"timestamp": 0,
+		"title":     "still playing",
+	}))
+	got, _ = mc.latest()
+	if got.Duration != 60 {
+		t.Errorf("Duration after omitted progress = %d, want 60 preserved", got.Duration)
+	}
+
+	// Explicit null progress → Duration cleared.
+	r.enqueueMetadata(metadataStateWithKeys(t, map[string]any{
+		"timestamp": 0,
+		"progress":  nil,
+	}))
+	got, _ = mc.latest()
+	t.Logf("snapshot after null progress: %+v", got)
+	if got.Duration != 0 {
+		t.Errorf("Duration after null progress = %d, want 0", got.Duration)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the bug where Artist/Album go blank in the player TUI after using next/prev, while Track stays populated.

## Root cause

aiosendspin server emits **partial** \`server/state\` updates via \`diff_update\`: only changed fields appear on the wire. The protocol uses three states:

| Wire JSON | Meaning |
|---|---|
| key absent | unchanged — preserve prior value |
| \`\"key\": null\` | explicitly clear |
| \`\"key\": value\` | replace |

Our Go \`MetadataState\` decoded \`*string\` for each optional, but \`omitempty\` only affects marshalling — both \`{}\` and \`{\"title\": null}\` decode to a nil pointer. \`derefString(nil) == \"\"\` then clobbered every prior field on every update.

Confirmed by reading \`Sendspin/aiosendspin/aiosendspin/server/roles/metadata/state.py\` (\`diff_update\`/\`cleared_update\`/\`snapshot_update\`) and \`tests/models/test_server_state_merge.py\`.

## Fix

Two layers:

1. **Wire-level** (\`pkg/protocol/messages.go\`): \`MetadataState.UnmarshalJSON\` now records key presence via \`map[string]json.RawMessage\` first pass + alias-recursion-guard second pass. New \`HasField(jsonKey string) bool\` API.

2. **Receiver-level** (\`pkg/sendspin/receiver.go\`): \`Receiver\` maintains a running merged \`Metadata\` snapshot, applies the tristate rules per field, and respects \`MetadataState.Timestamp\` so future-dated updates apply when server time reaches them (not on receipt). New \`metadataApplyLoop\` goroutine drains the pending queue.

## Tests

- 4 new protocol tests covering omitted/null/value across all 11 fields
- 5 new receiver tests covering merge, null-clear, future-timestamp deferral, sort order, progress tristate
- The regression scenario is locked down by \`TestReceiver_MetadataMergePreservesUnchangedFields\` (Title-only diff after full snapshot must preserve Artist/Album)

## Verification

- \`go vet ./...\` clean
- \`go test -race -count=10 ./pkg/protocol/...\` clean
- \`go test -race -count=5 ./pkg/sendspin/...\` clean
- \`go test -race -count=1 ./...\` all 13 packages green
- \`make conformance\` 12/12 — wire format unchanged

## Notable

- Public API unchanged except one new method: \`(*MetadataState).HasField\`. Existing in-Go construction of \`MetadataState{...}\` returns \`true\` for every \`HasField\` query (presentKeys nil = backward-compat path), so server-side snapshot pushes (\`role_metadata.go\`) work unmodified.
- \`Repeat\` and \`Shuffle\` are decoded but not merged because the public \`Metadata\` struct doesn't surface them — anti-goal per plan. If/when those become user-visible, the merge branches need to be added in lockstep.
- \`OnMetadata\` callback may now run from the apply-loop goroutine in addition to the channel reader. Documented at the callback's doc comment.

## Test plan

- [ ] CI green
- [ ] Manual: connect player, play, hit next/prev within an album — Artist/Album should stay populated
- [ ] Manual: skip to a track with no artwork — \`artwork_url\` should clear