### PR TITLE
fix(sendspin): validate static_delay_ms against spec range 0–5000

### DIFF
--- a/pkg/sendspin/scheduler.go
+++ b/pkg/sendspin/scheduler.go
@@ -14,6 +14,10 @@ import (
 	"github.com/Sendspin/sendspin-go/pkg/sync"
 )
 
+// maxStaticDelayMs is the upper bound the Sendspin spec defines for
+// static_delay_ms (integer, range 0–5000).
+const maxStaticDelayMs = 5000
+
 type Scheduler struct {
 	clockSync    *sync.ClockSync
 	bufferQ      *BufferQueue
@@ -41,8 +45,23 @@ type SchedulerStats struct {
 // bufferMs controls startup buffering (ms of audio to accumulate before playback).
 // staticDelayMs shifts every scheduled play time forward, compensating for
 // downstream hardware latency like Bluetooth sinks or AVRs. Zero means no shift.
+// Per the Sendspin spec static_delay_ms is an integer in the range 0–5000;
+// out-of-range values are clamped so a misbehaving server or bad local config
+// cannot push playback arbitrarily far out of sync.
 func NewScheduler(clockSync *sync.ClockSync, bufferMs int, staticDelayMs int) *Scheduler {
 	ctx, cancel := context.WithCancel(context.Background())
+
+	if staticDelayMs < 0 || staticDelayMs > maxStaticDelayMs {
+		clamped := staticDelayMs
+		if clamped < 0 {
+			clamped = 0
+		} else {
+			clamped = maxStaticDelayMs
+		}
+		log.Printf("static_delay_ms %d out of range [0,%d], clamping to %d",
+			staticDelayMs, maxStaticDelayMs, clamped)
+		staticDelayMs = clamped
+	}
 
 	// Calculate buffer target from user config (bufferMs / ChunkDurationMs)
 	bufferTarget := bufferMs / ChunkDurationMs

--- a/pkg/sendspin/scheduler_test.go
+++ b/pkg/sendspin/scheduler_test.go
@@ -68,3 +68,32 @@ func TestScheduler_StaticDelayDefaultZero(t *testing.T) {
 		t.Errorf("staticDelay with 0 arg = %v, want 0", sched.staticDelay)
 	}
 }
+
+// TestScheduler_StaticDelayClamped verifies that static_delay_ms values outside
+// the spec range 0–5000 are clamped rather than applied verbatim, so a bad
+// server value or local config cannot push playback arbitrarily out of sync.
+func TestScheduler_StaticDelayClamped(t *testing.T) {
+	cases := []struct {
+		name   string
+		in     int
+		wantMs int
+	}{
+		{"negative clamps to zero", -100, 0},
+		{"above max clamps to 5000", 9000, maxStaticDelayMs},
+		{"at max is unchanged", maxStaticDelayMs, maxStaticDelayMs},
+		{"in range is unchanged", 250, 250},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := sync.NewClockSync()
+			sched := NewScheduler(cs, 200, tc.in)
+			defer sched.Stop()
+
+			want := time.Duration(tc.wantMs) * time.Millisecond
+			if sched.staticDelay != want {
+				t.Errorf("staticDelay = %v, want %v", sched.staticDelay, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`NewScheduler` (`pkg/sendspin/scheduler.go`) applied `static_delay_ms` verbatim. This clamps it to the spec range `[0, 5000]` and logs when a value is adjusted.

## Why

Per spec, `static_delay_ms` is an integer in range 0–5000. The SDK did no range check, so an out-of-range value from a misbehaving server or a bad local config (negative, or far above the maximum) would shift scheduled playback arbitrarily out of sync.

The clamp lives at the single chokepoint (`NewScheduler`) that both the player- and receiver-config paths funnel through, mirroring the existing clamp style used by `Player.SetVolume`.

## Testing

- `go test -tags=nolibopusfile ./pkg/sendspin/...` — pass.
- Added `TestScheduler_StaticDelayClamped` (negative → 0, above-max → 5000, at-max and in-range unchanged).

Closes #124