### PR TITLE
refactor(encode): Phase 2 — promote encoders to pkg/audio/encode (gate met)

### DIFF
--- a/docs/superpowers/plans/2026-06-11-three-repo-split.md
+++ b/docs/superpowers/plans/2026-06-11-three-repo-split.md
@@ -101,9 +101,10 @@ Each phase is independently shippable and keeps `make test` + `make conformance`
 - Gate: `make test` green locally (12→ same after the file moves); `make conformance` runs in CI. **No public API change** — all symbols kept the same package + names, so the conformance adapter and external importers are unaffected.
 
 ### Phase 2 — Promote cross-boundary `internal/` to public `pkg/` (still one module)
-- [x] Promote `internal/discovery` → `pkg/discovery` (verbatim move; repointed `main.go`, `server.go`, `client_dialer.go`). `pkg/sendspin` no longer imports `internal/discovery`.
-- [ ] Promote encoders → `pkg/audio/encode`; repoint `server.go`/`server_client.go`/`role_player.go`. Verify both `make test` and `make BUILDTAGS= test` (the opus.Stream path). **Note:** `internal/server` has its own `AudioSource` interface and `Default*` constants entangled with the sources — reconcile when moving sources.
-- [ ] Promote source decoders → `pkg/audio/source`; leave server TUI in `internal/`.
+- [x] Promote `internal/discovery` → `pkg/discovery` (verbatim move; repointed `main.go`, `server.go`, `client_dialer.go`). `pkg/sendspin` no longer imports `internal/discovery`. *(PR #141, merged)*
+- [x] Promote encoders → `pkg/audio/encode` (verbatim; repointed `role_player.go`/`server.go`/`server_client.go`). **This was the only thing `pkg/sendspin` used from `internal/server`**, so it dropped the dependency entirely.
+- [x] **GATE MET** — `go list -deps ./pkg/...` confirms `pkg/` imports **zero** `internal/` packages. `internal/server` (sources + TUI) is now used only by `cmd/sendspin-server` → can stay private to the future server-CLI repo.
+- [ ] *(Optional, deferred)* Promote source decoders → `pkg/audio/source`. **No longer required for the boundary** — only `cmd` uses them, not the SDK. This is now a product decision: do we want the SDK to ship built-in file/MP3/FLAC/HLS sources to library consumers, or are sources a CLI concern? Decide before/with Phase 3.
 - Gate (critical checkpoint): SDK has **zero cross-boundary `internal/` imports**; `make test` + `make conformance` green.
 
 ### Phase 3 — Extract the two CLI modules
@@ -131,3 +132,4 @@ Each phase is independently shippable and keeps `make test` + `make conformance`
 - 2026-06-11: Plan written. Phase 0 complete (in one PR): removed the dead legacy `internal/server` server, the orphaned `pkg/discovery` and `pkg/audio/encode` packages, dead `ResampledSource`/`internal/server/resampler.go`, and fixed stale protocol godoc. `NewFileSource` stub deferred to Phase 1. Net ~1.4 KLOC of dead code removed.
 - 2026-06-11: Phase 1 complete — decomposed `pkg/sendspin` by file (in place, same package, no public API change): hoisted shared constants to `constants.go`, split `config.go` into common/player/server, split `source.go` and removed the `NewFileSource` stub, moved `containsRole` to `receiver.go`. Sets up the eventual client/server package split as a mechanical move.
 - 2026-06-11: Phase 2 (1/3) — promoted `internal/discovery` → `pkg/discovery` (verbatim move, repointed importers). Encoders and source decoders are the remaining two promotions; they need interface/constant reconciliation (`internal/server` has its own `AudioSource`) so they land as separate PRs.
+- 2026-06-11: Phase 2 GATE MET — promoted Opus/FLAC encoders → `pkg/audio/encode`. This turned out to be the *only* `internal/server` symbol the SDK used, so `pkg/` now has **zero** `internal/` imports (verified via `go list -deps`). The third promotion (source decoders → `pkg/audio/source`) is downgraded to optional: only `cmd/sendspin-server` uses the sources, so `internal/server` can stay private to the server-CLI repo. Phase 3 (extract CLI modules) is now unblocked.

--- a/pkg/audio/encode/doc.go
+++ b/pkg/audio/encode/doc.go
@@ -1,0 +1,9 @@
+// ABOUTME: Audio encoder package for the Sendspin server
+// ABOUTME: Provides real-time Opus and FLAC encoders for PCM audio
+// Package encode provides real-time audio encoders for the Sendspin server.
+//
+// Supports: Opus (lossy, bandwidth-efficient) and FLAC (lossless). Each
+// encoder turns a block of interleaved PCM samples into a single codec
+// frame/packet for streaming; FLAC additionally exposes its codec header
+// for the stream/start handshake.
+package encode

--- a/pkg/audio/encode/flac_encoder.go
+++ b/pkg/audio/encode/flac_encoder.go
@@ -1,6 +1,6 @@
 // ABOUTME: FLAC audio encoder for lossless streaming
 // ABOUTME: Wraps mewkiz/flac to encode PCM int32 samples to FLAC frames
-package server
+package encode
 
 import (
 	"bytes"

--- a/pkg/audio/encode/flac_encoder_test.go
+++ b/pkg/audio/encode/flac_encoder_test.go
@@ -1,6 +1,6 @@
 // ABOUTME: Tests for the FLAC encoder
 // ABOUTME: Verifies round-trip encode produces valid FLAC frames with compression
-package server
+package encode
 
 import (
 	"testing"

--- a/pkg/audio/encode/opus_encoder.go
+++ b/pkg/audio/encode/opus_encoder.go
@@ -1,6 +1,6 @@
 // ABOUTME: Opus audio encoder for bandwidth-efficient streaming
 // ABOUTME: Wraps libopus to encode PCM audio to Opus format
-package server
+package encode
 
 import (
 	"fmt"

--- a/pkg/audio/encode/opus_encoder_test.go
+++ b/pkg/audio/encode/opus_encoder_test.go
@@ -1,6 +1,6 @@
 // ABOUTME: Tests for Opus audio encoder
 // ABOUTME: Tests encoder creation, encoding, and format handling
-package server
+package encode
 
 import (
 	"testing"

--- a/pkg/sendspin/role_player.go
+++ b/pkg/sendspin/role_player.go
@@ -6,8 +6,8 @@ import (
 	"encoding/base64"
 	"log"
 
-	"github.com/Sendspin/sendspin-go/internal/server"
 	"github.com/Sendspin/sendspin-go/pkg/audio"
+	"github.com/Sendspin/sendspin-go/pkg/audio/encode"
 	"github.com/Sendspin/sendspin-go/pkg/protocol"
 )
 
@@ -18,12 +18,12 @@ type PlayerRoleConfig struct {
 	BitDepth   int
 
 	// NewEncoder creates an Opus encoder when needed. When nil, Opus
-	// clients fall back to PCM. Typically set to server.NewOpusEncoder.
-	NewEncoder func(sampleRate, channels, chunkSamples int) (*server.OpusEncoder, error)
+	// clients fall back to PCM. Typically set to encode.NewOpusEncoder.
+	NewEncoder func(sampleRate, channels, chunkSamples int) (*encode.OpusEncoder, error)
 
 	// NewFLACEncoder creates a FLAC encoder when needed. When nil, FLAC
 	// clients fall back to PCM.
-	NewFLACEncoder func(sampleRate, channels, bitDepth, blockSize int) (*server.FLACEncoder, error)
+	NewFLACEncoder func(sampleRate, channels, bitDepth, blockSize int) (*encode.FLACEncoder, error)
 }
 
 // PlayerGroupRole handles the "player" role family. On client join it
@@ -50,8 +50,8 @@ func (r *PlayerGroupRole) OnClientJoin(c *ServerClient) {
 
 	codec := negotiateCodec(c, r.config.SampleRate)
 
-	var opusEncoder *server.OpusEncoder
-	var flacEncoder *server.FLACEncoder
+	var opusEncoder *encode.OpusEncoder
+	var flacEncoder *encode.FLACEncoder
 	var resampler *audio.Resampler
 
 	switch codec {

--- a/pkg/sendspin/server.go
+++ b/pkg/sendspin/server.go
@@ -14,7 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Sendspin/sendspin-go/internal/server"
+	"github.com/Sendspin/sendspin-go/pkg/audio/encode"
 	"github.com/Sendspin/sendspin-go/pkg/discovery"
 	"github.com/Sendspin/sendspin-go/pkg/protocol"
 	"github.com/google/uuid"
@@ -136,11 +136,11 @@ func NewServer(config ServerConfig) (*Server, error) {
 		SampleRate: s.audioSource.SampleRate(),
 		Channels:   s.audioSource.Channels(),
 		BitDepth:   DefaultBitDepth,
-		NewEncoder: func(sampleRate, channels, chunkSamples int) (*server.OpusEncoder, error) {
-			return server.NewOpusEncoder(sampleRate, channels, chunkSamples)
+		NewEncoder: func(sampleRate, channels, chunkSamples int) (*encode.OpusEncoder, error) {
+			return encode.NewOpusEncoder(sampleRate, channels, chunkSamples)
 		},
-		NewFLACEncoder: func(sampleRate, channels, bitDepth, blockSize int) (*server.FLACEncoder, error) {
-			return server.NewFLACEncoder(sampleRate, channels, bitDepth, blockSize)
+		NewFLACEncoder: func(sampleRate, channels, bitDepth, blockSize int) (*encode.FLACEncoder, error) {
+			return encode.NewFLACEncoder(sampleRate, channels, bitDepth, blockSize)
 		},
 	}))
 

--- a/pkg/sendspin/server_client.go
+++ b/pkg/sendspin/server_client.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sendspin/sendspin-go/internal/server"
 	"github.com/Sendspin/sendspin-go/pkg/audio"
+	"github.com/Sendspin/sendspin-go/pkg/audio/encode"
 	"github.com/Sendspin/sendspin-go/pkg/protocol"
 	"github.com/gorilla/websocket"
 )
@@ -37,8 +37,8 @@ type ServerClient struct {
 	goodbyeReason string // reason from the last client/goodbye, if any
 
 	codec         string
-	opusEncoder   *server.OpusEncoder
-	flacEncoder   *server.FLACEncoder
+	opusEncoder   *encode.OpusEncoder
+	flacEncoder   *encode.FLACEncoder
 	resampler     *audio.Resampler // non-nil only when source rate != 48kHz
 	bufferTracker *BufferTracker
 


### PR DESCRIPTION
Phase 2 of the three-repo split (2 of 3 promotions) — and it **completes the Phase 2 gate**.

### Change
Promote the Opus/FLAC encoders from `internal/server` to a public **`pkg/audio/encode`**, and repoint the three `pkg/sendspin` users.

- `opus_encoder.go` / `flac_encoder.go` (+ tests) moved verbatim (`git mv`, history preserved), `package server` → `package encode`, plus a `doc.go` (matching `pkg/audio/decode`).
- `role_player.go`, `server.go`, `server_client.go`: import `pkg/audio/encode`, reference `encode.{Opus,FLAC}Encoder` / `encode.New{Opus,FLAC}Encoder`.

### Why this finishes the gate
The encoders turned out to be the **only** thing `pkg/sendspin` used from `internal/server` (the source decoders and TUI are used solely by `cmd/sendspin-server`). So this PR drops the SDK's `internal/server` dependency entirely:

```
go list -deps ./pkg/...  →  ZERO sendspin-go/internal/ packages
```

**Phase 2 gate ("SDK has zero cross-boundary `internal/` imports") is met** after discovery (#141) + this PR. `internal/server` (sources + TUI) is now used only by `cmd`, so it can stay private to the future server-CLI repo.

### Note: third promotion downgraded to optional
The planned `pkg/audio/source` promotion is **no longer required for the boundary** — only `cmd` imports the sources, not the SDK. Whether to promote them becomes a product decision (does the SDK ship built-in file/MP3/FLAC/HLS sources for library consumers, or are sources a CLI concern?). Captured in the plan; decide before/with Phase 3.

### Verification
- `go build ./...`, full `go test -race ./...` (10 packages) — green. gofmt + lint clean. `go doc ./pkg/audio/encode` renders.
- CGO/opus note: the encoders use `opus.Encoder` (not `opus.Stream`), so the `-tags=nolibopusfile` behavior is unchanged by the move — same as when they lived in `internal/server`.
