### PR TITLE
feat: move repeat/shuffle to controller state (spec#81) + client consumption

### DIFF
--- a/pkg/protocol/messages.go
+++ b/pkg/protocol/messages.go
@@ -221,11 +221,18 @@ type ProgressState struct {
 	PlaybackSpeed int `json:"playback_speed"` // Speed * 1000 (1000 = normal, 0 = paused)
 }
 
-// ControllerState contains controller state per spec
+// ControllerState contains controller state per spec.
+//
+// repeat and shuffle live here (not on MetadataState) as of spec#81:
+// they describe how playback behaves, alongside volume and mute. The
+// legacy MetadataState.Repeat/Shuffle fields are retained for
+// backward compatibility with v1 clients that read them from metadata.
 type ControllerState struct {
 	SupportedCommands []string `json:"supported_commands"`
-	Volume            int      `json:"volume"` // Group volume 0-100
-	Muted             bool     `json:"muted"`  // Group mute state
+	Volume            int      `json:"volume"`  // Group volume 0-100
+	Muted             bool     `json:"muted"`   // Group mute state
+	Repeat            string   `json:"repeat"`  // "off", "one", "all"
+	Shuffle           bool     `json:"shuffle"` // Shuffle enabled
 }
 
 // GroupUpdate is sent as group/update per spec

--- a/pkg/protocol/messages_test.go
+++ b/pkg/protocol/messages_test.go
@@ -7,6 +7,45 @@ import (
 	"testing"
 )
 
+func TestControllerState_RepeatShuffleRoundTrip(t *testing.T) {
+	cs := ControllerState{
+		SupportedCommands: []string{"repeat_all", "shuffle"},
+		Volume:            50,
+		Muted:             false,
+		Repeat:            "all",
+		Shuffle:           true,
+	}
+
+	data, err := json.Marshal(cs)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// repeat/shuffle are required controller-state fields per spec#81;
+	// they must always appear on the wire, even at zero value.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal to map: %v", err)
+	}
+	if _, ok := raw["repeat"]; !ok {
+		t.Errorf("marshaled controller state missing 'repeat' key: %s", data)
+	}
+	if _, ok := raw["shuffle"]; !ok {
+		t.Errorf("marshaled controller state missing 'shuffle' key: %s", data)
+	}
+
+	var got ControllerState
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Repeat != "all" {
+		t.Errorf("Repeat = %q, want %q", got.Repeat, "all")
+	}
+	if got.Shuffle != true {
+		t.Errorf("Shuffle = %v, want true", got.Shuffle)
+	}
+}
+
 func TestClientHelloMarshaling(t *testing.T) {
 	hello := ClientHello{
 		ClientID:       "test-id",

--- a/pkg/sendspin/controller_repeat_integration_test.go
+++ b/pkg/sendspin/controller_repeat_integration_test.go
@@ -1,0 +1,97 @@
+// ABOUTME: End-to-end test for controller repeat/shuffle (spec#81)
+// ABOUTME: Real Server + ControllerGroupRole + real Receiver over WebSocket
+package sendspin
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestController_RepeatShuffleEndToEnd is the full-stack scenario: a real
+// Server with a ControllerGroupRole, a real Receiver connecting over a
+// WebSocket, and a SetRepeat/SetShuffle call on the server that must show up
+// in the client's merged metadata snapshot. This exercises the spec#81
+// controller-state path across both implementations of the wire model in
+// this module (server broadcast -> protocol client -> receiver merge).
+func TestController_RepeatShuffleEndToEnd(t *testing.T) {
+	server, err := NewServer(ServerConfig{
+		Port:   0,
+		Name:   "Repeat E2E Server",
+		Source: NewTestTone(48000, 2),
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	ctrl := NewControllerRole(ControllerConfig{
+		SupportedCommands: []string{"repeat_off", "repeat_one", "repeat_all", "shuffle", "unshuffle"},
+		ClockMicros:       server.getClockMicros,
+	})
+	server.Group().RegisterRole(ctrl)
+
+	errChan := make(chan error, 1)
+	go func() { errChan <- server.Start() }()
+	defer func() {
+		server.Stop()
+		select {
+		case <-errChan:
+		case <-time.After(5 * time.Second):
+			t.Error("server stop timeout")
+		}
+	}()
+
+	port := waitForServerPort(t, server)
+
+	mc := &metadataCapture{}
+	recv, err := NewReceiver(ReceiverConfig{
+		ServerAddr: fmt.Sprintf("localhost:%d", port),
+		PlayerName: "Repeat E2E Client",
+		ClientID:   "repeat-e2e-client",
+		OnMetadata: mc.record,
+	})
+	if err != nil {
+		t.Fatalf("NewReceiver: %v", err)
+	}
+	defer recv.Close()
+
+	if err := recv.Connect(); err != nil {
+		t.Fatalf("Receiver.Connect: %v", err)
+	}
+
+	// Drain decoded audio so the scheduler never blocks on a full channel.
+	go func() {
+		for range recv.Output() {
+		}
+	}()
+
+	// Wait until the receiver has joined and we've seen the initial controller
+	// state (default repeat "off") before changing it, so the change is the
+	// observed transition rather than a race with the join snapshot.
+	waitFor(t, 3*time.Second, func() bool {
+		got, ok := mc.latest()
+		return ok && got.Repeat == "off"
+	}, "initial controller state (repeat=off) on join")
+
+	ctrl.SetRepeat("all")
+	ctrl.SetShuffle(true)
+
+	waitFor(t, 3*time.Second, func() bool {
+		got, ok := mc.latest()
+		return ok && got.Repeat == "all" && got.Shuffle
+	}, "controller repeat=all + shuffle=true after server SetRepeat/SetShuffle")
+}
+
+// waitFor polls cond until it returns true or the timeout elapses, failing
+// the test with desc on timeout.
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool, desc string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", desc)
+}

--- a/pkg/sendspin/group_role.go
+++ b/pkg/sendspin/group_role.go
@@ -25,6 +25,14 @@ type MessageHandler interface {
 	HandleMessage(c *ServerClient, payload json.RawMessage) error
 }
 
+// groupAware is an optional interface a GroupRole may implement to
+// receive a reference to its owning Group at registration time. Roles
+// that need to broadcast to all members (rather than only greet joining
+// clients) implement this. Unexported so the injection stays internal.
+type groupAware interface {
+	setGroup(g *Group)
+}
+
 // RegisterRole registers a GroupRole with this group. The role is
 // stored by its Role() family name. Duplicate registrations for the
 // same family overwrite the previous one.
@@ -40,6 +48,11 @@ func (g *Group) RegisterRole(role GroupRole) {
 		g.roles = make(map[string]GroupRole)
 	}
 	g.roles[role.Role()] = role
+
+	// Inject the owning group into roles that broadcast to members.
+	if ga, ok := role.(groupAware); ok {
+		ga.setGroup(g)
+	}
 
 	if g.roleDispatchStarted {
 		return

--- a/pkg/sendspin/player.go
+++ b/pkg/sendspin/player.go
@@ -124,7 +124,9 @@ type Metadata struct {
 	ArtworkURL  string
 	Track       int
 	Year        int
-	Duration    int // seconds
+	Duration    int    // seconds
+	Repeat      string // "off", "one", "all" (from controller state per spec#81)
+	Shuffle     bool   // shuffle enabled (from controller state per spec#81)
 }
 
 type PlayerState struct {

--- a/pkg/sendspin/receiver.go
+++ b/pkg/sendspin/receiver.go
@@ -90,10 +90,18 @@ type Receiver struct {
 	output          chan audio.Buffer
 	ctx             context.Context
 	cancel          context.CancelFunc
-	schedulerCtx    context.Context
 	schedulerCancel context.CancelFunc
 	serverAddr      string
 	connected       bool
+
+	// streamMu guards the stream-scoped fields that handleStreamStart
+	// swaps on each new stream (scheduler, decoder, format, schedulerCtx,
+	// schedulerCancel) against the goroutines that read them concurrently
+	// (handleAudioChunks, pumpSchedulerOutput, Stats, stream-clear and
+	// group-update handlers, Close). Readers snapshot the pointer under the
+	// lock and use it unlocked, so the lock is never held across a blocking
+	// decode/schedule/channel operation.
+	streamMu stdsync.Mutex
 
 	// Metadata merge state. mergedMetadata is the running snapshot fed to
 	// OnMetadata; pendingMetadata holds future-dated updates sorted by
@@ -165,16 +173,24 @@ func (r *Receiver) Done() <-chan struct{} {
 	return r.ctx.Done()
 }
 
+// currentScheduler returns the active scheduler under streamMu, or nil if no
+// stream has started. Callers use the returned pointer unlocked.
+func (r *Receiver) currentScheduler() *Scheduler {
+	r.streamMu.Lock()
+	defer r.streamMu.Unlock()
+	return r.scheduler
+}
+
 // Stats returns current pipeline statistics from the scheduler and clock sync.
 func (r *Receiver) Stats() ReceiverStats {
 	stats := ReceiverStats{}
 
-	if r.scheduler != nil {
-		s := r.scheduler.Stats()
+	if sched := r.currentScheduler(); sched != nil {
+		s := sched.Stats()
 		stats.Received = s.Received
 		stats.Played = s.Played
 		stats.Dropped = s.Dropped
-		stats.BufferDepth = r.scheduler.BufferDepth()
+		stats.BufferDepth = sched.BufferDepth()
 	}
 
 	if r.clockSync != nil {
@@ -288,24 +304,34 @@ func (r *Receiver) handleStreamStart() {
 				r.notifyError(fmt.Errorf("failed to create decoder: %w", err))
 				continue
 			}
-			r.decoder = decoder
-			r.format = format
-
 			if r.config.OnStreamStart != nil {
 				r.config.OnStreamStart(format)
 			}
 
-			if r.schedulerCancel != nil {
-				r.schedulerCancel()
+			newCtx, newCancel := context.WithCancel(r.ctx)
+			newScheduler := NewScheduler(r.clockSync, r.config.BufferMs, r.config.StaticDelayMs)
+
+			// Swap the stream-scoped state under the lock, capturing the
+			// previous scheduler/cancel so we can tear them down after
+			// releasing it (Stop/cancel must not run under streamMu).
+			r.streamMu.Lock()
+			oldScheduler := r.scheduler
+			oldCancel := r.schedulerCancel
+			r.decoder = decoder
+			r.format = format
+			r.schedulerCancel = newCancel
+			r.scheduler = newScheduler
+			r.streamMu.Unlock()
+
+			if oldCancel != nil {
+				oldCancel()
 			}
-			if r.scheduler != nil {
-				r.scheduler.Stop()
+			if oldScheduler != nil {
+				oldScheduler.Stop()
 			}
 
-			r.schedulerCtx, r.schedulerCancel = context.WithCancel(r.ctx)
-			r.scheduler = NewScheduler(r.clockSync, r.config.BufferMs, r.config.StaticDelayMs)
-			go r.scheduler.Run()
-			go r.pumpSchedulerOutput(r.schedulerCtx)
+			go newScheduler.Run()
+			go r.pumpSchedulerOutput(newCtx, newScheduler)
 
 		case <-r.ctx.Done():
 			return
@@ -330,11 +356,17 @@ func (r *Receiver) handleAudioChunks() {
 	for {
 		select {
 		case chunk := <-r.client.AudioChunks:
-			if r.decoder == nil || r.scheduler == nil {
+			r.streamMu.Lock()
+			decoder := r.decoder
+			scheduler := r.scheduler
+			format := r.format
+			r.streamMu.Unlock()
+
+			if decoder == nil || scheduler == nil {
 				continue
 			}
 
-			pcm, err := r.decoder.Decode(chunk.Data)
+			pcm, err := decoder.Decode(chunk.Data)
 			if err != nil {
 				r.notifyError(fmt.Errorf("decode error: %w", err))
 				continue
@@ -346,9 +378,9 @@ func (r *Receiver) handleAudioChunks() {
 			buf := audio.Buffer{
 				Timestamp: chunk.Timestamp,
 				Samples:   pcm,
-				Format:    r.format,
+				Format:    format,
 			}
-			r.scheduler.Schedule(buf)
+			scheduler.Schedule(buf)
 
 		case <-r.ctx.Done():
 			return
@@ -356,10 +388,10 @@ func (r *Receiver) handleAudioChunks() {
 	}
 }
 
-func (r *Receiver) pumpSchedulerOutput(ctx context.Context) {
+func (r *Receiver) pumpSchedulerOutput(ctx context.Context, sched *Scheduler) {
 	for {
 		select {
-		case buf := <-r.scheduler.Output():
+		case buf := <-sched.Output():
 			select {
 			case r.output <- buf:
 			case <-ctx.Done():
@@ -377,8 +409,8 @@ func (r *Receiver) handleStreamClear() {
 		case clear := <-r.client.StreamClear:
 			log.Printf("Stream clear received for roles: %v", clear.Roles)
 			if len(clear.Roles) == 0 || containsRole(clear.Roles, "player") {
-				if r.scheduler != nil {
-					r.scheduler.Clear()
+				if sched := r.currentScheduler(); sched != nil {
+					sched.Clear()
 				}
 			}
 		case <-r.ctx.Done():
@@ -404,9 +436,9 @@ func (r *Receiver) handleStreamEnd() {
 }
 
 // handleServerState reads server/state messages from the protocol client
-// and feeds metadata updates into the merge layer. Non-metadata fields
-// of ServerStateMessage are not used today; if/when they grow handlers
-// they should branch off here.
+// and feeds role-specific state into the merge layer: metadata updates go
+// through the timestamp-ordered queue, while controller state (repeat /
+// shuffle per spec#81) is a full snapshot that applies immediately.
 func (r *Receiver) handleServerState() {
 	for {
 		select {
@@ -414,9 +446,29 @@ func (r *Receiver) handleServerState() {
 			if state.Metadata != nil {
 				r.enqueueMetadata(state.Metadata)
 			}
+			if state.Controller != nil {
+				r.applyController(state.Controller)
+			}
 		case <-r.ctx.Done():
 			return
 		}
+	}
+}
+
+// applyController merges controller state (repeat / shuffle) onto the
+// running snapshot and fires OnMetadata. Controller state carries no
+// timestamp and is a full snapshot, so it applies immediately rather than
+// going through the metadata deferral queue.
+func (r *Receiver) applyController(c *protocol.ControllerState) {
+	r.metadataMu.Lock()
+	defer r.metadataMu.Unlock()
+
+	r.mergedMetadata.Repeat = c.Repeat
+	r.mergedMetadata.Shuffle = c.Shuffle
+
+	snapshot := r.mergedMetadata
+	if r.config.OnMetadata != nil {
+		r.config.OnMetadata(snapshot)
 	}
 }
 
@@ -512,6 +564,24 @@ func (r *Receiver) applyMetadataLocked(m *protocol.MetadataState) {
 			r.mergedMetadata.Duration = 0
 		}
 	}
+	// Legacy back-compat: a v1 server may still carry repeat/shuffle on the
+	// metadata state. The canonical source is controller state (spec#81,
+	// see applyController), but honor the metadata copy via the same
+	// tristate merge so older servers still drive the snapshot.
+	if m.HasField("repeat") {
+		if m.Repeat != nil {
+			r.mergedMetadata.Repeat = *m.Repeat
+		} else {
+			r.mergedMetadata.Repeat = ""
+		}
+	}
+	if m.HasField("shuffle") {
+		if m.Shuffle != nil {
+			r.mergedMetadata.Shuffle = *m.Shuffle
+		} else {
+			r.mergedMetadata.Shuffle = false
+		}
+	}
 
 	snapshot := r.mergedMetadata
 	if r.config.OnMetadata != nil {
@@ -562,8 +632,10 @@ func (r *Receiver) handleGroupUpdates() {
 			if update.PlaybackState != nil {
 				state := *update.PlaybackState
 				log.Printf("Group playback state: %s", state)
-				if (state == "paused" || state == "stopped") && r.scheduler != nil {
-					r.scheduler.Clear()
+				if state == "paused" || state == "stopped" {
+					if sched := r.currentScheduler(); sched != nil {
+						sched.Clear()
+					}
 				}
 			}
 			if update.GroupID != nil {
@@ -790,12 +862,17 @@ func (r *Receiver) Close() error {
 		r.client.Close()
 	}
 
-	if r.scheduler != nil {
-		r.scheduler.Stop()
+	r.streamMu.Lock()
+	scheduler := r.scheduler
+	decoder := r.decoder
+	r.streamMu.Unlock()
+
+	if scheduler != nil {
+		scheduler.Stop()
 	}
 
-	if r.decoder != nil {
-		if err := r.decoder.Close(); err != nil {
+	if decoder != nil {
+		if err := decoder.Close(); err != nil {
 			log.Printf("Receiver: decoder close error: %v", err)
 		}
 	}

--- a/pkg/sendspin/receiver_test.go
+++ b/pkg/sendspin/receiver_test.go
@@ -349,6 +349,86 @@ func newMetadataReceiver(t *testing.T, fakeNow int64, mc *metadataCapture) *Rece
 	return r
 }
 
+// TestReceiver_ControllerStateAppliesRepeatShuffle verifies the canonical
+// path: controller server/state (spec#81) drives the merged snapshot's
+// Repeat/Shuffle. Controller state is a full snapshot with no timestamp,
+// so it applies immediately.
+func TestReceiver_ControllerStateAppliesRepeatShuffle(t *testing.T) {
+	mc := &metadataCapture{}
+	r := newMetadataReceiver(t, 0, mc)
+
+	r.applyController(&protocol.ControllerState{Repeat: "all", Shuffle: true})
+
+	got, ok := mc.latest()
+	if !ok {
+		t.Fatal("OnMetadata was not invoked for controller state")
+	}
+	if got.Repeat != "all" {
+		t.Errorf("Repeat = %q, want %q", got.Repeat, "all")
+	}
+	if !got.Shuffle {
+		t.Error("Shuffle = false, want true")
+	}
+}
+
+// TestReceiver_ControllerStatePreservesTrackMetadata confirms a controller
+// update does not clobber previously-merged track fields (title etc.) — it
+// only touches Repeat/Shuffle.
+func TestReceiver_ControllerStatePreservesTrackMetadata(t *testing.T) {
+	mc := &metadataCapture{}
+	r := newMetadataReceiver(t, 0, mc)
+
+	r.enqueueMetadata(metadataStateWithKeys(t, map[string]any{
+		"timestamp": 0,
+		"title":     "Song A",
+		"artist":    "Artist X",
+	}))
+	r.applyController(&protocol.ControllerState{Repeat: "one", Shuffle: false})
+
+	got, _ := mc.latest()
+	if got.Title != "Song A" || got.Artist != "Artist X" {
+		t.Errorf("track metadata clobbered by controller update: %+v", got)
+	}
+	if got.Repeat != "one" {
+		t.Errorf("Repeat = %q, want %q", got.Repeat, "one")
+	}
+}
+
+// TestReceiver_MetadataLegacyRepeatShuffle verifies the back-compat path: a
+// v1 server that still carries repeat/shuffle on the metadata state is honored
+// via the same tristate merge as every other metadata field.
+func TestReceiver_MetadataLegacyRepeatShuffle(t *testing.T) {
+	mc := &metadataCapture{}
+	r := newMetadataReceiver(t, 0, mc)
+
+	r.enqueueMetadata(metadataStateWithKeys(t, map[string]any{
+		"timestamp": 0,
+		"repeat":    "one",
+		"shuffle":   true,
+	}))
+
+	got, ok := mc.latest()
+	if !ok {
+		t.Fatal("OnMetadata was not invoked")
+	}
+	if got.Repeat != "one" {
+		t.Errorf("Repeat = %q, want %q", got.Repeat, "one")
+	}
+	if !got.Shuffle {
+		t.Error("Shuffle = false, want true")
+	}
+
+	// A later diff that omits repeat/shuffle must preserve them.
+	r.enqueueMetadata(metadataStateWithKeys(t, map[string]any{
+		"timestamp": 0,
+		"title":     "Song B",
+	}))
+	got, _ = mc.latest()
+	if got.Repeat != "one" || !got.Shuffle {
+		t.Errorf("omitted repeat/shuffle not preserved across diff: %+v", got)
+	}
+}
+
 // TestReceiver_MetadataMergePreservesUnchangedFields is the headline
 // regression: a track A snapshot followed by a track B diff_update that
 // only carries `title` must not blank out artist/album. Pre-fix, the

--- a/pkg/sendspin/role_controller.go
+++ b/pkg/sendspin/role_controller.go
@@ -1,11 +1,12 @@
 // ABOUTME: ControllerGroupRole handles client/command messages
-// ABOUTME: Pushes controller capabilities to joining clients
+// ABOUTME: Owns group repeat/shuffle state and pushes controller state to clients
 package sendspin
 
 import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"sync"
 
 	"github.com/Sendspin/sendspin-go/pkg/protocol"
 )
@@ -13,49 +14,186 @@ import (
 // ControllerConfig configures the ControllerGroupRole.
 type ControllerConfig struct {
 	// SupportedCommands lists the media commands this server supports
-	// (e.g., "next", "previous", "play", "pause").
+	// (e.g., "next", "previous", "play", "pause", "repeat_all", "shuffle").
 	SupportedCommands []string
 
 	// OnCommand is called when a client sends a controller command.
 	// May be nil if the caller only wants to push capabilities.
 	OnCommand func(client *ServerClient, command string)
+
+	// Repeat is the group's initial repeat mode ("off", "one", "all").
+	// Empty defaults to "off".
+	Repeat string
+
+	// Shuffle is the group's initial shuffle state.
+	Shuffle bool
+
+	// ClockMicros returns the server's current clock in microseconds. When
+	// set, repeat/shuffle changes are mirrored into a metadata server/state
+	// for backward compatibility with v1 clients that read those fields from
+	// the metadata role (per spec#81 legacy support). When nil, no mirror is
+	// sent and only controller-role clients receive updates.
+	ClockMicros func() int64
 }
 
 // ControllerGroupRole handles the "controller" role family. It pushes
-// controller capabilities (supported commands) to clients that
-// advertise the controller role on join, and dispatches incoming
-// client/command payloads to an OnCommand callback.
+// controller state (supported commands plus repeat/shuffle) to clients
+// that advertise the controller role on join, dispatches incoming
+// client/command payloads to an OnCommand callback, and owns the group's
+// repeat/shuffle state. Changing that state via SetRepeat / SetShuffle
+// broadcasts a fresh controller server/state to all controller members.
 type ControllerGroupRole struct {
 	config ControllerConfig
+
+	mu      sync.Mutex
+	repeat  string
+	shuffle bool
+	group   *Group
 }
 
 // NewControllerRole creates a ControllerGroupRole with the given config.
 func NewControllerRole(config ControllerConfig) *ControllerGroupRole {
-	return &ControllerGroupRole{config: config}
+	repeat := config.Repeat
+	if repeat == "" {
+		repeat = "off"
+	}
+	return &ControllerGroupRole{
+		config:  config,
+		repeat:  repeat,
+		shuffle: config.Shuffle,
+	}
 }
 
 func (r *ControllerGroupRole) Role() string { return "controller" }
 
-// OnClientJoin sends controller state (supported commands) to clients
-// that advertise the controller role. Clients without the controller
-// role are skipped.
+// setGroup wires the owning Group into the role so state changes can be
+// broadcast to members. Called by Group.RegisterRole; the unexported name
+// keeps the injection internal to the package.
+func (r *ControllerGroupRole) setGroup(g *Group) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.group = g
+}
+
+// Repeat returns the current group repeat mode ("off", "one", "all").
+func (r *ControllerGroupRole) Repeat() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.repeat
+}
+
+// Shuffle returns the current group shuffle state.
+func (r *ControllerGroupRole) Shuffle() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.shuffle
+}
+
+// SetRepeat updates the group's repeat mode and broadcasts the new
+// controller state to members. A no-op (no broadcast) if the mode is
+// unchanged.
+func (r *ControllerGroupRole) SetRepeat(mode string) {
+	r.mu.Lock()
+	if r.repeat == mode {
+		r.mu.Unlock()
+		return
+	}
+	r.repeat = mode
+	r.mu.Unlock()
+	r.broadcastState()
+}
+
+// SetShuffle updates the group's shuffle state and broadcasts the new
+// controller state to members. A no-op (no broadcast) if unchanged.
+func (r *ControllerGroupRole) SetShuffle(on bool) {
+	r.mu.Lock()
+	if r.shuffle == on {
+		r.mu.Unlock()
+		return
+	}
+	r.shuffle = on
+	r.mu.Unlock()
+	r.broadcastState()
+}
+
+// OnClientJoin sends controller state (supported commands plus the current
+// repeat/shuffle) to clients that advertise the controller role. Clients
+// without the controller role are skipped.
 func (r *ControllerGroupRole) OnClientJoin(c *ServerClient) {
 	if !c.HasRole("controller") {
 		return
 	}
 
-	state := protocol.ServerStateMessage{
-		Controller: &protocol.ControllerState{
-			SupportedCommands: r.config.SupportedCommands,
-		},
-	}
-
-	if err := c.Send("server/state", state); err != nil {
+	if err := c.Send("server/state", r.controllerStateMessage()); err != nil {
 		log.Printf("ControllerRole: failed to send state to %s: %v", c.Name(), err)
 	}
 }
 
 func (r *ControllerGroupRole) OnClientLeave(id string, name string) {}
+
+// controllerStateMessage builds the controller server/state snapshot from
+// the current repeat/shuffle state.
+func (r *ControllerGroupRole) controllerStateMessage() protocol.ServerStateMessage {
+	r.mu.Lock()
+	repeat, shuffle := r.repeat, r.shuffle
+	r.mu.Unlock()
+
+	return protocol.ServerStateMessage{
+		Controller: &protocol.ControllerState{
+			SupportedCommands: r.config.SupportedCommands,
+			Repeat:            repeat,
+			Shuffle:           shuffle,
+		},
+	}
+}
+
+// broadcastState pushes the current controller state to every controller
+// member of the group. Metadata-only (v1) clients receive a mirrored
+// metadata server/state instead when ClockMicros is configured.
+func (r *ControllerGroupRole) broadcastState() {
+	r.mu.Lock()
+	g := r.group
+	repeat, shuffle := r.repeat, r.shuffle
+	r.mu.Unlock()
+
+	if g == nil {
+		return
+	}
+
+	ctrlState := protocol.ServerStateMessage{
+		Controller: &protocol.ControllerState{
+			SupportedCommands: r.config.SupportedCommands,
+			Repeat:            repeat,
+			Shuffle:           shuffle,
+		},
+	}
+
+	// Build the legacy metadata mirror once if a clock is available.
+	var mdState *protocol.ServerStateMessage
+	if r.config.ClockMicros != nil {
+		rp, sh := repeat, shuffle
+		mdState = &protocol.ServerStateMessage{
+			Metadata: &protocol.MetadataState{
+				Timestamp: r.config.ClockMicros(),
+				Repeat:    &rp,
+				Shuffle:   &sh,
+			},
+		}
+	}
+
+	for _, c := range g.Clients() {
+		switch {
+		case c.HasRole("controller"):
+			if err := c.Send("server/state", ctrlState); err != nil {
+				log.Printf("ControllerRole: failed to broadcast state to %s: %v", c.Name(), err)
+			}
+		case mdState != nil && c.HasRole("metadata"):
+			if err := c.Send("server/state", *mdState); err != nil {
+				log.Printf("ControllerRole: failed to mirror state to %s: %v", c.Name(), err)
+			}
+		}
+	}
+}
 
 // HandleMessage parses a controller command payload and invokes the
 // OnCommand callback.

--- a/pkg/sendspin/role_controller_test.go
+++ b/pkg/sendspin/role_controller_test.go
@@ -5,7 +5,39 @@ package sendspin
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/Sendspin/sendspin-go/pkg/protocol"
 )
+
+// drainSendChan empties a client's send channel without blocking, returning
+// the messages read. Used to discard setup messages (group/update, join
+// state) before asserting on a later broadcast.
+func drainSendChan(ch chan interface{}) []interface{} {
+	var out []interface{}
+	for {
+		select {
+		case m := <-ch:
+			out = append(out, m)
+		default:
+			return out
+		}
+	}
+}
+
+// controllerStateFrom extracts the ControllerState from a queued server/state
+// message, or nil if the message is not a controller server/state.
+func controllerStateFrom(t *testing.T, msg interface{}) *protocol.ControllerState {
+	t.Helper()
+	m, ok := msg.(protocol.Message)
+	if !ok || m.Type != "server/state" {
+		return nil
+	}
+	state, ok := m.Payload.(protocol.ServerStateMessage)
+	if !ok {
+		return nil
+	}
+	return state.Controller
+}
 
 func TestControllerRole_HandleCommand(t *testing.T) {
 	var received string
@@ -100,5 +132,158 @@ func TestControllerRole_Role(t *testing.T) {
 	ctrl := NewControllerRole(ControllerConfig{})
 	if ctrl.Role() != "controller" {
 		t.Errorf("Role() = %q, want %q", ctrl.Role(), "controller")
+	}
+}
+
+func TestControllerRole_DefaultRepeatOff(t *testing.T) {
+	ctrl := NewControllerRole(ControllerConfig{})
+	if got := ctrl.Repeat(); got != "off" {
+		t.Errorf("default Repeat() = %q, want %q", got, "off")
+	}
+	if ctrl.Shuffle() {
+		t.Error("default Shuffle() = true, want false")
+	}
+}
+
+func TestControllerRole_OnClientJoinIncludesRepeatShuffle(t *testing.T) {
+	ctrl := NewControllerRole(ControllerConfig{SupportedCommands: []string{"repeat_all", "shuffle"}})
+	ctrl.SetRepeat("all") // no group wired → state updates, no broadcast
+	ctrl.SetShuffle(true)
+
+	sc := &ServerClient{id: "c1", roles: []string{"controller@v1"}, sendChan: make(chan interface{}, 10)}
+	ctrl.OnClientJoin(sc)
+
+	msgs := drainSendChan(sc.sendChan)
+	if len(msgs) == 0 {
+		t.Fatal("OnClientJoin sent nothing")
+	}
+	cs := controllerStateFrom(t, msgs[0])
+	if cs == nil {
+		t.Fatalf("first message is not a controller server/state: %#v", msgs[0])
+	}
+	if cs.Repeat != "all" {
+		t.Errorf("join controller state Repeat = %q, want %q", cs.Repeat, "all")
+	}
+	if !cs.Shuffle {
+		t.Error("join controller state Shuffle = false, want true")
+	}
+}
+
+func TestControllerRole_RegisterRoleInjectsGroup(t *testing.T) {
+	g := NewGroup("g")
+	defer g.Close()
+
+	ctrl := NewControllerRole(ControllerConfig{})
+	g.RegisterRole(ctrl)
+
+	if ctrl.group != g {
+		t.Error("RegisterRole did not inject the group into the controller role")
+	}
+}
+
+func TestControllerRole_SetRepeatBroadcastsToControllerMembers(t *testing.T) {
+	g := NewGroup("g")
+	defer g.Close()
+
+	ctrl := NewControllerRole(ControllerConfig{SupportedCommands: []string{"repeat_all"}})
+	ctrl.setGroup(g)
+
+	c1 := &ServerClient{id: "c1", roles: []string{"controller@v1"}, sendChan: make(chan interface{}, 10)}
+	c2 := &ServerClient{id: "c2", roles: []string{"controller@v1"}, sendChan: make(chan interface{}, 10)}
+	g.addClient(c1)
+	g.addClient(c2)
+	drainSendChan(c1.sendChan) // discard group/update
+	drainSendChan(c2.sendChan)
+
+	ctrl.SetRepeat("one")
+
+	for _, c := range []*ServerClient{c1, c2} {
+		msgs := drainSendChan(c.sendChan)
+		if len(msgs) != 1 {
+			t.Fatalf("client %s got %d messages, want 1", c.id, len(msgs))
+		}
+		cs := controllerStateFrom(t, msgs[0])
+		if cs == nil || cs.Repeat != "one" {
+			t.Errorf("client %s did not receive controller state with Repeat=one: %#v", c.id, msgs[0])
+		}
+	}
+}
+
+func TestControllerRole_SetRepeatDedup(t *testing.T) {
+	g := NewGroup("g")
+	defer g.Close()
+
+	ctrl := NewControllerRole(ControllerConfig{})
+	ctrl.setGroup(g)
+
+	c1 := &ServerClient{id: "c1", roles: []string{"controller@v1"}, sendChan: make(chan interface{}, 10)}
+	g.addClient(c1)
+	drainSendChan(c1.sendChan)
+
+	ctrl.SetRepeat("all")
+	drainSendChan(c1.sendChan) // discard first broadcast
+
+	ctrl.SetRepeat("all") // same value — must not re-broadcast
+	if msgs := drainSendChan(c1.sendChan); len(msgs) != 0 {
+		t.Errorf("setting Repeat to the same value re-broadcast %d messages, want 0", len(msgs))
+	}
+}
+
+func TestControllerRole_SetShuffleBroadcasts(t *testing.T) {
+	g := NewGroup("g")
+	defer g.Close()
+
+	ctrl := NewControllerRole(ControllerConfig{})
+	ctrl.setGroup(g)
+
+	c1 := &ServerClient{id: "c1", roles: []string{"controller@v1"}, sendChan: make(chan interface{}, 10)}
+	g.addClient(c1)
+	drainSendChan(c1.sendChan)
+
+	ctrl.SetShuffle(true)
+
+	msgs := drainSendChan(c1.sendChan)
+	if len(msgs) != 1 {
+		t.Fatalf("got %d messages, want 1", len(msgs))
+	}
+	cs := controllerStateFrom(t, msgs[0])
+	if cs == nil || !cs.Shuffle {
+		t.Errorf("did not receive controller state with Shuffle=true: %#v", msgs[0])
+	}
+}
+
+func TestControllerRole_MirrorsToMetadataOnlyClient(t *testing.T) {
+	g := NewGroup("g")
+	defer g.Close()
+
+	ctrl := NewControllerRole(ControllerConfig{
+		ClockMicros: func() int64 { return 12345 },
+	})
+	ctrl.setGroup(g)
+
+	// Pure v1 client: metadata role only, no controller role.
+	md := &ServerClient{id: "m1", roles: []string{"metadata@v1"}, sendChan: make(chan interface{}, 10)}
+	g.addClient(md)
+	drainSendChan(md.sendChan)
+
+	ctrl.SetRepeat("one")
+
+	msgs := drainSendChan(md.sendChan)
+	if len(msgs) != 1 {
+		t.Fatalf("metadata-only client got %d messages, want 1", len(msgs))
+	}
+	m, ok := msgs[0].(protocol.Message)
+	if !ok || m.Type != "server/state" {
+		t.Fatalf("expected server/state, got %#v", msgs[0])
+	}
+	state := m.Payload.(protocol.ServerStateMessage)
+	if state.Metadata == nil || state.Metadata.Repeat == nil || *state.Metadata.Repeat != "one" {
+		t.Errorf("metadata mirror missing Repeat=one: %#v", state.Metadata)
+	}
+	if state.Metadata.Timestamp != 12345 {
+		t.Errorf("metadata mirror Timestamp = %d, want 12345", state.Metadata.Timestamp)
+	}
+	if state.Controller != nil {
+		t.Error("metadata-only client should not receive controller state")
 	}
 }


### PR DESCRIPTION
## Summary

Brings sendspin-go in line with [Sendspin/spec#81](https://github.com/Sendspin/spec/pull/81) (mirrored by aiosendspin commit `2528b97`): `repeat` and `shuffle` move from the **metadata** role state to the **controller** role state — "metadata describes *what* is playing; controller describes *how* it plays." The legacy metadata fields are retained for v1 backward compatibility on both the send and receive sides.

The change spans the full path so it's exercised end to end:

- **Wire model** — `ControllerState` gains required `repeat`/`shuffle` fields (canonical source), alongside `volume`/`muted`. `MetadataState.repeat/shuffle` kept as a legacy mirror.
- **Server role** — `ControllerGroupRole` becomes stateful: owns the group repeat/shuffle, includes them in the controller state sent on join, and exposes `SetRepeat`/`SetShuffle` which broadcast a fresh controller `server/state` to all controller members (no-op on unchanged value). v1 metadata-only clients get a mirrored metadata `server/state` when an optional `ClockMicros` is set. `RegisterRole` injects the owning `Group` into roles implementing the unexported `groupAware` interface, so broadcasting roles get a member handle without widening the `GroupRole` interface.
- **Client consume** — `Metadata` gains `Repeat`/`Shuffle`. The receiver applies controller state immediately (full snapshot, no timestamp) and still honors the legacy `metadata.repeat/shuffle` copy via the existing tristate merge.
- **E2E** — a real `Server` + `ControllerGroupRole` + real `Receiver` over a WebSocket: server `SetRepeat`/`SetShuffle` shows up in the client's merged `OnMetadata` snapshot.

## ⚠️ Pre-existing race fix — please review closely

The new E2E test is the first to connect a full `Receiver` to a real `Server`, and it surfaced a **pre-existing data race** unrelated to repeat/shuffle: `handleStreamStart` swaps the stream-scoped fields (`scheduler`, `decoder`, `format`, `schedulerCancel`) while `handleAudioChunks`, `pumpSchedulerOutput`, `Stats`, the stream-clear/group-update handlers, and `Close` read them from other goroutines without synchronization.

Fix: guard those fields with a dedicated `streamMu`. Readers snapshot the pointer under the lock and use it unlocked, so the lock is never held across a blocking decode/schedule/channel op. `pumpSchedulerOutput` now takes its scheduler as an argument (pinning each pump goroutine to the instance it was started for), and the orphaned `schedulerCtx` field is removed.

This touches the hot audio path — behavior-preserving (same teardown order and goroutine lifecycle), but worth a careful look.

## Testing

- New unit tests: controller-state apply, track-metadata preservation, legacy tristate, wire round-trip; server-side broadcast/dedup/mirror/join-state.
- New E2E: `TestController_RepeatShuffleEndToEnd`.
- `go test -race ./pkg/sendspin/` — clean, including the E2E run **10×** under `-race` (the race reproduced before the fix at `-count=5`, gone after).
- Full module `go test ./...` — all packages pass. `go vet` clean.
- `gofmt` verified clean on LF-normalized files (the local Windows working tree is CRLF; CI on Linux/LF is the gofmt gate).
- `make conformance` runs in CI to validate the wire change against aiosendspin.

## Notes / deliberate scope

- `NewServer` still registers only player+metadata by default; the controller role stays opt-in (conformance adapter / CLI wire it). No behavior change for existing servers.
- The metadata back-compat mirror covers state *changes*; a pure-v1 metadata-only client joining mid-session won't get initial repeat/shuffle until the next change (same as prior behavior — the metadata role never emitted them). Can extend if desired.
