### PR TITLE
feat(sendspin): add external_source client API

### DIFF
--- a/pkg/protocol/messages.go
+++ b/pkg/protocol/messages.go
@@ -91,7 +91,7 @@ type ClientStateMessage struct {
 
 // PlayerState reports the player's current state per spec
 type PlayerState struct {
-	State  string `json:"state"`            // "synchronized" or "error"
+	State  string `json:"state"`            // "synchronized", "error", or "external_source"
 	Volume int    `json:"volume,omitempty"` // 0-100, if volume command supported
 	Muted  bool   `json:"muted,omitempty"`  // if mute command supported
 }

--- a/pkg/sendspin/player.go
+++ b/pkg/sendspin/player.go
@@ -538,6 +538,39 @@ func (p *Player) SendCommand(command string) error {
 	return p.receiver.client.Send("client/command", payload)
 }
 
+// EnterExternalSource announces that this player is now driven by an external
+// system and is not participating in Sendspin playback, by sending client/state
+// with state "external_source". A conformant server moves the client to a solo
+// stopped group and ends its active streams (stream/end); the embedder owns
+// whatever local audio the external source produces. Call ExitExternalSource to
+// rejoin normal playback.
+func (p *Player) EnterExternalSource() error {
+	if p.receiver == nil || p.receiver.client == nil {
+		return fmt.Errorf("not connected")
+	}
+	if err := p.receiver.client.SendState(protocol.PlayerState{State: "external_source"}); err != nil {
+		return err
+	}
+	p.state.State = "external_source"
+	p.notifyStateChange()
+	return nil
+}
+
+// ExitExternalSource leaves external-source mode and rejoins normal Sendspin
+// playback by re-sending the synchronized client/state. A conformant server
+// returns the client to its previous group and resumes streaming.
+func (p *Player) ExitExternalSource() error {
+	if p.receiver == nil || p.receiver.client == nil {
+		return fmt.Errorf("not connected")
+	}
+	if err := p.sendState(); err != nil {
+		return err
+	}
+	p.state.State = "idle"
+	p.notifyStateChange()
+	return nil
+}
+
 func (p *Player) sendState() error {
 	if p.receiver == nil || p.receiver.client == nil {
 		return nil

--- a/pkg/sendspin/player_test.go
+++ b/pkg/sendspin/player_test.go
@@ -8,6 +8,25 @@ import (
 	"time"
 )
 
+// TestPlayer_ExternalSourceNotConnected guards #123: the external-source
+// API surface must fail cleanly (not panic) when there is no connection.
+func TestPlayer_ExternalSourceNotConnected(t *testing.T) {
+	player, err := NewPlayer(PlayerConfig{
+		ServerAddr: "localhost:8927",
+		PlayerName: "Test Player",
+	})
+	if err != nil {
+		t.Fatalf("NewPlayer: %v", err)
+	}
+
+	if err := player.EnterExternalSource(); err == nil {
+		t.Error("EnterExternalSource on a disconnected player should error")
+	}
+	if err := player.ExitExternalSource(); err == nil {
+		t.Error("ExitExternalSource on a disconnected player should error")
+	}
+}
+
 func TestNewPlayer_Defaults(t *testing.T) {
 	player, err := NewPlayer(PlayerConfig{
 		ServerAddr: "localhost:8927",

--- a/pkg/sendspin/server_test.go
+++ b/pkg/sendspin/server_test.go
@@ -509,6 +509,100 @@ func TestServer_GroupReceivesEventsFromRealHandshake(t *testing.T) {
 	}
 }
 
+// TestServer_ExternalSourceStateEndToEnd guards #123: a client/state with
+// state "external_source" (exactly what Player.EnterExternalSource sends)
+// flows through the real handshake and surfaces as a ClientStateChangedEvent
+// the server can act on.
+func TestServer_ExternalSourceStateEndToEnd(t *testing.T) {
+	server, err := NewServer(ServerConfig{
+		Port:   0,
+		Name:   "External Source Test",
+		Source: NewTestTone(48000, 2),
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	events, unsubscribe := server.Group().Subscribe()
+	defer unsubscribe()
+
+	errChan := make(chan error, 1)
+	go func() { errChan <- server.Start() }()
+	defer func() {
+		server.Stop()
+		select {
+		case <-errChan:
+		case <-time.After(5 * time.Second):
+			t.Error("server did not stop within timeout")
+		}
+	}()
+
+	port := waitForServerPort(t, server)
+	time.Sleep(200 * time.Millisecond)
+
+	conn, _, err := websocket.DefaultDialer.Dial(fmt.Sprintf("ws://localhost:%d/sendspin", port), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	hello := protocol.Message{
+		Type: "client/hello",
+		Payload: protocol.ClientHello{
+			ClientID:       "external-source-client",
+			Name:           "External Source Client",
+			Version:        1,
+			SupportedRoles: []string{"player@v1"},
+			PlayerV1Support: &protocol.PlayerV1Support{
+				SupportedFormats: []protocol.AudioFormat{
+					{Codec: "pcm", Channels: 2, SampleRate: 48000, BitDepth: 24},
+				},
+				BufferCapacity: 1048576,
+			},
+		},
+	}
+	if err := conn.WriteJSON(hello); err != nil {
+		t.Fatalf("write hello: %v", err)
+	}
+
+	// Drain the join event first.
+	select {
+	case evt := <-events:
+		if _, ok := evt.(ClientJoinedEvent); !ok {
+			t.Fatalf("first event = %T, want ClientJoinedEvent", evt)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for ClientJoinedEvent")
+	}
+
+	// Send the external_source state exactly as Player.EnterExternalSource does.
+	stateMsg := protocol.Message{
+		Type: "client/state",
+		Payload: protocol.ClientStateMessage{
+			Player: &protocol.PlayerState{State: "external_source"},
+		},
+	}
+	if err := conn.WriteJSON(stateMsg); err != nil {
+		t.Fatalf("write client/state: %v", err)
+	}
+
+	// Expect the matching ClientStateChangedEvent (ignoring unrelated events).
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case evt := <-events:
+			if sc, ok := evt.(ClientStateChangedEvent); ok {
+				if sc.State != "external_source" {
+					t.Errorf("ClientStateChangedEvent.State = %q, want %q", sc.State, "external_source")
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for ClientStateChangedEvent(external_source)")
+		}
+	}
+}
+
 // TestServer_ControllerCommandEndToEnd exercises the full client/command
 // pipeline: Server + ControllerGroupRole + real WebSocket handshake +
 // client/command message → OnCommand callback fires.


### PR DESCRIPTION
## What

Adds two methods to `Player`:
- `EnterExternalSource()` — sends `client/state` with `state: "external_source"`
- `ExitExternalSource()` — re-sends the `synchronized` state to rejoin normal playback

Both track `PlayerState.State` and fire `OnStateChange`; both error cleanly when not connected.

## Why

Per spec, a player can signal that it's being driven by an external system and is not participating in Sendspin playback. A conformant server then moves the client to a solo stopped group, sends `group/update`, and ends active streams (`stream/end`); on exit the server returns it to its previous group.

The Go SDK could *parse* `external_source` on the server side but had no client-side API to enter/leave it (mirrors `SendspinKit`'s `enterExternalSource()` / `exitExternalSource()`).

**This intentionally lands independently of server-side `external_source` handling** (which requires multi-group support the server doesn't have yet — tracked separately as a design item). A Go client can announce `external_source` to any conformant server today; our own server records the state via the existing `ClientStateChangedEvent` path.

## Testing

- `go test -tags=nolibopusfile ./pkg/sendspin/...` — pass.
- `TestPlayer_ExternalSourceNotConnected` — API fails cleanly (no panic) when disconnected.
- `TestServer_ExternalSourceStateEndToEnd` — real WebSocket handshake; `state: "external_source"` surfaces as a `ClientStateChangedEvent` through the live server wiring.

Closes #123