### PR TITLE
feat(sendspin): honor client/goodbye.reason for server re-dial

### DIFF
--- a/pkg/sendspin/client_dialer.go
+++ b/pkg/sendspin/client_dialer.go
@@ -5,6 +5,7 @@ package sendspin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -25,10 +26,18 @@ func clientInfoURL(info *discovery.ClientInfo) string {
 	return fmt.Sprintf("ws://%s:%d%s", info.Host, info.Port, path)
 }
 
+// errRetryRequested signals that a dialed connection completed normally but the
+// client asked to be re-dialed (it sent a "restart" goodbye). It is distinct
+// from a nil result (which latches the instance, never re-dialing) and from a
+// real dial error (which backs off).
+var errRetryRequested = errors.New("client requested re-dial (restart)")
+
 // dialAndHandle opens a WebSocket to a discovered client and hands the
-// connection to the provided handler. The handler is expected to block
-// until the connection is fully drained (e.g. handleConnection).
-func dialAndHandle(ctx context.Context, info *discovery.ClientInfo, handle func(*websocket.Conn)) error {
+// connection to the provided handler. The handler is expected to block until
+// the connection is fully drained (e.g. handleConnection) and to return whether
+// the client asked to be re-dialed. A true result is reported as
+// errRetryRequested so the dialer frees the slot for re-dial.
+func dialAndHandle(ctx context.Context, info *discovery.ClientInfo, handle func(*websocket.Conn) bool) error {
 	url := clientInfoURL(info)
 	dialer := websocket.Dialer{HandshakeTimeout: 10 * time.Second}
 
@@ -37,7 +46,9 @@ func dialAndHandle(ctx context.Context, info *discovery.ClientInfo, handle func(
 		return fmt.Errorf("dial %s: %w", url, err)
 	}
 	log.Printf("Dialed discovered client %s at %s", info.Name, url)
-	handle(conn)
+	if handle(conn) {
+		return errRetryRequested
+	}
 	return nil
 }
 
@@ -127,9 +138,11 @@ func (d *clientDialer) claim(instance string) bool {
 
 // release updates the instance slot after a dial attempt completes.
 // On success (dialErr == nil) the instance stays latched in the active
-// set — we never re-dial a successfully-connected instance. On error
-// it frees the slot and schedules an exponentially-backed-off cooldown
-// before the next retry.
+// set — we never re-dial a successfully-connected instance. When the client
+// asked to be re-dialed (errRetryRequested, a "restart" goodbye) the slot is
+// freed immediately with no cooldown so the next discovery event re-dials. On
+// any other error it frees the slot and schedules an exponentially-backed-off
+// cooldown before the next retry.
 func (d *clientDialer) release(instance string, dialErr error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -139,6 +152,16 @@ func (d *clientDialer) release(instance string, dialErr error) {
 		// events for this instance are silently ignored. The server
 		// already handled the connection; re-dialing would create a
 		// duplicate session.
+		delete(d.failures, instance)
+		delete(d.cooldown, instance)
+		return
+	}
+
+	if errors.Is(dialErr, errRetryRequested) {
+		// Client said "restart": it intends to return. Free the slot and
+		// clear any failure/cooldown so the next discovery event re-dials
+		// promptly rather than latching it out.
+		delete(d.active, instance)
 		delete(d.failures, instance)
 		delete(d.cooldown, instance)
 		return

--- a/pkg/sendspin/client_dialer_test.go
+++ b/pkg/sendspin/client_dialer_test.go
@@ -163,3 +163,28 @@ func TestClientDialerBackoffOnFailure(t *testing.T) {
 	cancel()
 	<-done
 }
+
+// TestClientDialerRetryOnRestart guards #117: a connection that ends with a
+// "restart" goodbye (surfaced as errRetryRequested) frees the instance slot
+// for re-dial, whereas a clean disconnect latches it.
+func TestClientDialerRetryOnRestart(t *testing.T) {
+	d := newClientDialer(make(chan *discovery.ClientInfo), func(context.Context, *discovery.ClientInfo) error { return nil })
+
+	const clean = "clean._sendspin._tcp.local."
+	if !d.claim(clean) {
+		t.Fatal("first claim of clean instance should succeed")
+	}
+	d.release(clean, nil)
+	if d.claim(clean) {
+		t.Error("instance should stay latched after a clean disconnect (no re-dial)")
+	}
+
+	const restart = "restart._sendspin._tcp.local."
+	if !d.claim(restart) {
+		t.Fatal("first claim of restart instance should succeed")
+	}
+	d.release(restart, errRetryRequested)
+	if !d.claim(restart) {
+		t.Error("instance should be re-claimable after a restart goodbye")
+	}
+}

--- a/pkg/sendspin/server.go
+++ b/pkg/sendspin/server.go
@@ -344,7 +344,11 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	s.handleConnection(conn)
 }
 
-func (s *Server) handleConnection(conn *websocket.Conn) {
+// handleConnection serves one client connection until it closes. The returned
+// retry flag is true only when the client left with a "restart" goodbye,
+// signalling that a server-dialed client should be re-dialed; it is ignored
+// for client-initiated connections.
+func (s *Server) handleConnection(conn *websocket.Conn) (retry bool) {
 	defer conn.Close()
 	conn.SetReadLimit(1 << 20) // 1MB
 
@@ -461,6 +465,11 @@ func (s *Server) handleConnection(conn *websocket.Conn) {
 
 		s.handleClientMessage(c, data)
 	}
+
+	// Once the connection has closed, a "restart" goodbye means the client
+	// intends to return — signal the dialer to re-dial. Any other reason (or
+	// none) leaves retry false so the client stays latched / not re-dialed.
+	return c.GoodbyeReason() == goodbyeReasonRestart
 }
 
 func (s *Server) clientWriter(c *ServerClient) {

--- a/pkg/sendspin/server_client.go
+++ b/pkg/sendspin/server_client.go
@@ -34,6 +34,8 @@ type ServerClient struct {
 	volume int
 	muted  bool
 
+	goodbyeReason string // reason from the last client/goodbye, if any
+
 	codec         string
 	opusEncoder   *server.OpusEncoder
 	flacEncoder   *server.FLACEncoder
@@ -131,6 +133,21 @@ func (c *ServerClient) Muted() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.muted
+}
+
+// setGoodbyeReason records the reason from a client/goodbye message.
+func (c *ServerClient) setGoodbyeReason(reason string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.goodbyeReason = reason
+}
+
+// GoodbyeReason returns the reason from the client's last client/goodbye, or
+// the empty string if none was received. Safe to call concurrently.
+func (c *ServerClient) GoodbyeReason() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.goodbyeReason
 }
 
 // Codec returns the currently-negotiated codec name ("pcm", "opus", "").

--- a/pkg/sendspin/server_dispatch.go
+++ b/pkg/sendspin/server_dispatch.go
@@ -9,6 +9,11 @@ import (
 	"github.com/Sendspin/sendspin-go/pkg/protocol"
 )
 
+// goodbyeReasonRestart is the client/goodbye reason that, per spec, means the
+// client intends to reconnect. Only this reason warrants re-dialing a
+// server-dialed client; "shutdown", "another_server", and "user_request" do not.
+const goodbyeReasonRestart = "restart"
+
 func (s *Server) handleClientMessage(c *ServerClient, data []byte) {
 	var msg protocol.Message
 	if err := json.Unmarshal(data, &msg); err != nil {
@@ -127,5 +132,11 @@ func (s *Server) handleClientGoodbye(c *ServerClient, payload interface{}) {
 	}
 
 	log.Printf("Client %s goodbye: %s", c.name, goodbye.Reason)
+
+	// Record the reason so handleConnection can decide, once the connection
+	// closes, whether a server-dialed client should be re-dialed. Per spec
+	// only "restart" implies the client will return; "shutdown",
+	// "another_server", and "user_request" do not.
+	c.setGoodbyeReason(goodbye.Reason)
 	// Connection close happens in handleConnection's read loop once this returns.
 }


### PR DESCRIPTION
## What

The server now acts on `client/goodbye.reason` for connections it dialed itself (discovery / server-dials-client mode):
- The reason is recorded on `ServerClient` (`setGoodbyeReason` / `GoodbyeReason()`).
- `handleConnection` returns a `retry` flag, true only when the reason is `"restart"`.
- The dialer frees the instance slot (no cooldown) on that signal so the next discovery event re-dials; any other reason keeps the instance latched.

## Why

Per spec, a `"restart"` goodbye means the client intends to reconnect, whereas `"shutdown"`, `"another_server"`, and `"user_request"` do not.

A note on the issue framing: it describes the current behavior as "restart is NOT auto-reconnected and shutdown IS — the inverse of the spec." In `sendspin-go` the actual prior behavior was **latch-all** — `client_dialer.go release()` latched *every* successfully-connected instance and never re-dialed it, regardless of reason. So nothing was re-dialed after a clean disconnect. This change introduces the spec-correct distinction: `restart` → re-dialable, everything else → latched.

This only affects the **server-dials-client** path; client-initiated connections own their own reconnection (`handleConnection`'s return is ignored there).

## Testing

- `go test -tags=nolibopusfile -race ./pkg/sendspin/...` — pass.
- `TestClientDialerRetryOnRestart` — a clean disconnect (`release(nil)`) keeps the instance latched (not re-claimable); a restart goodbye (`release(errRetryRequested)`) frees the slot for re-dial.
- Existing `TestClientDialerDedupesByInstance` / `TestClientDialerBackoffOnFailure` unchanged and passing.

## Limitation / follow-up

Freeing the slot relies on a subsequent mDNS discovery event to actually trigger the re-dial. If the discovery layer doesn't re-emit for an already-known instance, a restarted client may not be re-dialed until it re-advertises. A more active re-dial could be layered on later; this change implements the minimal spec-correct honoring at the dialer.

Closes #117