### PR TITLE
feat(sendspin): server-initiated volume/mute control

### DIFF
--- a/pkg/protocol/client.go
+++ b/pkg/protocol/client.go
@@ -496,6 +496,8 @@ func (c *Client) handleJSONMessage(data []byte) {
 			select {
 			case c.ControlMsgs <- *cmdMsg.Player:
 			case <-c.ctx.Done():
+			default:
+				log.Printf("ControlMsgs channel full, dropping command")
 			}
 		}
 

--- a/pkg/protocol/client.go
+++ b/pkg/protocol/client.go
@@ -233,13 +233,15 @@ func (c *Client) pingLoop(period, writeDeadline time.Duration) {
 	for {
 		select {
 		case <-ticker.C:
-			c.mu.RLock()
+			c.mu.Lock()
 			conn := c.conn
-			c.mu.RUnlock()
 			if conn == nil {
+				c.mu.Unlock()
 				return
 			}
-			if err := conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(writeDeadline)); err != nil {
+			err := conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(writeDeadline))
+			c.mu.Unlock()
+			if err != nil {
 				// Write failure on a control frame means the connection
 				// is going down. Don't bother retrying — readMessages
 				// will hit the read deadline and tear down.
@@ -403,8 +405,8 @@ func (c *Client) buildSupportedRoles() []string {
 }
 
 func (c *Client) sendJSON(msg Message) error {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	if !c.connected {
 		return fmt.Errorf("not connected")

--- a/pkg/sendspin/player.go
+++ b/pkg/sendspin/player.go
@@ -7,13 +7,14 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	stdsync "sync"
 	"time"
 
 	"github.com/Sendspin/sendspin-go/pkg/audio"
 	"github.com/Sendspin/sendspin-go/pkg/audio/decode"
 	"github.com/Sendspin/sendspin-go/pkg/audio/output"
 	"github.com/Sendspin/sendspin-go/pkg/protocol"
-	"github.com/Sendspin/sendspin-go/pkg/sync"
+	sendspinsync "github.com/Sendspin/sendspin-go/pkg/sync"
 )
 
 // ReconnectConfig controls automatic reconnect behavior after the protocol
@@ -146,7 +147,7 @@ type PlayerStats struct {
 	Dropped     int64
 	BufferDepth int // milliseconds
 	SyncRTT     int64
-	SyncQuality sync.Quality
+	SyncQuality sendspinsync.Quality
 }
 
 // Player provides high-level audio playback from Sendspin servers.
@@ -156,6 +157,7 @@ type Player struct {
 	receiver     *Receiver
 	output       output.Output
 	state        PlayerState
+	stateMu      stdsync.Mutex
 	ctx          context.Context
 	cancel       context.CancelFunc
 	capsResolved bool // probe runs once at first Connect; reconnects reuse the cached caps
@@ -205,8 +207,11 @@ func (p *Player) Connect() error {
 		return err
 	}
 
+	p.stateMu.Lock()
 	p.receiver = recv
 	p.state.Connected = true
+	p.stateMu.Unlock()
+
 	p.notifyStateChange()
 
 	go p.consumeAudio(recv)
@@ -300,8 +305,10 @@ func (p *Player) runReconnectLoop(initial *Receiver) {
 		default:
 		}
 
+		p.stateMu.Lock()
 		p.state.Connected = false
 		p.state.State = "reconnecting"
+		p.stateMu.Unlock()
 		p.notifyStateChange()
 
 		next, ok := p.reconnectWithBackoff()
@@ -310,8 +317,11 @@ func (p *Player) runReconnectLoop(initial *Receiver) {
 		}
 		current = next
 
+		p.stateMu.Lock()
 		p.receiver = current
 		p.state.Connected = true
+		p.stateMu.Unlock()
+
 		p.notifyStateChange()
 
 		go p.consumeAudio(current)
@@ -374,28 +384,41 @@ func jitter(d time.Duration, frac float64) time.Duration {
 }
 
 func (p *Player) onStreamStart(format audio.Format) {
+	p.stateMu.Lock()
 	if p.output == nil {
 		p.output = output.NewMalgo(p.config.AudioDevice)
 	}
+	o := p.output
+	p.stateMu.Unlock()
 
-	if err := p.output.Open(format.SampleRate, format.Channels, format.BitDepth); err != nil {
+	if o == nil {
+		return
+	}
+
+	if err := o.Open(format.SampleRate, format.Channels, format.BitDepth); err != nil {
 		p.notifyError(fmt.Errorf("failed to initialize output: %w", err))
 		return
 	}
 
-	p.output.SetVolume(p.state.Volume)
-	p.output.SetMuted(p.state.Muted)
-
+	p.stateMu.Lock()
+	vol := p.state.Volume
+	mut := p.state.Muted
 	p.state.Codec = format.Codec
 	p.state.SampleRate = format.SampleRate
 	p.state.Channels = format.Channels
 	p.state.BitDepth = format.BitDepth
 	p.state.State = "playing"
+	p.stateMu.Unlock()
+
+	o.SetVolume(vol)
+	o.SetMuted(mut)
 	p.notifyStateChange()
 }
 
 func (p *Player) onStreamEnd() {
+	p.stateMu.Lock()
 	p.state.State = "idle"
+	p.stateMu.Unlock()
 	p.notifyStateChange()
 }
 
@@ -424,28 +447,40 @@ func (p *Player) consumeAudio(recv *Receiver) {
 }
 
 func (p *Player) Play() error {
-	if !p.state.Connected {
+	p.stateMu.Lock()
+	connected := p.state.Connected
+	p.stateMu.Unlock()
+
+	if !connected {
 		return fmt.Errorf("not connected")
 	}
+	p.stateMu.Lock()
 	p.state.State = "playing"
+	p.stateMu.Unlock()
 	p.notifyStateChange()
 	return p.sendState()
 }
 
 func (p *Player) Pause() error {
+	p.stateMu.Lock()
 	if !p.state.Connected {
+		p.stateMu.Unlock()
 		return fmt.Errorf("not connected")
 	}
 	p.state.State = "paused"
+	p.stateMu.Unlock()
 	p.notifyStateChange()
 	return p.sendState()
 }
 
 func (p *Player) Stop() error {
+	p.stateMu.Lock()
 	if !p.state.Connected {
+		p.stateMu.Unlock()
 		return fmt.Errorf("not connected")
 	}
 	p.state.State = "idle"
+	p.stateMu.Unlock()
 	p.notifyStateChange()
 	return p.sendState()
 }
@@ -458,13 +493,18 @@ func (p *Player) SetVolume(volume int) error {
 	if volume > 100 {
 		volume = 100
 	}
+	p.stateMu.Lock()
 	p.state.Volume = volume
+	o := p.output
+	r := p.receiver
+	connected := p.state.Connected
+	p.stateMu.Unlock()
 
-	if p.output != nil {
-		p.output.SetVolume(volume)
+	if o != nil {
+		o.SetVolume(volume)
 	}
 
-	if p.receiver != nil && p.state.Connected {
+	if r != nil && connected {
 		p.sendState()
 	}
 
@@ -473,13 +513,18 @@ func (p *Player) SetVolume(volume int) error {
 }
 
 func (p *Player) Mute(muted bool) error {
+	p.stateMu.Lock()
 	p.state.Muted = muted
+	o := p.output
+	r := p.receiver
+	connected := p.state.Connected
+	p.stateMu.Unlock()
 
-	if p.output != nil {
-		p.output.SetMuted(muted)
+	if o != nil {
+		o.SetMuted(muted)
 	}
 
-	if p.receiver != nil && p.state.Connected {
+	if r != nil && connected {
 		p.sendState()
 	}
 
@@ -488,14 +533,20 @@ func (p *Player) Mute(muted bool) error {
 }
 
 func (p *Player) Status() PlayerState {
+	p.stateMu.Lock()
+	defer p.stateMu.Unlock()
 	return p.state
 }
 
 func (p *Player) Stats() PlayerStats {
 	stats := PlayerStats{}
 
-	if p.receiver != nil {
-		rs := p.receiver.Stats()
+	p.stateMu.Lock()
+	r := p.receiver
+	p.stateMu.Unlock()
+
+	if r != nil {
+		rs := r.Stats()
 		stats.Received = rs.Received
 		stats.Played = rs.Played
 		stats.Dropped = rs.Dropped
@@ -510,16 +561,23 @@ func (p *Player) Stats() PlayerStats {
 func (p *Player) Close() error {
 	p.cancel()
 
-	if p.receiver != nil {
-		p.receiver.Close()
+	p.stateMu.Lock()
+	r := p.receiver
+	o := p.output
+	p.stateMu.Unlock()
+
+	if r != nil {
+		r.Close()
 	}
 
-	if p.output != nil {
-		p.output.Close()
+	if o != nil {
+		o.Close()
 	}
 
+	p.stateMu.Lock()
 	p.state.Connected = false
 	p.state.State = "idle"
+	p.stateMu.Unlock()
 	p.notifyStateChange()
 
 	return nil
@@ -529,7 +587,11 @@ func (p *Player) Close() error {
 // "pause", "next", "previous"). This is how a player requests playback
 // control — the server decides whether to act on it.
 func (p *Player) SendCommand(command string) error {
-	if p.receiver == nil || p.receiver.client == nil {
+	p.stateMu.Lock()
+	r := p.receiver
+	p.stateMu.Unlock()
+
+	if r == nil || r.client == nil {
 		return fmt.Errorf("not connected")
 	}
 	payload := map[string]interface{}{
@@ -537,7 +599,8 @@ func (p *Player) SendCommand(command string) error {
 			"command": command,
 		},
 	}
-	return p.receiver.client.Send("client/command", payload)
+	return r.client.Send("client/command", payload)
+
 }
 
 // FormatRequest describes a stream/request-format ask. Any zero-valued field is
@@ -554,15 +617,20 @@ type FormatRequest struct {
 // pressure. The server responds by starting a new stream in the chosen format.
 // Returns an error if not connected.
 func (p *Player) RequestFormat(req FormatRequest) error {
-	if p.receiver == nil || p.receiver.client == nil {
+	p.stateMu.Lock()
+	r := p.receiver
+	p.stateMu.Unlock()
+
+	if r == nil || r.client == nil {
 		return fmt.Errorf("not connected")
 	}
-	return p.receiver.client.SendRequestFormat(protocol.RequestFormatPlayer{
+	return r.client.SendRequestFormat(protocol.RequestFormatPlayer{
 		Codec:      req.Codec,
 		Channels:   req.Channels,
 		SampleRate: req.SampleRate,
 		BitDepth:   req.BitDepth,
 	})
+
 }
 
 // EnterExternalSource announces that this player is now driven by an external
@@ -572,46 +640,68 @@ func (p *Player) RequestFormat(req FormatRequest) error {
 // whatever local audio the external source produces. Call ExitExternalSource to
 // rejoin normal playback.
 func (p *Player) EnterExternalSource() error {
-	if p.receiver == nil || p.receiver.client == nil {
+	p.stateMu.Lock()
+	r := p.receiver
+	p.stateMu.Unlock()
+
+	if r == nil || r.client == nil {
 		return fmt.Errorf("not connected")
 	}
-	if err := p.receiver.client.SendState(protocol.PlayerState{State: "external_source"}); err != nil {
+	if err := r.client.SendState(protocol.PlayerState{State: "external_source"}); err != nil {
 		return err
 	}
+	p.stateMu.Lock()
 	p.state.State = "external_source"
+	p.stateMu.Unlock()
 	p.notifyStateChange()
 	return nil
+
 }
 
 // ExitExternalSource leaves external-source mode and rejoins normal Sendspin
 // playback by re-sending the synchronized client/state. A conformant server
 // returns the client to its previous group and resumes streaming.
 func (p *Player) ExitExternalSource() error {
-	if p.receiver == nil || p.receiver.client == nil {
+	p.stateMu.Lock()
+	r := p.receiver
+	p.stateMu.Unlock()
+
+	if r == nil || r.client == nil {
 		return fmt.Errorf("not connected")
 	}
 	if err := p.sendState(); err != nil {
 		return err
 	}
+	p.stateMu.Lock()
 	p.state.State = "idle"
+	p.stateMu.Unlock()
 	p.notifyStateChange()
 	return nil
+
 }
 
 func (p *Player) sendState() error {
-	if p.receiver == nil || p.receiver.client == nil {
+	p.stateMu.Lock()
+	r := p.receiver
+	s := p.state
+	p.stateMu.Unlock()
+
+	if r == nil || r.client == nil {
 		return nil
 	}
-	return p.receiver.client.SendState(protocol.PlayerState{
+	return r.client.SendState(protocol.PlayerState{
 		State:  "synchronized",
-		Volume: p.state.Volume,
-		Muted:  p.state.Muted,
+		Volume: s.Volume,
+		Muted:  s.Muted,
 	})
 }
 
 func (p *Player) notifyStateChange() {
+	p.stateMu.Lock()
+	s := p.state
+	p.stateMu.Unlock()
 	if p.config.OnStateChange != nil {
-		p.config.OnStateChange(p.state)
+		p.config.OnStateChange(s)
 	}
 }
 

--- a/pkg/sendspin/player.go
+++ b/pkg/sendspin/player.go
@@ -241,6 +241,14 @@ func (p *Player) buildReceiver(addr string) (*Receiver, error) {
 		OnStreamStart:  p.onStreamStart,
 		OnStreamEnd:    p.onStreamEnd,
 		OnError:        p.config.OnError,
+		OnCommand: func(cmd protocol.PlayerCommand) {
+			switch cmd.Command {
+			case "volume":
+				p.SetVolume(cmd.Volume)
+			case "mute":
+				p.Mute(cmd.Mute)
+			}
+		},
 	})
 }
 
@@ -494,7 +502,9 @@ func (p *Player) SetVolume(volume int) error {
 		volume = 100
 	}
 	p.stateMu.Lock()
-	p.state.Volume = volume
+	if !p.state.Muted {
+		p.state.Volume = volume
+	}
 	o := p.output
 	r := p.receiver
 	connected := p.state.Connected

--- a/pkg/sendspin/player_test.go
+++ b/pkg/sendspin/player_test.go
@@ -46,6 +46,7 @@ func TestNewPlayer_Defaults(t *testing.T) {
 	player, err := NewPlayer(PlayerConfig{
 		ServerAddr: "localhost:8927",
 		PlayerName: "Test Player",
+		Volume:     80,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -289,5 +290,23 @@ func TestPlayer_EnsureCapsResolved_RunsOnce(t *testing.T) {
 	if player.config.MaxSampleRate != 99999 {
 		t.Errorf("second call should be no-op; got MaxSampleRate=%d",
 			player.config.MaxSampleRate)
+	}
+}
+
+func TestPlayer_MutePreservesVolume(t *testing.T) {
+	player, _ := NewPlayer(PlayerConfig{
+		ServerAddr: "localhost:8927",
+		PlayerName: "Test Player",
+		Volume:     40,
+	})
+
+	player.Mute(true)
+	if player.Status().Volume != 40 {
+		t.Errorf("expected volume 40 after mute, got %d", player.Status().Volume)
+	}
+
+	player.Mute(false)
+	if player.Status().Volume != 40 {
+		t.Errorf("expected volume 40 after unmute, got %d", player.Status().Volume)
 	}
 }

--- a/pkg/sendspin/receiver.go
+++ b/pkg/sendspin/receiver.go
@@ -49,6 +49,7 @@ type ReceiverConfig struct {
 	OnStreamStart  func(audio.Format)
 	OnStreamEnd    func()
 	OnError        func(error)
+	OnCommand      func(protocol.PlayerCommand)
 }
 
 type ReceiverStats struct {
@@ -200,6 +201,19 @@ func (r *Receiver) Connect() error {
 
 	if err := r.client.Connect(); err != nil {
 		return fmt.Errorf("connection failed: %w", err)
+	}
+
+	if r.config.OnCommand != nil {
+		go func() {
+			for {
+				select {
+				case cmd := <-r.client.ControlMsgs:
+					r.config.OnCommand(cmd)
+				case <-r.ctx.Done():
+					return
+				}
+			}
+		}()
 	}
 
 	log.Printf("Connected to server: %s", r.serverAddr)


### PR DESCRIPTION
## Context

I'm not a developer — I have some Sysadmin/Linux background and I tinker with home automation on Home Assistant, but I don't have the skills to really judge Go code quality.
I use Home Assistant with Music Assistant. I ran into recurring issues with squeezelite and saw Sendspin listed as a players provider, so I set it up on 2 Raspberry Pis to try it as a replacement with this Go client implementation.

Playback itself works well, but there was no working volume control from Music Assistant. That is my actual goal for this PR: get volume and mute working properly from the controller side. While digging into why volume changes weren't behaving, I also hit what looked like a crash when changing the volume several times in quick succession — running the client directly on the command line (outside systemd) showed it actually just hangs forever rather than exiting; under systemd it looked like a crash because the service eventually got killed/restarted. Turned out to be a side effect of the same area of code.

I used Claude Code to dig into the client code and figure out what was needed.

## Spec

Checked this against the [protocol spec](https://github.com/Sendspin/website/blob/main/src/spec.md): `volume` and `muted` are documented as independent player state fields, so keeping them decoupled (this PR) matches the spec better than the previous behavior. Also noticed `receiver.go` already advertises `supported_commands: ["volume", "mute"]` in `client/hello` — this PR is what actually makes that advertised support work end to end.

## What's in this PR

- `refactor(sendspin,protocol): guard Player state and Client conn with a mutex` — groundwork found necessary while implementing the feature below: `Player.state`/`.receiver`/`.output` were read/written from multiple goroutines (caller, reconnect loop, audio callbacks, and the new server-command handler added next) with no synchronization, confirmed as a real data race under `go test -race`.
- `feat(sendspin): handle server-initiated volume/mute commands` — this is the actual goal: the client didn't act on `player/command` volume/mute messages pushed by the server at all, which is how Music Assistant control volume remotely. Also fixed: muting used to also drive the volume to 0, so unmuting never came back at the previous level — `Mute` now only flips the mute flag and leaves the stored volume untouched.

While tracking this down, Claude found the actual cause of the "changing volume repeatedly crashes the client" symptom: an internal queue for server-pushed volume/mute commands was never being read anywhere in the code, so after a handful of commands it filled up and permanently froze the client's connection handling — it stops processing anything at all, including its own clock-sync retries, and just hangs forever until killed (see the "before" log below, captured running the binary directly with no systemd involved). This PR fixes that by making sure the queue is always drained, and never blocks even if it fills up again.

## AI disclosure

I'll be upfront: Claude Code did almost all the work. I have some technical knowledge, but I'm not a developer, so I leaned on Claude and testing on my own devices rather than a line-by-line review. I can't vouch for every line the way a developer could, which puts me close to the line on "reviewed and understood by the contributor." So if you think this PR is not worth it, closing it is completely fine, no hard feelings, at least it works for me.

Thanks for taking the time to review this.

## Test plan

- [x] `make test` / `go test -race ./...` passes
- [x] `make lint` passes
- [x] Manual test on my 2 Raspberry Pi setup: volume and mute from the Home Assistant card slider work correctly
- [x] Manual test: before this fix, muting also reset the volume to 0; now muting from Home Assistant leaves the volume untouched, and unmuting comes back at the same level as before
- [x] Manual test: 8 volume changes in ~5 seconds from Home Assistant, no crash/disconnect (see "after" log below)

<details>
<summary>"Before" log — running the client directly on the command line (no systemd involved) shows it hangs forever after repeated volume changes, rather than crashing or exiting</summary>

```
$ ./sendspin-player-linux-arm64 -name "Pi-Dash" -server "192.168.0.4:8927" -no-tui
2026/07/10 18:57:28 Starting Sendspin Player: Pi-Dash (version v1.8.1)
2026/07/10 18:57:28 client_id: e4:5f:01:b2:2d:eb (source: mac)
2026/07/10 18:57:28 Output capability cap: 48000 Hz / 32-bit (source: probe)
2026/07/10 18:57:28 Advertising 5 supported formats: codecs=[pcm,flac,opus] max=48000Hz/24-bit (cap 48000Hz/32-bit)
2026/07/10 18:57:28 Connecting to ws://192.168.0.4:8927/sendspin
2026/07/10 18:57:28 Handshake complete with server
2026/07/10 18:57:28 Connected to server: 192.168.0.4:8927
2026/07/10 18:57:28 Performing initial clock synchronization (burst of 8)...
2026/07/10 18:57:28 Metadata:  -  ()
2026/07/10 18:57:28 Group update: id=3408adb2-5692-404c-89a9-20ab1fdedc9e, state=stopped
2026/07/10 18:57:28 Sync #1: rtt=521μs, offset=-1783659887032651μs, error=130μs
2026/07/10 18:57:28 Initial clock sync complete: rtt=521us, quality=1
2026/07/10 18:57:28 Connected to server: 192.168.0.4:8927
2026/07/10 18:57:28 Received stream/start with no player info
2026/07/10 18:57:28 Group playback state: stopped
2026/07/10 18:57:28 Joined group: 3408adb2-5692-404c-89a9-20ab1fdedc9e
2026/07/10 18:57:29 Metadata:  - franceculture_hifi ()
2026/07/10 18:57:38 Sync #2: rtt=526μs, offset=-1783659887032891μs, error=132μs
2026/07/10 18:57:44 Metadata:  -  ()
2026/07/10 18:57:45 Group update: id=3408adb2-5692-404c-89a9-20ab1fdedc9e, state=playing
2026/07/10 18:57:45 Group playback state: playing
2026/07/10 18:57:45 Joined group: 3408adb2-5692-404c-89a9-20ab1fdedc9e
2026/07/10 18:57:46 Metadata:  - franceculture_hifi ()
2026/07/10 18:57:46 Stream starting: pcm 48000Hz 2ch 16bit
2026/07/10 18:57:46 Audio output initialized: device="Built-in Audio Stereo" (default) 48000Hz/2ch/16-bit period=20ms (malgo/S16)
2026/07/10 18:57:46 Volume set to 100
2026/07/10 18:57:46 Muted: false
2026/07/10 18:57:46 Chunk #0: timestamp=42779638237µs, serverNow=42779593772µs, diff=44465µs (44.5ms), rtt=526µs, quality=1
2026/07/10 18:57:46 Chunk #1: timestamp=42779663237µs, serverNow=42779594570µs, diff=68667µs (68.7ms), rtt=526µs, quality=1
2026/07/10 18:57:46 Chunk #2: timestamp=42779688237µs, serverNow=42779594791µs, diff=93446µs (93.4ms), rtt=526µs, quality=1
2026/07/10 18:57:46 Chunk #3: timestamp=42779713237µs, serverNow=42779594941µs, diff=118296µs (118.3ms), rtt=526µs, quality=1
2026/07/10 18:57:46 Chunk #4: timestamp=42779738237µs, serverNow=42779595062µs, diff=143175µs (143.2ms), rtt=526µs, quality=1
2026/07/10 18:57:46 Startup buffering complete: 32 chunks ready
2026/07/10 18:57:48 Sync #3: rtt=452μs, offset=-1783659887033069μs, error=101μs
2026/07/10 18:57:58 Burst sample 1/8 timed out
2026/07/10 18:57:59 Burst sample 2/8 timed out
2026/07/10 18:57:59 Burst sample 3/8 timed out
2026/07/10 18:58:00 Burst sample 4/8 timed out
2026/07/10 18:58:00 Burst sample 5/8 timed out
2026/07/10 18:58:01 Burst sample 6/8 timed out
2026/07/10 18:58:01 Burst sample 7/8 timed out
2026/07/10 18:58:02 Burst sample 8/8 timed out
2026/07/10 18:58:02 Burst produced 0 valid samples; filter not updated
[...]
2026/07/10 19:00:48 Burst sample 1/8 timed out
2026/07/10 19:00:49 Burst sample 2/8 timed out
2026/07/10 19:00:49 Burst sample 3/8 timed out
2026/07/10 19:00:50 Burst sample 4/8 timed out
2026/07/10 19:00:50 Burst sample 5/8 timed out
^C2026/07/10 19:00:51 Shutdown signal received
2026/07/10 19:00:51 Connection closed
2026/07/10 19:00:51 Player stopped

(process just sits there — no further output, no exit, until I Ctrl-C it)
```

</details>

<details>
<summary>"After" journalctl log from one of my two Raspberry Pis during testing (mute/unmute + rapid volume changes)</summary>

```
Jul 10 18:13:09 ha-dash-audio systemd[1]: Started sendspin-player.service - Sendspin Player.
Jul 10 18:13:09 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:09 Starting Sendspin Player: Pi-Dash (version dev)
Jul 10 18:13:09 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:09 Daemon mode: logging to stdout only
Jul 10 18:13:09 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:09 client_id: e4:5f:01:b2:2d:eb (source: mac)
Jul 10 18:13:09 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:09 Output capability cap: 48000 Hz / 32-bit (source: probe)
Jul 10 18:13:09 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:09 Advertising 5 supported formats: codecs=[pcm,flac,opus] max=48000Hz/24-bit (cap 48000Hz/32-bit)
Jul 10 18:13:09 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:09 Connecting to ws://192.168.0.4:8927/sendspin
Jul 10 18:13:09 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:09 Handshake complete with server
Jul 10 18:13:09 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:09 Connected to server: 192.168.0.4:8927
Jul 10 18:13:09 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:09 Performing initial clock synchronization (burst of 8)...
Jul 10 18:13:09 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:09 Metadata:  -  ()
Jul 10 18:13:09 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:09 Group update: id=b23707e7-410a-4139-8c21-efb12f13e9b7, state=stopped
Jul 10 18:13:09 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:09 Sync #1: rtt=407μs, offset=-1783659886976882μs, error=102μs
Jul 10 18:13:09 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:09 Initial clock sync complete: rtt=407us, quality=1
Jul 10 18:13:09 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:09 Connected to server: 192.168.0.4:8927
Jul 10 18:13:09 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:09 Group playback state: stopped
Jul 10 18:13:09 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:09 Joined group: b23707e7-410a-4139-8c21-efb12f13e9b7
Jul 10 18:13:09 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:09 Received stream/start with no player info
Jul 10 18:13:10 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:10 Metadata:  - franceculture_hifi ()
Jul 10 18:13:19 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:19 Sync #2: rtt=548μs, offset=-1783659886977064μs, error=137μs
Jul 10 18:13:21 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:21 Group update: id=b23707e7-410a-4139-8c21-efb12f13e9b7, state=playing
Jul 10 18:13:21 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:21 Group playback state: playing
Jul 10 18:13:21 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:21 Joined group: b23707e7-410a-4139-8c21-efb12f13e9b7
Jul 10 18:13:22 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:22 Stream starting: pcm 48000Hz 2ch 16bit
Jul 10 18:13:22 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:22 Audio output initialized: device="Built-in Audio Stereo" (default) 48000Hz/2ch/16-bit period=20ms (malgo/S16)
Jul 10 18:13:22 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:22 Volume set to 100
Jul 10 18:13:22 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:22 Muted: false
Jul 10 18:13:22 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:22 Chunk #0: timestamp=40115815877µs, serverNow=40115771036µs, diff=44841µs (44.8ms), rtt=548µs, quality=1
Jul 10 18:13:22 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:22 Chunk #1: timestamp=40115840877µs, serverNow=40115771174µs, diff=69703µs (69.7ms), rtt=548µs, quality=1
Jul 10 18:13:22 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:22 Chunk #2: timestamp=40115865877µs, serverNow=40115771222µs, diff=94655µs (94.7ms), rtt=548µs, quality=1
Jul 10 18:13:22 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:22 Chunk #3: timestamp=40115890877µs, serverNow=40115771259µs, diff=119618µs (119.6ms), rtt=548µs, quality=1
Jul 10 18:13:22 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:22 Chunk #4: timestamp=40115915877µs, serverNow=40115771296µs, diff=144581µs (144.6ms), rtt=548µs, quality=1
Jul 10 18:13:22 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:22 Startup buffering complete: 39 chunks ready
Jul 10 18:13:25 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:25 Metadata:  -  ()
Jul 10 18:13:29 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:29 Muted: true
Jul 10 18:13:29 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:29 Sync #3: rtt=357μs, offset=-1783659886977268μs, error=82μs
Jul 10 18:13:30 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:30 Metadata:  -  ()
Jul 10 18:13:31 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:31 Muted: false
Jul 10 18:13:34 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:34 Volume set to 82
Jul 10 18:13:34 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:34 Muted: false
Jul 10 18:13:34 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:34 Volume set to 82
Jul 10 18:13:34 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:34 Volume set to 62
Jul 10 18:13:34 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:34 Muted: false
Jul 10 18:13:34 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:34 Volume set to 62
Jul 10 18:13:35 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:35 Volume set to 34
Jul 10 18:13:35 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:35 Muted: false
Jul 10 18:13:35 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:35 Volume set to 34
Jul 10 18:13:36 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:36 Volume set to 76
Jul 10 18:13:36 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:36 Muted: false
Jul 10 18:13:36 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:36 Volume set to 76
Jul 10 18:13:36 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:36 Volume set to 60
Jul 10 18:13:36 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:36 Muted: false
Jul 10 18:13:36 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:36 Volume set to 60
Jul 10 18:13:37 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:37 Volume set to 14
Jul 10 18:13:37 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:37 Muted: false
Jul 10 18:13:37 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:37 Volume set to 14
Jul 10 18:13:38 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:38 Volume set to 60
Jul 10 18:13:38 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:38 Muted: false
Jul 10 18:13:38 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:38 Volume set to 60
Jul 10 18:13:39 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:39 Volume set to 90
Jul 10 18:13:39 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:39 Volume set to 90
Jul 10 18:13:39 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:39 Sync #4: rtt=400μs, offset=-1783659886977451μs, error=86μs
Jul 10 18:13:41 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:41 Metadata:  -  ()
Jul 10 18:13:41 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:41 Stream end received for roles: [player]
Jul 10 18:13:41 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:41 Group update: id=b23707e7-410a-4139-8c21-efb12f13e9b7, state=stopped
Jul 10 18:13:41 ha-dash-audio sendspin-player[52459]: 2026/07/10 18:13:41 Group playback state: stopped
```

</details>

