### PR TITLE
feat(sendspin): persist static_delay_ms across restarts

### DIFF
--- a/main.go
+++ b/main.go
@@ -186,6 +186,13 @@ func main() {
 		log.Fatalf("client_id: %v", err)
 	}
 
+	// Persist a static delay supplied on the CLI so it survives restarts and
+	// need not be re-supplied on every launch (per spec). Mirrors client_id
+	// persistence. Values already present in the config are left untouched.
+	if setByUser["static-delay-ms"] {
+		persistStaticDelay(*staticDelayMs, cfg, loadedConfigPath)
+	}
+
 	config := sendspin.PlayerConfig{
 		ServerAddr:     serverAddress,
 		PlayerName:     playerName,
@@ -400,6 +407,34 @@ func resolveClientID(override string, cfg *sendspin.PlayerConfigFile, loadedConf
 	}
 
 	return sendspin.ResolveClientID(override, fromConfig, persist)
+}
+
+// persistStaticDelay writes a CLI-supplied static delay back to the player
+// config so it survives restarts. Best-effort: failures are logged, not fatal.
+func persistStaticDelay(value int, cfg *sendspin.PlayerConfigFile, loadedConfigPath string) {
+	persistPath := loadedConfigPath
+	if persistPath == "" {
+		p, err := sendspin.DefaultPlayerConfigPath()
+		if err != nil {
+			log.Printf("static_delay_ms: no config path available for persistence: %v", err)
+			return
+		}
+		persistPath = p
+	}
+
+	var current *int
+	if cfg != nil {
+		current = cfg.StaticDelayMs
+	}
+
+	wrote, err := sendspin.PersistStaticDelay(persistPath, current, value)
+	if err != nil {
+		log.Printf("static_delay_ms: failed to persist: %v", err)
+		return
+	}
+	if wrote {
+		log.Printf("static_delay_ms: persisted %d to %s", value, persistPath)
+	}
 }
 
 func statsUpdateLoop(player *sendspin.Player, updateTUI func(ui.StatusMsg)) {

--- a/pkg/sendspin/config.go
+++ b/pkg/sendspin/config.go
@@ -223,6 +223,20 @@ func (c *PlayerConfigFile) AsStringMap() map[string]string {
 // existing keys are preserved via yaml.Node round-tripping. Used to persist
 // the auto-generated client_id and the --client-id override.
 func WriteStringKey(path, key, value string) error {
+	return writeScalarKey(path, key, value, "!!str")
+}
+
+// WriteIntKey is like WriteStringKey but writes an integer scalar, for numeric
+// config fields (e.g. static_delay_ms) that load into int. A string scalar
+// would fail to unmarshal back into the typed config.
+func WriteIntKey(path, key string, value int) error {
+	return writeScalarKey(path, key, strconv.Itoa(value), "!!int")
+}
+
+// writeScalarKey reads the YAML at path (if any), sets the given top-level key
+// to a scalar carrying valueTag, and atomically writes the result back.
+// Comments and existing keys are preserved via yaml.Node round-tripping.
+func writeScalarKey(path, key, value, valueTag string) error {
 	var root yaml.Node
 
 	if data, err := os.ReadFile(path); err == nil {
@@ -235,13 +249,28 @@ func WriteStringKey(path, key, value string) error {
 
 	mapping := topLevelMapping(&root)
 
-	setOrAppendStringKey(mapping, key, value)
+	setOrAppendScalarKey(mapping, key, value, valueTag)
 
 	buf, err := yaml.Marshal(&root)
 	if err != nil {
 		return fmt.Errorf("marshal config: %w", err)
 	}
 	return atomicWriteFile(path, buf)
+}
+
+// PersistStaticDelay writes static_delay_ms to the YAML config at path so the
+// value survives restarts and the embedder need not re-supply it on every
+// connect (per spec). It is a no-op when current already equals value, so a
+// launch that merely reuses the persisted value doesn't rewrite the file.
+// Returns whether a write occurred.
+func PersistStaticDelay(path string, current *int, value int) (bool, error) {
+	if current != nil && *current == value {
+		return false, nil
+	}
+	if err := WriteIntKey(path, "static_delay_ms", value); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // topLevelMapping returns the mapping node that backs the top of a YAML
@@ -256,14 +285,15 @@ func topLevelMapping(root *yaml.Node) *yaml.Node {
 	return mapping
 }
 
-// setOrAppendStringKey updates the value for key in a MappingNode, or appends
-// a new key/value pair if the key is not present. Leaves all other entries
-// (and their comments) untouched.
-func setOrAppendStringKey(mapping *yaml.Node, key, value string) {
+// setOrAppendScalarKey updates the value for key in a MappingNode, or appends
+// a new key/value pair if the key is not present. The value node carries
+// valueTag (e.g. "!!str" or "!!int"); the key is always a string. Leaves all
+// other entries (and their comments) untouched.
+func setOrAppendScalarKey(mapping *yaml.Node, key, value, valueTag string) {
 	for i := 0; i+1 < len(mapping.Content); i += 2 {
 		if mapping.Content[i].Value == key {
 			mapping.Content[i+1].Kind = yaml.ScalarNode
-			mapping.Content[i+1].Tag = "!!str"
+			mapping.Content[i+1].Tag = valueTag
 			mapping.Content[i+1].Value = value
 			mapping.Content[i+1].Style = 0
 			return
@@ -271,7 +301,7 @@ func setOrAppendStringKey(mapping *yaml.Node, key, value string) {
 	}
 	mapping.Content = append(mapping.Content,
 		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
-		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: valueTag, Value: value},
 	)
 }
 

--- a/pkg/sendspin/config_test.go
+++ b/pkg/sendspin/config_test.go
@@ -395,3 +395,70 @@ func TestWriteStringKey_AppendsKeyWhenAbsent(t *testing.T) {
 		t.Errorf("new key missing: client_id = %q", cfg.ClientID)
 	}
 }
+
+// TestPersistStaticDelay guards #122: static_delay_ms is persisted to YAML so
+// the embedder need not re-supply it across restarts.
+func TestPersistStaticDelay(t *testing.T) {
+	t.Run("writes when absent and round-trips", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "player.yaml")
+
+		wrote, err := PersistStaticDelay(path, nil, 250)
+		if err != nil {
+			t.Fatalf("persist: %v", err)
+		}
+		if !wrote {
+			t.Error("expected a write when no value was persisted")
+		}
+
+		cfg, _, err := LoadPlayerConfig(path)
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if cfg.StaticDelayMs == nil || *cfg.StaticDelayMs != 250 {
+			t.Errorf("static_delay_ms = %v, want 250", cfg.StaticDelayMs)
+		}
+	})
+
+	t.Run("no-op when value unchanged", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "player.yaml")
+		current := 250
+
+		wrote, err := PersistStaticDelay(path, &current, 250)
+		if err != nil {
+			t.Fatalf("persist: %v", err)
+		}
+		if wrote {
+			t.Error("expected no write when value is unchanged")
+		}
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("no-op should not create the file: %v", err)
+		}
+	})
+
+	t.Run("overwrites a differing value", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "player.yaml")
+		if err := os.WriteFile(path, []byte("name: Den\nstatic_delay_ms: 100\n"), 0o600); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		current := 100
+
+		wrote, err := PersistStaticDelay(path, &current, 500)
+		if err != nil {
+			t.Fatalf("persist: %v", err)
+		}
+		if !wrote {
+			t.Error("expected a write when the value differs")
+		}
+
+		cfg, _, err := LoadPlayerConfig(path)
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if cfg.StaticDelayMs == nil || *cfg.StaticDelayMs != 500 {
+			t.Errorf("static_delay_ms = %v, want 500", cfg.StaticDelayMs)
+		}
+		if cfg.Name != "Den" {
+			t.Errorf("unrelated key lost: name = %q", cfg.Name)
+		}
+	})
+}


### PR DESCRIPTION
## What

A static delay supplied on the CLI (`--static-delay-ms`) is now written back to the player YAML config, so it persists across restarts. Adds:
- `PersistStaticDelay(path, current, value)` — no-op when the value is unchanged (avoids rewriting the file every launch).
- `WriteIntKey` — a numeric sibling of `WriteStringKey`.
- CLI wiring in `main.go` mirroring `client_id` persistence.

## Why

Per spec, the client should persist `static_delay_ms` locally across reboots and reconnections; today the embedder must re-supply it on every connect. This follows the existing `client_id` persistence pattern (the SDK `Player` doesn't own a config path; the CLI layer does), so persistence lives where the established precedent already is.

### Why `WriteIntKey` was needed

`WriteStringKey` always emits a quoted string scalar (`static_delay_ms: "250"`). That's correct for `client_id`, but a quoted string **fails to unmarshal** back into the `*int` `static_delay_ms` field (`cannot unmarshal !!str into int`) — a test caught this. `WriteIntKey` writes a proper `!!int` scalar. `WriteStringKey` and the `client_id` path are unchanged (shared helper, string tag preserved).

## Testing

- `go test -tags=nolibopusfile ./pkg/sendspin/...` — pass (incl. the existing `WriteStringKey` tests, confirming the string path is unchanged).
- `TestPersistStaticDelay` — writes-and-round-trips through `LoadPlayerConfig` (proving the int loads back), no-ops when unchanged, and overwrites a differing value while preserving unrelated keys.

## Note / possible follow-up

This persists a delay set via CLI/config. There is still no *runtime* setter to change `static_delay_ms` mid-session (it's applied at `NewScheduler`); if that's wanted later, it'd pair with this persistence. Pairs with the range validation in #129.

Closes #122