### PR TITLE
feat(sendspin): emit stream/request-format for format adaptation

### DIFF
--- a/pkg/protocol/client.go
+++ b/pkg/protocol/client.go
@@ -608,6 +608,20 @@ func (c *Client) SendGoodbye(reason string) error {
 	return c.sendJSON(msg)
 }
 
+// SendRequestFormat sends a stream/request-format message asking the server to
+// switch the player stream to a different codec/format. Zero-valued fields are
+// omitted, asking the server to keep the current value. The server responds
+// with a new stream/start.
+func (c *Client) SendRequestFormat(player RequestFormatPlayer) error {
+	msg := Message{
+		Type: "stream/request-format",
+		Payload: StreamRequestFormat{
+			Player: &player,
+		},
+	}
+	return c.sendJSON(msg)
+}
+
 func (c *Client) SendTimeSync(t1 int64) error {
 	msg := Message{
 		Type: "client/time",

--- a/pkg/protocol/messages.go
+++ b/pkg/protocol/messages.go
@@ -245,6 +245,23 @@ type StreamEnd struct {
 	Roles []string `json:"roles,omitempty"` // Roles to end (omit = all)
 }
 
+// RequestFormatPlayer carries the player-role fields of a stream/request-format
+// message. All fields are optional per spec; an omitted (zero) field asks the
+// server to keep the current value for it.
+type RequestFormatPlayer struct {
+	Codec      string `json:"codec,omitempty"`
+	Channels   int    `json:"channels,omitempty"`
+	SampleRate int    `json:"sample_rate,omitempty"`
+	BitDepth   int    `json:"bit_depth,omitempty"`
+}
+
+// StreamRequestFormat is the client → server payload for stream/request-format,
+// used by clients to adapt the stream to changing network or CPU conditions.
+// The server responds with a new stream/start.
+type StreamRequestFormat struct {
+	Player *RequestFormatPlayer `json:"player,omitempty"`
+}
+
 // ClientGoodbye is sent before graceful disconnect
 type ClientGoodbye struct {
 	Reason string `json:"reason"` // "another_server", "shutdown", "restart", "user_request"

--- a/pkg/protocol/messages_test.go
+++ b/pkg/protocol/messages_test.go
@@ -4,8 +4,56 @@ package protocol
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
+
+func TestStreamRequestFormatMarshaling(t *testing.T) {
+	// A full request round-trips with all player fields present.
+	msg := Message{
+		Type: "stream/request-format",
+		Payload: StreamRequestFormat{
+			Player: &RequestFormatPlayer{
+				Codec:      "opus",
+				Channels:   2,
+				SampleRate: 48000,
+				BitDepth:   16,
+			},
+		},
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(data)
+	for _, want := range []string{
+		`"type":"stream/request-format"`,
+		`"player"`,
+		`"codec":"opus"`,
+		`"sample_rate":48000`,
+		`"bit_depth":16`,
+		`"channels":2`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("marshaled message missing %q\n got: %s", want, got)
+		}
+	}
+
+	// A partial request omits zero-valued fields (server keeps current value).
+	partial, err := json.Marshal(StreamRequestFormat{Player: &RequestFormatPlayer{Codec: "pcm"}})
+	if err != nil {
+		t.Fatalf("marshal partial: %v", err)
+	}
+	ps := string(partial)
+	if !strings.Contains(ps, `"codec":"pcm"`) {
+		t.Errorf("partial request missing codec: %s", ps)
+	}
+	for _, omitted := range []string{"sample_rate", "bit_depth", "channels"} {
+		if strings.Contains(ps, omitted) {
+			t.Errorf("partial request should omit zero-valued %q, got: %s", omitted, ps)
+		}
+	}
+}
 
 func TestClientHelloMarshaling(t *testing.T) {
 	hello := ClientHello{

--- a/pkg/sendspin/player.go
+++ b/pkg/sendspin/player.go
@@ -538,6 +538,31 @@ func (p *Player) SendCommand(command string) error {
 	return p.receiver.client.Send("client/command", payload)
 }
 
+// FormatRequest describes a stream/request-format ask. Any zero-valued field is
+// omitted, asking the server to keep the current value for it.
+type FormatRequest struct {
+	Codec      string // "pcm", "opus", "flac"
+	Channels   int
+	SampleRate int
+	BitDepth   int
+}
+
+// RequestFormat asks the server to switch the player stream to a different
+// format — for example dropping to a lower bitrate codec under network or CPU
+// pressure. The server responds by starting a new stream in the chosen format.
+// Returns an error if not connected.
+func (p *Player) RequestFormat(req FormatRequest) error {
+	if p.receiver == nil || p.receiver.client == nil {
+		return fmt.Errorf("not connected")
+	}
+	return p.receiver.client.SendRequestFormat(protocol.RequestFormatPlayer{
+		Codec:      req.Codec,
+		Channels:   req.Channels,
+		SampleRate: req.SampleRate,
+		BitDepth:   req.BitDepth,
+	})
+}
+
 func (p *Player) sendState() error {
 	if p.receiver == nil || p.receiver.client == nil {
 		return nil

--- a/pkg/sendspin/player_test.go
+++ b/pkg/sendspin/player_test.go
@@ -8,6 +8,21 @@ import (
 	"time"
 )
 
+// TestPlayer_RequestFormatNotConnected guards #127: RequestFormat must fail
+// cleanly (not panic) when there is no connection.
+func TestPlayer_RequestFormatNotConnected(t *testing.T) {
+	player, err := NewPlayer(PlayerConfig{
+		ServerAddr: "localhost:8927",
+		PlayerName: "Test Player",
+	})
+	if err != nil {
+		t.Fatalf("NewPlayer: %v", err)
+	}
+	if err := player.RequestFormat(FormatRequest{Codec: "opus"}); err == nil {
+		t.Error("RequestFormat on a disconnected player should error")
+	}
+}
+
 func TestNewPlayer_Defaults(t *testing.T) {
 	player, err := NewPlayer(PlayerConfig{
 		ServerAddr: "localhost:8927",


### PR DESCRIPTION
## What

Adds the `stream/request-format` client message end-to-end:
- Wire types `StreamRequestFormat` / `RequestFormatPlayer` (all player fields optional, `omitempty`).
- `protocol.Client.SendRequestFormat(...)`.
- Public `Player.RequestFormat(FormatRequest{...})` API.

## Why

The issue noted the message "exists and parsing works" — in fact there was **no** `stream/request-format` type, parsing, or emit path anywhere in the codebase. Per spec, clients use this to adapt the stream to changing network conditions or CPU constraints (the server replies with a new `stream/start`). This wires up the full client-side path.

Zero-valued fields are omitted so a caller can request just a codec change without forcing `sample_rate: 0` etc. — the server keeps the current value for omitted fields.

## Scope

This is the **manual** API. An automatic, buffer-health-driven adaptation *policy* (when to downgrade under sustained drops/underruns) is a separate design decision and intentionally not included here.

## Testing

- `go test -tags=nolibopusfile ./pkg/protocol/... ./pkg/sendspin/...` — pass.
- `TestStreamRequestFormatMarshaling` — asserts the exact wire shape (`type`, nested `player`, all fields) **and** that a partial request omits zero-valued fields.
- `TestPlayer_RequestFormatNotConnected` — API fails cleanly when disconnected.

The change is purely additive (a new opt-in outbound message); no existing message types or default behavior change. Worth a `make conformance` run in CI to confirm.

Closes #127