### PR TITLE
style(sendspin): gofmt receiver.go (fix red Lint check)

### DIFF
--- a/pkg/sendspin/receiver.go
+++ b/pkg/sendspin/receiver.go
@@ -27,28 +27,28 @@ const (
 )
 
 // metadataApplyTickInterval is the cadence at which metadataApplyLoop wakes
-// to drain pending updates whose server timestamp has elapsed. 
+// to drain pending updates whose server timestamp has elapsed.
 const metadataApplyTickInterval = 100 * time.Millisecond
 
 type ReceiverConfig struct {
 	ServerAddr     string
 	PlayerName     string
 	BufferMs       int
-	StaticDelayMs  int   
-	PreferredCodec string 
-	BufferCapacity int    // buffer_capacity in bytes advertised to the server (default: 1048576 = 1MB
+	StaticDelayMs  int
+	PreferredCodec string
+	BufferCapacity int // buffer_capacity in bytes advertised to the server (default: 1048576 = 1MB
 	// MaxSampleRate caps the highest SampleRate advertised to the server. 0 = no cap.
 	MaxSampleRate int
-	// MaxBitDepth caps the highest BitDepth advertised to the server.  0 = no cap. 
+	// MaxBitDepth caps the highest BitDepth advertised to the server.  0 = no cap.
 	MaxBitDepth int
 	// ClientID is the already-resolved client_id to advertise in client/hello.
 	ClientID       string
 	DeviceInfo     DeviceInfo
 	DecoderFactory func(audio.Format) (decode.Decoder, error)
-	OnMetadata    func(Metadata)
-	OnStreamStart func(audio.Format)
-	OnStreamEnd   func()
-	OnError       func(error)
+	OnMetadata     func(Metadata)
+	OnStreamStart  func(audio.Format)
+	OnStreamEnd    func()
+	OnError        func(error)
 }
 
 type ReceiverStats struct {
@@ -73,12 +73,13 @@ type Receiver struct {
 	schedulerCancel context.CancelFunc
 	serverAddr      string
 	connected       bool
-	streamMu stdsync.Mutex
+	streamMu        stdsync.Mutex
 	metadataMu      stdsync.Mutex
 	mergedMetadata  Metadata
 	pendingMetadata []*protocol.MetadataState
-	clockNow func() int64
+	clockNow        func() int64
 }
+
 func NewReceiver(config ReceiverConfig) (*Receiver, error) {
 	if config.ServerAddr == "" {
 		return nil, fmt.Errorf("ReceiverConfig.ServerAddr is required")


### PR DESCRIPTION
## Problem

The **Lint** CI check is failing on `main` (gofmt). golangci-lint surfaces it as a single finding at `receiver.go:30`, but the whole file is unformatted — so it kept the check red on #137 (and has been red on main since the formatting drift was merged).

## Fix

Ran `gofmt -w pkg/sendspin/receiver.go`. Pure formatting, no behavior change:

- Trailing whitespace removed from a few comment/field lines.
- Struct fields re-aligned (`streamMu`, `clockNow`, the `On*` callbacks).
- Blank line restored before `NewReceiver`.

## Verification

- Module-wide gofmt scan clean; `go build ./...`, `go vet`, and `go test ./pkg/sendspin/` all pass.
- Only `receiver.go` was affected (the sole gofmt-dirty file in the module).
