### PR TITLE
feat(sendspin): broadcast metadata on playback-state change and on demand

### DIFF
--- a/pkg/sendspin/group.go
+++ b/pkg/sendspin/group.go
@@ -65,6 +65,20 @@ type ClientStateChangedEvent struct {
 
 func (ClientStateChangedEvent) isGroupEvent() {}
 
+// GroupPlaybackStateChangedEvent fires when the group's playback state
+// transitions. Roles that need to react (e.g. re-broadcast metadata at
+// stopped→playing) listen via the optional PlaybackStateChangedHandler
+// interface dispatched by Group's role event loop.
+//
+// OldState may be empty for the initial transition out of the zero value.
+// Same-state transitions are not published (no-op writes are silent).
+type GroupPlaybackStateChangedEvent struct {
+	OldState string
+	NewState string
+}
+
+func (GroupPlaybackStateChangedEvent) isGroupEvent() {}
+
 // Group owns the event bus and the set of clients currently attached to
 // a playback group. For M2 there is exactly one Group per Server,
 // auto-created in NewServer. Multi-group support is a post-#61 concern.
@@ -267,10 +281,20 @@ func (g *Group) Close() {
 	clear(g.clients)
 }
 
-// SetPlaybackState updates the group's playback state. Future clients
-// joining the group will receive this state in group/update.
+// SetPlaybackState updates the group's playback state. If the new state
+// differs from the current value, a GroupPlaybackStateChangedEvent is
+// published. Future clients joining the group will receive the new
+// state in group/update. Same-state writes are a silent no-op.
 func (g *Group) SetPlaybackState(state string) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
+	if g.playbackState == state {
+		return
+	}
+	oldState := g.playbackState
 	g.playbackState = state
+	g.publishLocked(GroupPlaybackStateChangedEvent{
+		OldState: oldState,
+		NewState: state,
+	})
 }

--- a/pkg/sendspin/group_role.go
+++ b/pkg/sendspin/group_role.go
@@ -25,6 +25,18 @@ type MessageHandler interface {
 	HandleMessage(c *ServerClient, payload json.RawMessage) error
 }
 
+// PlaybackStateChangedHandler is an optional interface that a GroupRole
+// may implement to receive notifications when the group's playback state
+// transitions. The Group dispatches GroupPlaybackStateChangedEvent to
+// roles that implement this interface; same-state writes are not
+// dispatched (Group.SetPlaybackState filters them out).
+//
+// Note: oldState may be empty for the very first transition out of the
+// zero value.
+type PlaybackStateChangedHandler interface {
+	OnPlaybackStateChanged(oldState, newState string)
+}
+
 // RegisterRole registers a GroupRole with this group. The role is
 // stored by its Role() family name. Duplicate registrations for the
 // same family overwrite the previous one.
@@ -40,6 +52,14 @@ func (g *Group) RegisterRole(role GroupRole) {
 		g.roles = make(map[string]GroupRole)
 	}
 	g.roles[role.Role()] = role
+
+	// Optional attach-to-group hook: roles that need to iterate the
+	// group's clients on broadcast (e.g. MetadataGroupRole) implement
+	// the unexported attachToGroup method to receive a back-reference.
+	// Kept unexported so callers can't bypass RegisterRole.
+	if a, ok := role.(interface{ attachToGroup(*Group) }); ok {
+		a.attachToGroup(g)
+	}
 
 	if g.roleDispatchStarted {
 		return
@@ -101,6 +121,12 @@ func (g *Group) dispatchRoleEvents(events <-chan Event) {
 		case ClientLeftEvent:
 			for _, r := range roles {
 				r.OnClientLeave(e.ClientID, e.ClientName)
+			}
+		case GroupPlaybackStateChangedEvent:
+			for _, r := range roles {
+				if h, ok := r.(PlaybackStateChangedHandler); ok {
+					h.OnPlaybackStateChanged(e.OldState, e.NewState)
+				}
 			}
 		default:
 			// ClientStateChangedEvent and future event types are

--- a/pkg/sendspin/group_test.go
+++ b/pkg/sendspin/group_test.go
@@ -208,6 +208,103 @@ func TestGroup_ConcurrentPublishClose(t *testing.T) {
 	<-done
 }
 
+// TestGroup_SetPlaybackState_PublishesOnChange confirms that
+// SetPlaybackState publishes a GroupPlaybackStateChangedEvent only on
+// actual transitions, and is a silent no-op on same-state writes. The
+// group's default state is "playing" (per NewGroup), so calling
+// SetPlaybackState("playing") first must produce no event; transitioning
+// to "stopped" must produce exactly one event with OldState="playing".
+func TestGroup_SetPlaybackState_PublishesOnChange(t *testing.T) {
+	g := NewGroup("test-group")
+	defer g.Close()
+
+	// Subscribe BEFORE any state writes so we observe every emitted event.
+	events, unsubscribe := g.Subscribe()
+	defer unsubscribe()
+
+	// Same-state write: must not publish (default is "playing").
+	g.SetPlaybackState("playing")
+
+	select {
+	case evt := <-events:
+		t.Fatalf("same-state SetPlaybackState published unexpected event: %T %+v", evt, evt)
+	case <-time.After(30 * time.Millisecond):
+		// Expected: no event.
+	}
+
+	// Real transition: must publish exactly one event.
+	g.SetPlaybackState("stopped")
+
+	select {
+	case evt := <-events:
+		ps, ok := evt.(GroupPlaybackStateChangedEvent)
+		if !ok {
+			t.Fatalf("got %T, want GroupPlaybackStateChangedEvent", evt)
+		}
+		t.Logf("event=%+v", ps)
+		if ps.OldState != "playing" || ps.NewState != "stopped" {
+			t.Errorf("event = %+v, want {OldState: playing, NewState: stopped}", ps)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timed out waiting for GroupPlaybackStateChangedEvent")
+	}
+
+	// Same-state write again: must not publish.
+	g.SetPlaybackState("stopped")
+
+	select {
+	case evt := <-events:
+		t.Fatalf("repeat same-state SetPlaybackState published unexpected event: %T %+v", evt, evt)
+	case <-time.After(30 * time.Millisecond):
+		// Expected.
+	}
+}
+
+// TestGroup_SetPlaybackState_OldStateInEvent pins that successive
+// transitions carry the prior playback state in OldState — not the empty
+// string, not the first-ever value. This guards against future refactors
+// that might forget to capture oldState before mutation.
+func TestGroup_SetPlaybackState_OldStateInEvent(t *testing.T) {
+	g := NewGroup("test-group")
+	defer g.Close()
+
+	events, unsubscribe := g.Subscribe()
+	defer unsubscribe()
+
+	g.SetPlaybackState("paused")
+	g.SetPlaybackState("playing")
+
+	// First event: playing → paused
+	select {
+	case evt := <-events:
+		ps, ok := evt.(GroupPlaybackStateChangedEvent)
+		if !ok {
+			t.Fatalf("got %T, want GroupPlaybackStateChangedEvent", evt)
+		}
+		t.Logf("event[0]=%+v", ps)
+		if ps.OldState != "playing" || ps.NewState != "paused" {
+			t.Errorf("event[0] = %+v, want {playing, paused}", ps)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timed out on first event")
+	}
+
+	// Second event: paused → playing
+	select {
+	case evt := <-events:
+		ps, ok := evt.(GroupPlaybackStateChangedEvent)
+		if !ok {
+			t.Fatalf("got %T, want GroupPlaybackStateChangedEvent", evt)
+		}
+		t.Logf("event[1]=%+v", ps)
+		if ps.OldState != "paused" || ps.NewState != "playing" {
+			t.Errorf("event[1] = %+v, want {paused, playing}", ps)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timed out on second event")
+	}
+}
+
 // TestGroup_AddClientSendsGroupUpdate confirms that addClient sends
 // a group/update message to the joining client before publishing
 // ClientJoinedEvent.

--- a/pkg/sendspin/role_metadata.go
+++ b/pkg/sendspin/role_metadata.go
@@ -1,9 +1,10 @@
 // ABOUTME: MetadataGroupRole pushes track metadata to joining clients
-// ABOUTME: Sends server/state with metadata snapshot on client join
+// ABOUTME: Sends server/state with metadata snapshot on join, transition, or on demand
 package sendspin
 
 import (
 	"log"
+	"sync"
 
 	"github.com/Sendspin/sendspin-go/pkg/protocol"
 )
@@ -19,27 +20,47 @@ type MetadataConfig struct {
 
 // MetadataGroupRole handles the "metadata" role family. It pushes a
 // server/state message with the current track metadata to clients
-// that advertise the metadata role when they join.
+// that advertise the metadata role: on join, on stopped→playing
+// transitions, and on demand via BroadcastMetadata.
 type MetadataGroupRole struct {
 	config MetadataConfig
+
+	mu    sync.RWMutex
+	group *Group
 }
 
 // NewMetadataRole creates a MetadataGroupRole with the given config.
+// The role must be registered on a Group via Group.RegisterRole; the
+// group reference is captured so OnPlaybackStateChanged and
+// BroadcastMetadata can iterate the group's attached clients.
 func NewMetadataRole(config MetadataConfig) *MetadataGroupRole {
 	return &MetadataGroupRole{config: config}
 }
 
+// attachToGroup is called by Group.RegisterRole to give the role a
+// back-reference for client iteration. Unexported because role authors
+// must register via Group.RegisterRole rather than calling this directly.
+func (r *MetadataGroupRole) attachToGroup(g *Group) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.group = g
+}
+
+// attachedGroup returns the group this role was registered on, or nil
+// if it has not yet been registered.
+func (r *MetadataGroupRole) attachedGroup() *Group {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.group
+}
+
 func (r *MetadataGroupRole) Role() string { return "metadata" }
 
-// OnClientJoin sends the current metadata snapshot to clients that
-// advertise the metadata role.
-func (r *MetadataGroupRole) OnClientJoin(c *ServerClient) {
-	if !c.HasRole("metadata") {
-		return
-	}
-
+// snapshotMessage builds the current server/state metadata snapshot.
+// Returns nil if no GetMetadata callback is configured.
+func (r *MetadataGroupRole) snapshotMessage() *protocol.ServerStateMessage {
 	if r.config.GetMetadata == nil {
-		return
+		return nil
 	}
 
 	title, artist, album := r.config.GetMetadata()
@@ -49,7 +70,7 @@ func (r *MetadataGroupRole) OnClientJoin(c *ServerClient) {
 		clockMicros = r.config.ClockMicros()
 	}
 
-	state := protocol.ServerStateMessage{
+	return &protocol.ServerStateMessage{
 		Metadata: &protocol.MetadataState{
 			Timestamp: clockMicros,
 			Title:     strPtr(title),
@@ -57,10 +78,73 @@ func (r *MetadataGroupRole) OnClientJoin(c *ServerClient) {
 			Album:     strPtr(album),
 		},
 	}
+}
 
-	if err := c.Send("server/state", state); err != nil {
+// OnClientJoin sends the current metadata snapshot to clients that
+// advertise the metadata role.
+func (r *MetadataGroupRole) OnClientJoin(c *ServerClient) {
+	if !c.HasRole("metadata") {
+		return
+	}
+
+	state := r.snapshotMessage()
+	if state == nil {
+		return
+	}
+
+	if err := c.Send("server/state", *state); err != nil {
 		log.Printf("MetadataRole: failed to send state to %s: %v", c.Name(), err)
 	}
 }
 
 func (r *MetadataGroupRole) OnClientLeave(id string, name string) {}
+
+// OnPlaybackStateChanged broadcasts the current metadata snapshot to
+// every attached metadata-role client when the group transitions to
+// "playing" from a non-playing state. This closes the gap where a
+// client connects while the group is stopped (and thus receives only
+// the empty-state on join), then never sees metadata when playback
+// subsequently begins.
+//
+// Other transitions (playing→paused, playing→stopped) are intentionally
+// not re-broadcast — the existing client state is already correct for
+// "the same track is paused/stopped".
+func (r *MetadataGroupRole) OnPlaybackStateChanged(oldState, newState string) {
+	if newState != "playing" || oldState == "playing" {
+		return
+	}
+	r.broadcast()
+}
+
+// BroadcastMetadata pushes the current metadata snapshot to every
+// attached metadata-role client. Use this when the server's metadata
+// source has mutated and connected clients need to see the new value
+// (e.g., HLS playlist advance, controller-driven track change).
+//
+// Safe to call concurrently with the group's own event dispatch — uses
+// Group.Clients which returns a snapshot copy.
+func (r *MetadataGroupRole) BroadcastMetadata() {
+	r.broadcast()
+}
+
+// broadcast sends the snapshot to every metadata-role client in the
+// attached group. Logs and continues on per-client send errors so one
+// dropped client does not stall the rest.
+func (r *MetadataGroupRole) broadcast() {
+	g := r.attachedGroup()
+	if g == nil {
+		return
+	}
+	state := r.snapshotMessage()
+	if state == nil {
+		return
+	}
+	for _, c := range g.Clients() {
+		if !c.HasRole("metadata") {
+			continue
+		}
+		if err := c.Send("server/state", *state); err != nil {
+			log.Printf("MetadataRole: broadcast to %s failed: %v", c.Name(), err)
+		}
+	}
+}

--- a/pkg/sendspin/role_metadata_test.go
+++ b/pkg/sendspin/role_metadata_test.go
@@ -1,10 +1,50 @@
 // ABOUTME: Tests for the MetadataGroupRole implementation
-// ABOUTME: Verifies metadata state push to joining clients
+// ABOUTME: Verifies metadata state push to joining clients and broadcast paths
 package sendspin
 
 import (
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/Sendspin/sendspin-go/pkg/protocol"
 )
+
+// drainServerStateMessage reads one queued send from a fake client's
+// sendChan and returns the decoded protocol.Message + ServerStateMessage.
+// Fails the test if nothing is queued or if the queued payload is not a
+// server/state message.
+func drainServerStateMessage(t *testing.T, sc *ServerClient) (protocol.Message, protocol.ServerStateMessage) {
+	t.Helper()
+	select {
+	case raw := <-sc.sendChan:
+		msg, ok := raw.(protocol.Message)
+		if !ok {
+			t.Fatalf("queued send was %T, want protocol.Message", raw)
+		}
+		state, ok := msg.Payload.(protocol.ServerStateMessage)
+		if !ok {
+			t.Fatalf("Message.Payload was %T, want protocol.ServerStateMessage", msg.Payload)
+		}
+		return msg, state
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("expected a server/state send, none arrived")
+		return protocol.Message{}, protocol.ServerStateMessage{}
+	}
+}
+
+// expectNoSend fails the test if the client received any queued send
+// within the wait window. Used to assert non-metadata clients don't get
+// broadcasts.
+func expectNoSend(t *testing.T, sc *ServerClient, wait time.Duration, label string) {
+	t.Helper()
+	select {
+	case raw := <-sc.sendChan:
+		t.Fatalf("%s: unexpected send queued: %T %+v", label, raw, raw)
+	case <-time.After(wait):
+		// Expected: nothing.
+	}
+}
 
 func TestMetadataRole_OnClientJoinSendsState(t *testing.T) {
 	meta := NewMetadataRole(MetadataConfig{
@@ -55,5 +95,322 @@ func TestMetadataRole_Role(t *testing.T) {
 	meta := NewMetadataRole(MetadataConfig{})
 	if meta.Role() != "metadata" {
 		t.Errorf("Role() = %q, want %q", meta.Role(), "metadata")
+	}
+}
+
+// TestMetadataRole_OnPlaybackStateChanged_BroadcastsToMetadataClients
+// builds a Group with two attached clients (one with the metadata role,
+// one without), registers a MetadataGroupRole, and invokes
+// OnPlaybackStateChanged("stopped", "playing"). The metadata client must
+// receive a server/state with the expected payload; the non-metadata
+// client must not.
+func TestMetadataRole_OnPlaybackStateChanged_BroadcastsToMetadataClients(t *testing.T) {
+	g := NewGroup("test-group")
+	defer g.Close()
+
+	meta := NewMetadataRole(MetadataConfig{
+		GetMetadata: func() (string, string, string) {
+			return "Track Title", "Artist Name", "Album Name"
+		},
+		ClockMicros: func() int64 { return 42 },
+	})
+	g.RegisterRole(meta)
+
+	metaClient := &ServerClient{
+		id:       "meta-c",
+		name:     "metadata client",
+		roles:    []string{"metadata@v1"},
+		sendChan: make(chan interface{}, 10),
+	}
+	playerClient := &ServerClient{
+		id:       "player-c",
+		name:     "player client",
+		roles:    []string{"player@v1"},
+		sendChan: make(chan interface{}, 10),
+	}
+
+	// Attach via addClient so they're members of g.Clients(); drain the
+	// group/update that addClient sends before exercising broadcast.
+	g.addClient(metaClient)
+	g.addClient(playerClient)
+	<-metaClient.sendChan   // group/update
+	<-playerClient.sendChan // group/update
+
+	// Drain the OnClientJoin server/state that fires on the metadata
+	// client (since meta was registered before the client joined).
+	// Sleep briefly so the dispatcher goroutine processes the join.
+	time.Sleep(20 * time.Millisecond)
+	select {
+	case raw := <-metaClient.sendChan:
+		t.Logf("drained join-time send: %+v", raw)
+	default:
+		// Already drained or never sent — fine, this test exercises the
+		// broadcast path, not the join path.
+	}
+
+	// Direct invocation — independent of event dispatch.
+	meta.OnPlaybackStateChanged("stopped", "playing")
+
+	msg, state := drainServerStateMessage(t, metaClient)
+	t.Logf("metaClient received: type=%s payload=%+v metadata=%+v", msg.Type, state, state.Metadata)
+	if msg.Type != "server/state" {
+		t.Errorf("Message.Type = %q, want server/state", msg.Type)
+	}
+	if state.Metadata == nil {
+		t.Fatal("state.Metadata is nil")
+	}
+	if state.Metadata.Title == nil || *state.Metadata.Title != "Track Title" {
+		t.Errorf("Title = %v, want \"Track Title\"", state.Metadata.Title)
+	}
+	if state.Metadata.Artist == nil || *state.Metadata.Artist != "Artist Name" {
+		t.Errorf("Artist = %v, want \"Artist Name\"", state.Metadata.Artist)
+	}
+	if state.Metadata.Album == nil || *state.Metadata.Album != "Album Name" {
+		t.Errorf("Album = %v, want \"Album Name\"", state.Metadata.Album)
+	}
+	if state.Metadata.Timestamp != 42 {
+		t.Errorf("Timestamp = %d, want 42", state.Metadata.Timestamp)
+	}
+
+	expectNoSend(t, playerClient, 30*time.Millisecond, "non-metadata client")
+}
+
+// TestMetadataRole_OnPlaybackStateChanged_IgnoresNonPlayingTransitions
+// asserts that transitions that aren't "* → playing" (excluding
+// playing→playing) do not broadcast.
+func TestMetadataRole_OnPlaybackStateChanged_IgnoresNonPlayingTransitions(t *testing.T) {
+	g := NewGroup("test-group")
+	defer g.Close()
+
+	meta := NewMetadataRole(MetadataConfig{
+		GetMetadata: func() (string, string, string) { return "t", "a", "al" },
+		ClockMicros: func() int64 { return 0 },
+	})
+	g.RegisterRole(meta)
+
+	sc := &ServerClient{
+		id:       "meta-c",
+		roles:    []string{"metadata@v1"},
+		sendChan: make(chan interface{}, 10),
+	}
+	g.addClient(sc)
+	<-sc.sendChan // group/update
+
+	// Drain any OnClientJoin send that landed.
+	time.Sleep(20 * time.Millisecond)
+	select {
+	case <-sc.sendChan:
+	default:
+	}
+
+	cases := []struct {
+		oldState, newState string
+	}{
+		{"playing", "paused"},
+		{"playing", "stopped"},
+		{"stopped", "paused"},
+		{"playing", "playing"}, // would have been filtered by Group; pin role-level guard too
+	}
+
+	for _, tc := range cases {
+		t.Logf("trying transition %s -> %s (must not broadcast)", tc.oldState, tc.newState)
+		meta.OnPlaybackStateChanged(tc.oldState, tc.newState)
+		expectNoSend(t, sc, 30*time.Millisecond, tc.oldState+"->"+tc.newState)
+	}
+
+	// Sanity: stopped -> playing IS broadcast.
+	t.Log("sanity: stopped -> playing must broadcast")
+	meta.OnPlaybackStateChanged("stopped", "playing")
+	msg, state := drainServerStateMessage(t, sc)
+	t.Logf("sanity broadcast received: type=%s metadata=%+v", msg.Type, state.Metadata)
+}
+
+// TestMetadataRole_BroadcastMetadata_BroadcastsRegardlessOfState confirms
+// that the public BroadcastMetadata method pushes the snapshot to every
+// metadata-role client unconditionally.
+func TestMetadataRole_BroadcastMetadata_BroadcastsRegardlessOfState(t *testing.T) {
+	g := NewGroup("test-group")
+	defer g.Close()
+
+	meta := NewMetadataRole(MetadataConfig{
+		GetMetadata: func() (string, string, string) {
+			return "Updated Title", "Updated Artist", "Updated Album"
+		},
+		ClockMicros: func() int64 { return 100 },
+	})
+	g.RegisterRole(meta)
+
+	sc1 := &ServerClient{
+		id:       "meta-1",
+		roles:    []string{"metadata@v1"},
+		sendChan: make(chan interface{}, 10),
+	}
+	sc2 := &ServerClient{
+		id:       "meta-2",
+		roles:    []string{"metadata@v2"}, // versioned form must still match
+		sendChan: make(chan interface{}, 10),
+	}
+	scPlayer := &ServerClient{
+		id:       "player-1",
+		roles:    []string{"player@v1"},
+		sendChan: make(chan interface{}, 10),
+	}
+
+	g.addClient(sc1)
+	g.addClient(sc2)
+	g.addClient(scPlayer)
+	<-sc1.sendChan
+	<-sc2.sendChan
+	<-scPlayer.sendChan
+
+	// Drain join-time server/state on the metadata clients.
+	time.Sleep(20 * time.Millisecond)
+	for _, sc := range []*ServerClient{sc1, sc2} {
+		select {
+		case <-sc.sendChan:
+		default:
+		}
+	}
+
+	meta.BroadcastMetadata()
+
+	msg1, state1 := drainServerStateMessage(t, sc1)
+	t.Logf("sc1 (metadata@v1) received: type=%s metadata=%+v", msg1.Type, state1.Metadata)
+	if state1.Metadata == nil || state1.Metadata.Title == nil || *state1.Metadata.Title != "Updated Title" {
+		t.Errorf("sc1: title = %v, want \"Updated Title\"", state1.Metadata)
+	}
+
+	msg2, state2 := drainServerStateMessage(t, sc2)
+	t.Logf("sc2 (metadata@v2) received: type=%s metadata=%+v", msg2.Type, state2.Metadata)
+	if state2.Metadata == nil || state2.Metadata.Title == nil || *state2.Metadata.Title != "Updated Title" {
+		t.Errorf("sc2: title = %v, want \"Updated Title\"", state2.Metadata)
+	}
+
+	expectNoSend(t, scPlayer, 30*time.Millisecond, "player-only client")
+}
+
+// TestMetadataRole_OnPlaybackStateChanged_FiresFromGroupEvent is the
+// end-to-end wiring proof: register the role on a real Group, attach a
+// metadata-role client, call g.SetPlaybackState("stopped") then
+// g.SetPlaybackState("playing"), assert the client received the broadcast
+// via the dispatcher path.
+func TestMetadataRole_OnPlaybackStateChanged_FiresFromGroupEvent(t *testing.T) {
+	g := NewGroup("test-group")
+	defer g.Close()
+
+	meta := NewMetadataRole(MetadataConfig{
+		GetMetadata: func() (string, string, string) {
+			return "E2E Title", "E2E Artist", "E2E Album"
+		},
+		ClockMicros: func() int64 { return 7 },
+	})
+	g.RegisterRole(meta)
+
+	sc := &ServerClient{
+		id:       "meta-c",
+		name:     "metadata client",
+		roles:    []string{"metadata@v1"},
+		sendChan: make(chan interface{}, 10),
+	}
+	g.addClient(sc)
+	<-sc.sendChan // group/update
+
+	// Drain join-time server/state.
+	time.Sleep(20 * time.Millisecond)
+	select {
+	case msg := <-sc.sendChan:
+		t.Logf("drained join-time send: %+v", msg)
+	default:
+	}
+
+	// Default playback state is "playing"; transition through stopped to
+	// trigger an actual stopped→playing edge.
+	g.SetPlaybackState("stopped")
+	g.SetPlaybackState("playing")
+
+	// Wait for the dispatcher to deliver, then assert.
+	deadline := time.After(200 * time.Millisecond)
+	for {
+		select {
+		case raw := <-sc.sendChan:
+			msg, ok := raw.(protocol.Message)
+			if !ok {
+				t.Fatalf("queued send was %T, want protocol.Message", raw)
+			}
+			if msg.Type != "server/state" {
+				continue
+			}
+			state, ok := msg.Payload.(protocol.ServerStateMessage)
+			if !ok {
+				t.Fatalf("Message.Payload was %T, want ServerStateMessage", msg.Payload)
+			}
+			t.Logf("E2E broadcast received: type=%s metadata=%+v", msg.Type, state.Metadata)
+			if state.Metadata == nil || state.Metadata.Title == nil || *state.Metadata.Title != "E2E Title" {
+				t.Errorf("E2E broadcast title = %v, want \"E2E Title\"", state.Metadata)
+			}
+			return
+		case <-deadline:
+			t.Fatal("timed out waiting for E2E broadcast via SetPlaybackState")
+		}
+	}
+}
+
+// TestMetadataRole_BroadcastMetadata_ConcurrentCallsAreSafe runs many
+// parallel BroadcastMetadata calls and asserts no panics, no races, and
+// every call lands at least one send on the metadata client. The fake
+// client's sendChan has capacity 200; the test bounds itself to fewer
+// broadcasts so we don't need to drain in parallel.
+func TestMetadataRole_BroadcastMetadata_ConcurrentCallsAreSafe(t *testing.T) {
+	g := NewGroup("test-group")
+	defer g.Close()
+
+	meta := NewMetadataRole(MetadataConfig{
+		GetMetadata: func() (string, string, string) { return "t", "a", "al" },
+		ClockMicros: func() int64 { return 0 },
+	})
+	g.RegisterRole(meta)
+
+	sc := &ServerClient{
+		id:       "meta-c",
+		roles:    []string{"metadata@v1"},
+		sendChan: make(chan interface{}, 200),
+	}
+	g.addClient(sc)
+	<-sc.sendChan
+
+	// Drain any join-time send.
+	time.Sleep(20 * time.Millisecond)
+	select {
+	case <-sc.sendChan:
+	default:
+	}
+
+	const callers = 10
+	const perCaller = 5
+	var wg sync.WaitGroup
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perCaller; j++ {
+				meta.BroadcastMetadata()
+			}
+		}()
+	}
+	wg.Wait()
+
+	count := 0
+loop:
+	for {
+		select {
+		case <-sc.sendChan:
+			count++
+		default:
+			break loop
+		}
+	}
+	t.Logf("concurrent broadcasts queued %d sends (callers=%d, perCaller=%d)", count, callers, perCaller)
+	if count == 0 {
+		t.Error("expected at least one queued send from concurrent broadcasts, got 0")
 	}
 }


### PR DESCRIPTION
## Summary

Closes the same gap the player just hit against aiosendspin (issue I'll be filing separately), but on **our server side**: a metadata-role client can no longer find itself stuck on stale state when playback state transitions, and the server now has an explicit hook for re-broadcasting when the source's metadata changes mid-session.

## Changes

- `Group.SetPlaybackState` is now no-op on same-state writes and publishes a new `GroupPlaybackStateChangedEvent` with `OldState`/`NewState` on actual transitions.
- New optional `PlaybackStateChangedHandler` interface — roles opt in via type assertion; `GroupRole` itself is unchanged.
- `MetadataGroupRole.OnPlaybackStateChanged` re-broadcasts the current snapshot to every attached metadata-role client on `* → playing` transitions (excluding `playing → playing`).
- New public `(*MetadataGroupRole).BroadcastMetadata()` for explicit out-of-band re-broadcasts (e.g., HLS playlist advance, controller-driven track change).
- `attachToGroup` hook is unexported, invoked by `RegisterRole` inside the existing critical section so the role has its group reference before any event reaches the dispatcher.

## Why now

While testing PR #113 (player-side metadata tristate merge) against aiosendspin, the player showed "No metadata" between connect and the first next/prev. Root cause was server-side: aiosendspin emits `cleared_update` at connect (correct — nothing was loaded) but doesn't re-broadcast when the group transitions to playing. This PR makes our Go server defensively correct against the same scenario, *plus* gives us the explicit hook we need for any future metadata-mutation flow.

`Group.SetPlaybackState` is still dead code at the call site today (the audio engine streams continuously, no stopped state is ever emitted). But the wiring is now correct for when something does start using it.

## Verification

- `go vet` clean
- `golangci-lint` clean (modulo the documented Windows CRLF artifact)
- `go test -race -count=10 ./pkg/sendspin/...` — clean, 40.6s, no flakes
- `go test -race -count=1 ./...` — every package green
- `make conformance` 12/12 — wire format unchanged
- Independent validator audit passed all 12 verification items, no blockers/majors/minors

## Notable

- Zero changes to `pkg/protocol`, `pkg/sync`, `pkg/audio`, or anything outside `pkg/sendspin/`.
- `GroupRole` interface is byte-identical to main — no required methods added.
- Five new tests cover: same-state no-op, transition publish with correct old state, `OnPlaybackStateChanged` filter table including the `playing→playing` defensive case, `BroadcastMetadata` matching versioned role names (`metadata@v1`/`v2`), end-to-end via `SetPlaybackState`, and a concurrent-broadcast race test.

## Test plan

- [ ] CI green
- [ ] If/when audio engine grows a stopped state, verify connecting metadata-role clients still see metadata correctly after play resumes