### PR TITLE
fix(protocol): detect half-open WebSocket via ping/pong heartbeat

### DIFF
--- a/pkg/protocol/client.go
+++ b/pkg/protocol/client.go
@@ -34,6 +34,22 @@ const (
 	ArtworkChannelCount = 4
 )
 
+// Heartbeat parameters. Vars (not consts) so tests can override with shorter
+// values; production code never mutates them.
+//
+//	pingPeriod: how often we send a control Ping to the server.
+//	pongWait:   read deadline; reset on every Pong arrival.
+//	writeWait:  bound on each WriteControl call so a slow socket doesn't
+//	            block the ping goroutine forever.
+//
+// Invariant: pingPeriod < pongWait. Otherwise the deadline can expire
+// before our next ping has a chance to elicit a pong.
+var (
+	pingPeriod = 30 * time.Second
+	pongWait   = 60 * time.Second
+	writeWait  = 10 * time.Second
+)
+
 type Config struct {
 	ServerAddr          string
 	ClientID            string
@@ -173,9 +189,66 @@ func (c *Client) Start() error {
 		return fmt.Errorf("handshake failed: %w", err)
 	}
 
+	// Snapshot the heartbeat vars on Start's goroutine so the values we
+	// pass to pingLoop and the PongHandler are read here, not from the
+	// goroutines we're about to spawn. Tests mutate these package-level
+	// vars between test cases; the snapshot establishes a happens-before
+	// from the mutation site to the goroutine read, which the race
+	// detector requires.
+	pp, pw, ww := pingPeriod, pongWait, writeWait
+
+	// Install PongHandler that resets the read deadline. The handler runs
+	// synchronously from ReadMessage's goroutine, so SetReadDeadline is
+	// safe to call from here.
+	conn.SetPongHandler(func(string) error {
+		return conn.SetReadDeadline(time.Now().Add(pw))
+	})
+
+	// Initial deadline. If the server never pongs, ReadMessage in
+	// readMessages will hit this deadline and exit, triggering Close().
+	if err := conn.SetReadDeadline(time.Now().Add(pw)); err != nil {
+		c.Close()
+		return fmt.Errorf("set read deadline: %w", err)
+	}
+
 	go c.readMessages()
+	go c.pingLoop(pp, ww)
 
 	return nil
+}
+
+// pingLoop sends a periodic WebSocket control ping. The server's pong
+// reply arrives via the PongHandler installed in Start, which resets
+// the read deadline. Exits on context cancel or write failure; on
+// write failure we just return — readMessages's defer is responsible
+// for the Close, so calling it from here would race that path.
+//
+// The period and write deadline are passed as args (rather than read
+// from the package vars) so the read happens-before the goroutine
+// launch; tests that mutate the package vars between cases stay clean
+// under -race.
+func (c *Client) pingLoop(period, writeDeadline time.Duration) {
+	ticker := time.NewTicker(period)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			c.mu.RLock()
+			conn := c.conn
+			c.mu.RUnlock()
+			if conn == nil {
+				return
+			}
+			if err := conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(writeDeadline)); err != nil {
+				// Write failure on a control frame means the connection
+				// is going down. Don't bother retrying — readMessages
+				// will hit the read deadline and tear down.
+				return
+			}
+		case <-c.ctx.Done():
+			return
+		}
+	}
 }
 
 func (c *Client) handshake() error {

--- a/pkg/protocol/client_test.go
+++ b/pkg/protocol/client_test.go
@@ -497,6 +497,115 @@ func TestClientSend_WritesEnvelope(t *testing.T) {
 	}
 }
 
+// TestClient_DetectsHalfOpenConnection verifies that the client tears down
+// (Done() fires) when the server stops responding to WebSocket control
+// pings. Without the heartbeat fix, ReadMessage blocks forever after a
+// silently-dropped connection (NAT timeout, idle eviction, missed RST) and
+// Done() never closes — the symptom Chris saw in the field as "Burst sample
+// N/8 timed out" with no reconnect.
+//
+// The fake server completes the Sendspin handshake and then installs a
+// no-op PingHandler so the client's pings are read but never elicit a Pong.
+// The client's pongWait deadline expires, ReadMessage errors out, Close
+// runs from readMessages's defer, and Done() fires.
+func TestClient_DetectsHalfOpenConnection(t *testing.T) {
+	// Override the package-level heartbeat vars to test-friendly values
+	// so the test wallclock budget is well under a second. Restore via
+	// t.Cleanup so other tests in this binary keep production timings.
+	savedPingPeriod, savedPongWait, savedWriteWait := pingPeriod, pongWait, writeWait
+	pingPeriod = 50 * time.Millisecond
+	pongWait = 250 * time.Millisecond
+	writeWait = 100 * time.Millisecond
+	t.Cleanup(func() {
+		pingPeriod = savedPingPeriod
+		pongWait = savedPongWait
+		writeWait = savedWriteWait
+	})
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	serverDone := make(chan struct{})
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		defer close(serverDone)
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+
+		// Override the default PingHandler so the server does NOT auto-pong.
+		// This is the half-open simulation: pings arrive but no pong reply
+		// goes back. Returning nil keeps ReadMessage from surfacing an error,
+		// so the server happily reads forever while the client's read deadline
+		// counts down on the other side.
+		conn.SetPingHandler(func(string) error { return nil })
+
+		// Sendspin handshake: client/hello → server/hello → client/state.
+		if _, _, err := conn.ReadMessage(); err != nil {
+			t.Errorf("read client/hello: %v", err)
+			return
+		}
+		if err := conn.WriteJSON(Message{
+			Type:    "server/hello",
+			Payload: ServerHello{ServerID: "srv", Name: "srv", Version: 1},
+		}); err != nil {
+			t.Errorf("write server/hello: %v", err)
+			return
+		}
+		if _, _, err := conn.ReadMessage(); err != nil {
+			t.Errorf("read client/state: %v", err)
+			return
+		}
+
+		// Drain any further frames (the client's pings) until the connection
+		// errors out from the client side. We don't pong, so the client's
+		// read deadline will fire and it will close the socket.
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	client := NewClientFromConn(Config{
+		ClientID:       "half-open-test",
+		Name:           "Half Open Test",
+		Version:        1,
+		SupportedRoles: []string{"controller@v1"},
+	}, conn)
+	defer client.Close()
+
+	if err := client.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// pongWait + slack. If Done() doesn't fire, the heartbeat is broken.
+	select {
+	case <-client.Done():
+	case <-time.After(750 * time.Millisecond):
+		t.Fatal("Done() did not fire within pongWait + slack; half-open connection went undetected")
+	}
+
+	// Idempotent shutdown: calling Close again must not panic.
+	client.Close()
+
+	// Let the server goroutine unwind so the test doesn't leak it.
+	select {
+	case <-serverDone:
+	case <-time.After(500 * time.Millisecond):
+		t.Log("server handler did not unwind in time (not fatal; client side already verified)")
+	}
+}
+
 // TestHandshake_PlayerSupportGatedByRoles is a regression test for a real
 // bug caught by the conformance harness against aiosendspin. The Go
 // library used to emit player@v1_support in every client/hello regardless


### PR DESCRIPTION
## Summary

Closes the half-open-connection bug observed in the field: 4 minutes of correct operation, then `Burst sample N/8 timed out` for every subsequent burst, no \"Server connection lost\" log, audio stops. WebSocket connection silently closed (NAT timeout, server-side eviction, anything) and we never noticed.

Today \`pkg/protocol/client.go\` clears the read deadline after handshake and never sets it again. No ping. No pong handler. \`ReadMessage\` blocks forever waiting for data that won't come, so \`Done()\` never fires.

## Fix

Standard gorilla/websocket heartbeat pattern:

- \`pingPeriod = 30s\`, \`pongWait = 60s\`, \`writeWait = 10s\` as package vars (lowercase, unexported)
- After handshake: install \`PongHandler\` that resets read deadline, set initial deadline
- New \`pingLoop\` goroutine sends \`WriteControl(PingMessage)\` every \`pingPeriod\`
- On \`pongWait\` expiry: \`ReadMessage\` returns \`i/o timeout\` → \`readMessages\` defers \`Close\` → ctx cancels → \`Done()\` fires → \`Receiver.watchConnection\` cancels the receiver → reconnect logic kicks in (default behavior)

## Concurrency

- \`WriteControl\` is gorilla-documented as concurrent-safe with \`WriteJSON\` — pingLoop and any caller's \`sendJSON\` don't fight
- \`PongHandler\` runs synchronously from \`ReadMessage\`'s goroutine, so its \`SetReadDeadline\` call is on the read goroutine where it belongs

## Notable: race-detector fix that diverged from plan

Plan called for \`func (c *Client) pingLoop()\` reading the package vars directly. Implementer caught a real \`-race\` hazard during full-suite runs: tests mutate the vars in \`t.Cleanup\`, but a stale pingLoop from a prior test could still be reading them on its own goroutine without a happens-before edge. Fix is to snapshot vars at \`Start\`'s call site and pass them as args. Validator independently confirmed this is sound and necessary.

## Test

\`TestClient_DetectsHalfOpenConnection\` stands up a fake server with a **no-op \`PingHandler\`** (suppressing gorilla's default auto-pong, simulating the half-open state), overrides the heartbeat vars to 50/250/100 ms via \`t.Cleanup\`, and asserts \`Done()\` fires within 750 ms. Without the no-op override the test would silently pass even with the bug — the override is what makes it a real regression detector.

**Validator independently verified the test fails against \`origin/main\` code** (by stashing \`client.go\` while keeping the test in place). Pre-fix: 750ms timeout, \"Done() did not fire\". Post-fix: 250ms with \`i/o timeout\`. The \`i/o timeout\` log signal is itself diagnostic — if you ever see \"closed network connection\" instead, the heartbeat path didn't actually fire.

## Verification

- \`go vet\` clean
- \`go test -race -count=10 ./pkg/protocol/...\` clean (6.2s, no flakes)
- \`go test -race -count=1 ./...\` all 13 packages green
- \`make conformance\` 12/12 — wire format unchanged (control pings are stdlib-handled, not protocol messages)
- Independent validator audit: APPROVED with no blockers/majors/minors

## Notes for follow-up

- **Server-side parity**: \`pkg/protocol/server_conn.go\` and the audio engine in \`internal/server/\` don't run a complementary heartbeat. If a player goes silent under the same half-open conditions, the server keeps pacing audio bookkeeping into a dead socket until TCP keepalive fires (much longer). Worth a separate PR.
- **Production tunability**: heartbeat constants are package vars only for test-mutability. If a deployment hits a NAT with a < 60s idle timeout, exposing them via \`Config\` is a separate ergonomics PR.

## Test plan

- [ ] CI green
- [ ] Manual: leave the player connected idle for >5 minutes against your aiosendspin server, confirm time-sync bursts continue indefinitely (or, if the server hangs up, the player reconnects within ~60s)