### PR TITLE
fix(audio): apply perceptual volume curve (vol/100)^1.5

### DIFF
--- a/pkg/audio/output/volume.go
+++ b/pkg/audio/output/volume.go
@@ -2,7 +2,11 @@
 // ABOUTME: Extracted from oto.go during the oto removal cleanup
 package output
 
-import "github.com/Sendspin/sendspin-go/pkg/audio"
+import (
+	"math"
+
+	"github.com/Sendspin/sendspin-go/pkg/audio"
+)
 
 // applyVolume applies volume and mute to samples with clipping protection.
 // Samples are expected to be in the int32 24-bit range.
@@ -26,9 +30,14 @@ func applyVolume(samples []int32, volume int, muted bool) []int32 {
 }
 
 // getVolumeMultiplier returns the float multiplier for a given volume/mute state.
+// Volume is mapped through the Sendspin perceptual curve (vol/100)^1.5 so the
+// gain tracks perceived loudness rather than raw amplitude. A linear vol/100
+// mapping outputs ~0.5 (-6 dB) at volume 50 where a conformant player outputs
+// ~0.354 (-9 dB); in a multi-room group that divergence makes this client
+// audibly louder than its peers at any volume below 100.
 func getVolumeMultiplier(volume int, muted bool) float64 {
 	if muted {
 		return 0.0
 	}
-	return float64(volume) / 100.0
+	return math.Pow(float64(volume)/100.0, 1.5)
 }

--- a/pkg/audio/output/volume_test.go
+++ b/pkg/audio/output/volume_test.go
@@ -3,42 +3,53 @@
 package output
 
 import (
+	"math"
 	"testing"
 
 	"github.com/Sendspin/sendspin-go/pkg/audio"
 )
 
 func TestVolumeMultiplier(t *testing.T) {
+	const tol = 1e-9
 	tests := []struct {
 		volume   int
 		muted    bool
 		expected float64
 	}{
-		{100, false, 1.0},
-		{50, false, 0.5},
-		{0, false, 0.0},
-		{80, true, 0.0}, // muted overrides volume
+		{100, false, 1.0},               // full scale is unchanged by the curve
+		{50, false, 0.3535533905932738}, // (0.5)^1.5 ≈ -9 dB, per the perceptual curve
+		{0, false, 0.0},                 // silence
+		{80, true, 0.0},                 // muted overrides volume
 	}
 
 	for _, tt := range tests {
 		result := getVolumeMultiplier(tt.volume, tt.muted)
-		if result != tt.expected {
+		if math.Abs(result-tt.expected) > tol {
 			t.Errorf("volume=%d muted=%v: expected %f, got %f",
 				tt.volume, tt.muted, tt.expected, result)
 		}
 	}
 }
 
-func TestApplyVolume_HalfScale(t *testing.T) {
-	samples := []int32{1000 << 8, -1000 << 8}
+func TestApplyVolume_PerceptualMidScale(t *testing.T) {
+	// At volume 50 the perceptual curve (0.5)^1.5 yields ~0.354 gain, quieter
+	// than the 0.5 a linear mapping would produce. This is the audible
+	// conformance fix, so guard against a regression back to linear gain.
+	const sample = int32(1000 << 8)
+	samples := []int32{sample, -sample}
 
 	result := applyVolume(samples, 50, false)
 
-	if result[0] != int32(500<<8) {
-		t.Errorf("sample 0: expected %d, got %d", 500<<8, result[0])
+	want := int32(float64(sample) * math.Pow(0.5, 1.5))
+	if result[0] != want {
+		t.Errorf("sample 0: expected %d, got %d", want, result[0])
 	}
-	if result[1] != int32(-500<<8) {
-		t.Errorf("sample 1: expected %d, got %d", -500<<8, result[1])
+	if result[1] != -want {
+		t.Errorf("sample 1: expected %d, got %d", -want, result[1])
+	}
+	if result[0] >= sample/2 {
+		t.Errorf("perceptual gain at vol 50 (%d) should be quieter than linear half (%d)",
+			result[0], sample/2)
 	}
 }
 


### PR DESCRIPTION
## What

`getVolumeMultiplier` (`pkg/audio/output/volume.go`) applied gain linearly as `vol/100`. This maps the multiplier through the Sendspin perceptual curve `(vol/100)^1.5` instead.

## Why

Per the spec's volume-curve example, at volume 50 a conformant player outputs ≈ 0.354 amplitude (≈ −9 dB, perceived half-loudness). The linear mapping output ≈ 0.5 (≈ −6 dB). In a multi-room group, a Go client was therefore **audibly louder than its conformant peers at any volume below 100**.

- `0 → 0.0` and `100 → 1.0` endpoints are unchanged.
- `50 → 0.3536` now matches the spec example.
- Mute path is unchanged.

## Testing

- `go test -tags=nolibopusfile ./pkg/audio/...` — pass.
- Updated `TestVolumeMultiplier` and replaced `TestApplyVolume_HalfScale` with `TestApplyVolume_PerceptualMidScale`, which asserts the curved value **and** guards against a regression back to linear gain.

## Out of scope

The issue also suggests "consider a 20 ms gain ramp to avoid clicks." That is an independent anti-click concern (a ramp on volume *changes*, not the steady-state curve) and is intentionally left for a separate change.

Closes #116